### PR TITLE
docs: replace stacked PR wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">pr-split</h1>
 
 <p align="center">
-  Decompose large PRs into a DAG of small, reviewable stacked PRs
+  Decompose large PRs into a DAG of small, reviewable PRs
 </p>
 
 <p align="center">
@@ -14,7 +14,7 @@
 
 ## Why pr-split?
 
-Vibe coding with AI assistants can produce massive PRs that no one wants to review. A 2,000 line PR with changes across dozens of files is a review bottleneck: teammates skim it, rubber stamp it, or just ignore it. `pr-split` turns that monolith into a stack of focused, bite-sized PRs your team can actually review with confidence. Each sub-PR has a clear purpose, minimal scope, and explicit dependencies, so reviewers know exactly what changed and why.
+Vibe coding with AI assistants can produce massive PRs that no one wants to review. A 2,000 line PR with changes across dozens of files is a review bottleneck: teammates skim it, rubber stamp it, or just ignore it. `pr-split` turns that monolith into a set of focused, bite-sized PRs your team can actually review with confidence. Each sub-PR has a clear purpose, minimal scope, and explicit dependencies, so reviewers know exactly what changed and why.
 
 ## How it works
 

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -44,7 +44,7 @@ from .schemas import (
 )
 from .types_defs import ForkPRInfo
 
-app = typer.Typer(name="pr-split", help="Decompose large PRs into reviewable stacked PRs")
+app = typer.Typer(name="pr-split", help="Decompose large PRs into reviewable dependency-ordered PRs")
 console = Console()
 
 

--- a/pr_split/planner/prompts.py
+++ b/pr_split/planner/prompts.py
@@ -68,7 +68,7 @@ _SYSTEM_PROMPT_TEMPLATE = """\
 You are a senior software engineer specializing in pull request decomposition.
 
 Your task: given a unified diff, split it into a set of small, reviewable groups \
-that can be submitted as stacked pull requests.
+that can be submitted as dependency-ordered pull requests.
 
 Rules:
 1. Every hunk in the diff MUST be assigned to exactly one group. No hunk may be \


### PR DESCRIPTION
## Summary
- remove "stacked PRs" wording from the repo tagline and README copy
- update CLI help and the planner prompt to describe dependency-ordered PRs instead

## Testing
- not run (copy-only change)