### PR TITLE
fix: harden OpenAI error handling and unify provider signatures

### DIFF
--- a/pr_split/config.py
+++ b/pr_split/config.py
@@ -36,6 +36,19 @@ class Settings(BaseSettings):
                     self.model = DEFAULT_MODEL
                 case Provider.OPENAI:
                     self.model = OPENAI_MODEL
+                case _:
+                    raise NotImplementedError(f"No default model for provider '{self.provider}'")
+        return self
+
+    @model_validator(mode="after")
+    def check_api_key_is_present(self):
+        match self.provider:
+            case Provider.ANTHROPIC:
+                if not self.anthropic_api_key:
+                    raise ValueError("ANTHROPIC_API_KEY must be set when provider is 'anthropic'")
+            case Provider.OPENAI:
+                if not self.openai_api_key:
+                    raise ValueError("OPENAI_API_KEY must be set when provider is 'openai'")
         return self
 
     @property
@@ -45,6 +58,8 @@ class Settings(BaseSettings):
                 return self.anthropic_api_key
             case Provider.OPENAI:
                 return self.openai_api_key
+            case _:
+                raise NotImplementedError(f"Provider '{self.provider}' is not supported")
 
     @property
     def max_context_tokens(self) -> int:
@@ -53,3 +68,5 @@ class Settings(BaseSettings):
                 return ANTHROPIC_MAX_CONTEXT_TOKENS
             case Provider.OPENAI:
                 return OPENAI_MAX_CONTEXT_TOKENS
+            case _:
+                raise NotImplementedError(f"Provider '{self.provider}' is not supported")

--- a/pr_split/config.py
+++ b/pr_split/config.py
@@ -49,6 +49,8 @@ class Settings(BaseSettings):
             case Provider.OPENAI:
                 if not self.openai_api_key:
                     raise ValueError("OPENAI_API_KEY must be set when provider is 'openai'")
+            case _:
+                raise NotImplementedError(f"API key check not implemented for provider '{self.provider}'")
         return self
 
     @property

--- a/pr_split/planner/client.py
+++ b/pr_split/planner/client.py
@@ -99,16 +99,10 @@ def _log_truncation(response: object) -> None:
     logger.warning(logs.LLM_OUTPUT_TRUNCATED.format(stop_reason=stop_reason, keys=keys))
 
 
-def _count_tokens_anthropic(
-    system: str,
-    user: str,
-    *,
-    api_key: str,
-    model: str,
-) -> int:
-    client = anthropic.Anthropic(api_key=api_key)
+def _count_tokens_anthropic(system: str, user: str, *, settings: Settings) -> int:
+    client = anthropic.Anthropic(api_key=settings.api_key)
     response = client.messages.count_tokens(
-        model=model,
+        model=settings.model,
         system=system,
         messages=[{"role": "user", "content": user}],
         tools=[_ANTHROPIC_TOOL_DEF],
@@ -127,24 +121,16 @@ def _count_tokens_openai(texts: list[str], *, model: str) -> int:
 def _count_tokens(system: str, user: str, *, settings: Settings) -> int:
     match settings.provider:
         case Provider.ANTHROPIC:
-            return _count_tokens_anthropic(
-                system, user, api_key=settings.api_key, model=settings.model
-            )
+            return _count_tokens_anthropic(system, user, settings=settings)
         case Provider.OPENAI:
             return _count_tokens_openai([system, user], model=settings.model)
 
 
-def _call_anthropic(
-    system: str,
-    user: str,
-    *,
-    api_key: str,
-    model: str,
-) -> RawToolOutput:
-    client = anthropic.Anthropic(api_key=api_key)
+def _call_anthropic(system: str, user: str, *, settings: Settings) -> RawToolOutput:
+    client = anthropic.Anthropic(api_key=settings.api_key)
     try:
         response = client.beta.messages.create(
-            model=model,
+            model=settings.model,
             max_tokens=MAX_OUTPUT_TOKENS,
             system=system,
             messages=[{"role": "user", "content": user}],
@@ -165,18 +151,23 @@ def _call_anthropic(
 
 def _call_openai(system: str, user: str, *, settings: Settings) -> RawToolOutput:
     client = openai.OpenAI(api_key=settings.api_key)
-    response = client.chat.completions.create(
-        model=settings.model,
-        messages=[
-            {"role": "system", "content": system},
-            {"role": "user", "content": user},
-        ],
-        tools=[_OPENAI_TOOL_DEF],
-        tool_choice={
-            "type": "function",
-            "function": {"name": SPLIT_TOOL_NAME},
-        },
-    )
+    try:
+        response = client.chat.completions.create(
+            model=settings.model,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            tools=[_OPENAI_TOOL_DEF],
+            tool_choice={
+                "type": "function",
+                "function": {"name": SPLIT_TOOL_NAME},
+            },
+        )
+    except openai.APIError as exc:
+        raise LLMError(ErrorMsg.LLM_PARSE_ERROR(detail=str(exc))) from exc
+    if not response.choices:
+        raise LLMError(ErrorMsg.LLM_PARSE_ERROR(detail="no choices in response"))
     tool_calls = response.choices[0].message.tool_calls
     if not tool_calls:
         raise LLMError(ErrorMsg.LLM_PARSE_ERROR(detail="no tool call in response"))
@@ -193,7 +184,7 @@ def _call_openai(system: str, user: str, *, settings: Settings) -> RawToolOutput
 def _call_llm(system: str, user: str, *, settings: Settings) -> RawToolOutput:
     match settings.provider:
         case Provider.ANTHROPIC:
-            return _call_anthropic(system, user, api_key=settings.api_key, model=settings.model)
+            return _call_anthropic(system, user, settings=settings)
         case Provider.OPENAI:
             return _call_openai(system, user, settings=settings)
 


### PR DESCRIPTION
## Summary
- Wrap OpenAI API call in `try/except openai.APIError` for consistent error handling
- Guard against empty `response.choices` before indexing
- Add `check_api_key_is_present` model validator for early failure with clear message
- Add catch-all `case _` to all match statements in config.py for future-proofing
- Unify `_call_anthropic` and `_count_tokens_anthropic` to accept `settings` instead of individual args

## Test plan
- [x] All 46 tests pass
- [x] Ruff lint and format clean