### PR TITLE
feat: add optimizer planning backends

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+      - "codex/**"
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Run tests
+        run: uv run pytest -q

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pip install pr-split
 
 - Python 3.12+
 - [GitHub CLI](https://cli.github.com/) (`gh`) authenticated via `gh auth login`
-- `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` environment variable set
+- `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` environment variable set when using the `llm` partition backend
 
 ## Usage
 
@@ -65,6 +65,8 @@ pr-split split someuser:feature-branch --base main
 | `--base` | `main` | Base branch for the diff |
 | `--max-loc` | `400` | Soft limit on diff lines per sub-PR |
 | `--priority` | `orthogonal` | Grouping priority (`orthogonal` or `logical`) |
+| `--chunk-strategy` | `dynamic_programming` | Large-diff chunking strategy (`dynamic_programming` or `greedy`) |
+| `--partition-strategy` | `llm` | Hunk-to-PR partition backend (`llm`, `graph`, or `cp_sat`) |
 
 ### Other commands
 
@@ -88,6 +90,17 @@ Settings can be set via environment variables with the `PR_SPLIT_` prefix:
 | `PR_SPLIT_MODEL` | auto per provider | Model name (defaults to best available model for the chosen provider) |
 | `PR_SPLIT_MAX_LOC` | `400` | Default soft limit on diff lines |
 | `PR_SPLIT_PRIORITY` | `orthogonal` | Default grouping priority |
+| `PR_SPLIT_CHUNK_STRATEGY` | `dynamic_programming` | Large-diff chunking strategy |
+| `PR_SPLIT_PARTITION_STRATEGY` | `llm` | Hunk-to-PR partition backend |
+
+## Planning backends
+
+`pr-split` now separates two optimization layers:
+
+- **Chunking**: for diffs that exceed the model context window, `dynamic_programming` chooses chunk boundaries to avoid splitting the same file when possible. `greedy` keeps the previous first-fit behavior.
+- **Partitioning**: `llm` preserves the original semantic planner, `graph` uses deterministic affinity-based grouping, and `cp_sat` uses an optimization model to balance group count, LOC, and cohesion.
+
+The `cp_sat` backend requires the optional [`ortools`](https://developers.google.com/optimization) package to be installed in the runtime environment.
 
 ## What it does
 
@@ -96,7 +109,7 @@ Settings can be set via environment variables with the `PR_SPLIT_` prefix:
 3. Validates the plan: full coverage (every hunk assigned exactly once), no cycles, no merge conflicts between independent groups
 4. Shows you the plan (table + dependency tree) and asks for confirmation
 5. Creates branches, commits, pushes, and opens GitHub PRs in topological order
-6. For diffs exceeding the model's context window, automatically chunks the diff and processes sequentially, carrying forward the group catalog across chunks
+6. For diffs exceeding the model's context window, uses the configured chunking strategy and processes chunks sequentially while carrying forward the group catalog across chunks
 
 ## License
 

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -13,7 +13,15 @@ from rich.tree import Tree
 
 from . import logs
 from .config import Settings
-from .constants import DEFAULT_MAX_LOC, PLAN_DIR, Priority
+from .constants import (
+    DEFAULT_CHUNK_STRATEGY,
+    DEFAULT_MAX_LOC,
+    DEFAULT_PARTITION_STRATEGY,
+    PLAN_DIR,
+    ChunkStrategy,
+    PartitionStrategy,
+    Priority,
+)
 from .diff_ops import ParsedDiff, extract_diff, materialize_group_files, parse_diff
 from .exceptions import ErrorMsg, PRSplitError
 from .git_ops import (
@@ -217,6 +225,12 @@ def split(
         int, typer.Option(help="Soft limit on diff lines per sub-PR")
     ] = DEFAULT_MAX_LOC,
     priority: Annotated[Priority, typer.Option(help="Grouping priority")] = Priority.ORTHOGONAL,
+    chunk_strategy: Annotated[
+        ChunkStrategy, typer.Option(help="Chunking strategy for large diffs")
+    ] = DEFAULT_CHUNK_STRATEGY,
+    partition_strategy: Annotated[
+        PartitionStrategy, typer.Option(help="Backend for hunk-to-PR partitioning")
+    ] = DEFAULT_PARTITION_STRATEGY,
 ) -> None:
     dev_branch_arg = dev_branch
     author: str | None = None
@@ -251,7 +265,12 @@ def split(
         )
     )
 
-    settings = Settings(max_loc=max_loc, priority=priority)
+    settings = Settings(
+        max_loc=max_loc,
+        priority=priority,
+        chunk_strategy=chunk_strategy,
+        partition_strategy=partition_strategy,
+    )
     groups = plan_split(parsed_diff, settings)
 
     logger.info(logs.VALIDATING_PLAN)

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -15,6 +15,7 @@ from . import logs
 from .config import Settings
 from .constants import (
     DEFAULT_CHUNK_STRATEGY,
+    DEFAULT_CP_SAT_TIMEOUT_SECONDS,
     DEFAULT_MAX_LOC,
     DEFAULT_PARTITION_STRATEGY,
     PLAN_DIR,
@@ -231,6 +232,9 @@ def split(
     partition_strategy: Annotated[
         PartitionStrategy, typer.Option(help="Backend for hunk-to-PR partitioning")
     ] = DEFAULT_PARTITION_STRATEGY,
+    cp_sat_timeout: Annotated[
+        float, typer.Option(help="Maximum seconds to spend in the CP-SAT solver")
+    ] = DEFAULT_CP_SAT_TIMEOUT_SECONDS,
 ) -> None:
     dev_branch_arg = dev_branch
     author: str | None = None
@@ -267,6 +271,7 @@ def split(
 
     settings = Settings(
         max_loc=max_loc,
+        cp_sat_timeout=cp_sat_timeout,
         priority=priority,
         chunk_strategy=chunk_strategy,
         partition_strategy=partition_strategy,

--- a/pr_split/config.py
+++ b/pr_split/config.py
@@ -3,10 +3,14 @@ from pydantic_settings import BaseSettings
 
 from .constants import (
     ANTHROPIC_MAX_CONTEXT_TOKENS,
+    DEFAULT_CHUNK_STRATEGY,
     DEFAULT_MAX_LOC,
     DEFAULT_MODEL,
+    DEFAULT_PARTITION_STRATEGY,
     OPENAI_MAX_CONTEXT_TOKENS,
     OPENAI_MODEL,
+    ChunkStrategy,
+    PartitionStrategy,
     Priority,
     Provider,
 )
@@ -27,6 +31,8 @@ class Settings(BaseSettings):
     model: str = ""
     max_loc: int = DEFAULT_MAX_LOC
     priority: Priority = Priority.ORTHOGONAL
+    chunk_strategy: ChunkStrategy = DEFAULT_CHUNK_STRATEGY
+    partition_strategy: PartitionStrategy = DEFAULT_PARTITION_STRATEGY
 
     @model_validator(mode="after")
     def set_default_model(self):
@@ -42,6 +48,8 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def check_api_key_is_present(self):
+        if self.partition_strategy != PartitionStrategy.LLM:
+            return self
         match self.provider:
             case Provider.ANTHROPIC:
                 if not self.anthropic_api_key:
@@ -50,7 +58,9 @@ class Settings(BaseSettings):
                 if not self.openai_api_key:
                     raise ValueError("OPENAI_API_KEY must be set when provider is 'openai'")
             case _:
-                raise NotImplementedError(f"API key check not implemented for provider '{self.provider}'")
+                raise NotImplementedError(
+                    f"API key check not implemented for provider '{self.provider}'"
+                )
         return self
 
     @property

--- a/pr_split/config.py
+++ b/pr_split/config.py
@@ -4,6 +4,7 @@ from pydantic_settings import BaseSettings
 from .constants import (
     ANTHROPIC_MAX_CONTEXT_TOKENS,
     DEFAULT_CHUNK_STRATEGY,
+    DEFAULT_CP_SAT_TIMEOUT_SECONDS,
     DEFAULT_MAX_LOC,
     DEFAULT_MODEL,
     DEFAULT_PARTITION_STRATEGY,
@@ -30,6 +31,7 @@ class Settings(BaseSettings):
     provider: Provider = Provider.ANTHROPIC
     model: str = ""
     max_loc: int = DEFAULT_MAX_LOC
+    cp_sat_timeout: float = DEFAULT_CP_SAT_TIMEOUT_SECONDS
     priority: Priority = Priority.ORTHOGONAL
     chunk_strategy: ChunkStrategy = DEFAULT_CHUNK_STRATEGY
     partition_strategy: PartitionStrategy = DEFAULT_PARTITION_STRATEGY

--- a/pr_split/constants.py
+++ b/pr_split/constants.py
@@ -11,6 +11,17 @@ class Priority(StrEnum):
     LOGICAL = "logical"
 
 
+class ChunkStrategy(StrEnum):
+    GREEDY = "greedy"
+    DYNAMIC_PROGRAMMING = "dynamic_programming"
+
+
+class PartitionStrategy(StrEnum):
+    LLM = "llm"
+    GRAPH = "graph"
+    CP_SAT = "cp_sat"
+
+
 class PRState(StrEnum):
     OPEN = "open"
     CLOSED = "closed"
@@ -26,6 +37,8 @@ BRANCH_PREFIX = "pr-split/"
 PLAN_DIR = ".pr-split"
 PLAN_FILE = ".pr-split/plan.json"
 DEFAULT_MAX_LOC = 400
+DEFAULT_CHUNK_STRATEGY = ChunkStrategy.DYNAMIC_PROGRAMMING
+DEFAULT_PARTITION_STRATEGY = PartitionStrategy.LLM
 PR_REF_PREFIX = "refs/pr-split/pr-"
 FORK_REF_PREFIX = "refs/pr-split/fork-"
 DEFAULT_MODEL = "claude-opus-4-6"

--- a/pr_split/constants.py
+++ b/pr_split/constants.py
@@ -37,6 +37,7 @@ BRANCH_PREFIX = "pr-split/"
 PLAN_DIR = ".pr-split"
 PLAN_FILE = ".pr-split/plan.json"
 DEFAULT_MAX_LOC = 400
+DEFAULT_CP_SAT_TIMEOUT_SECONDS = 15.0
 DEFAULT_CHUNK_STRATEGY = ChunkStrategy.DYNAMIC_PROGRAMMING
 DEFAULT_PARTITION_STRATEGY = PartitionStrategy.LLM
 PR_REF_PREFIX = "refs/pr-split/pr-"

--- a/pr_split/logs.py
+++ b/pr_split/logs.py
@@ -24,6 +24,8 @@ FETCHING_FORK_BRANCH = "Fetching branch {branch} from fork {fork}"
 AUTHOR_PRESERVED = "Preserving author: {author}"
 COUNTING_TOKENS = "Counting input tokens ({model})"
 TOKEN_COUNT = "Token count: {tokens} (limit: {limit})"
+PLANNING_WITH_BACKEND = "Planning split with backend '{backend}'"
+CHUNK_STRATEGY_SELECTED = "Using chunking strategy '{strategy}'"
 DIFF_TOO_LARGE = (
     "Diff exceeds context window ({tokens} tokens > {limit} limit), switching to chunked mode"
 )
@@ -43,3 +45,7 @@ INVALID_HUNK_INDEX = (
 )
 HUNK_AUTO_ASSIGNED = "Auto-assigned uncovered hunk {file}[{index}] to group '{group}'"
 UNCOVERED_HUNKS_FIXED = "Auto-assigned {count} uncovered hunk(s) to existing groups"
+PLAN_METRICS = (
+    "Plan metrics: groups={groups}, max_group_loc={max_loc}, overflow={overflow}, "
+    "width={width}, depth={depth}, scatter={scatter}, objective={objective}"
+)

--- a/pr_split/planner/__init__.py
+++ b/pr_split/planner/__init__.py
@@ -1,4 +1,5 @@
 from .client import plan_split
+from .scoring import score_plan
 from .validator import validate_plan
 
-__all__ = ["plan_split", "validate_plan"]
+__all__ = ["plan_split", "score_plan", "validate_plan"]

--- a/pr_split/planner/chunker.py
+++ b/pr_split/planner/chunker.py
@@ -139,6 +139,8 @@ def chunk_hunks(
             return chunk_hunks_greedy(hunk_sequence, token_budget)
         case ChunkStrategy.DYNAMIC_PROGRAMMING:
             return chunk_hunks_dynamic_programming(hunk_sequence, token_budget)
+        case _:
+            raise ValueError(f"Unknown chunk strategy '{strategy}'")
 
 
 def build_chunk_diff_from_hunks(parsed_diff: ParsedDiff, hunk_refs: list[HunkRef]) -> str:

--- a/pr_split/planner/chunker.py
+++ b/pr_split/planner/chunker.py
@@ -12,6 +12,9 @@ from ..schemas import Group, GroupAssignment
 from ..types_defs import DiffStats, FileSummary, HunkRef
 
 _DEFAULT_TOKEN_RATIO = 0.25
+_DP_CHUNK_BASE_COST = 100.0
+_DP_FILE_MIX_PENALTY = 50.0
+_DP_SAME_FILE_BOUNDARY_PENALTY = 10_000.0
 
 
 def build_hunk_sequence(
@@ -65,7 +68,7 @@ def _chunk_boundary_penalty(hunk_sequence: list[HunkRef], boundary_index: int) -
     left = hunk_sequence[boundary_index]
     right = hunk_sequence[boundary_index + 1]
     if left.file_path == right.file_path:
-        return 10_000.0
+        return _DP_SAME_FILE_BOUNDARY_PENALTY
     return 0.0
 
 
@@ -101,9 +104,9 @@ def chunk_hunks_dynamic_programming(
                 break
 
             files.add(href.file_path)
-            file_mix_penalty = max(0, len(files) - 1) * 50.0
+            file_mix_penalty = max(0, len(files) - 1) * _DP_FILE_MIX_PENALTY
             chunk_cost = (
-                100.0
+                _DP_CHUNK_BASE_COST
                 + _chunk_slack_penalty(used_tokens, token_budget)
                 + file_mix_penalty
                 + _chunk_boundary_penalty(hunk_sequence, end - 1)

--- a/pr_split/planner/chunker.py
+++ b/pr_split/planner/chunker.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from loguru import logger
 
 from .. import logs
-from ..constants import AssignmentType
+from ..constants import AssignmentType, ChunkStrategy
 from ..diff_ops import ParsedDiff
 from ..exceptions import ErrorMsg
 from ..schemas import Group, GroupAssignment
@@ -27,7 +27,7 @@ def build_hunk_sequence(
     return sequence
 
 
-def chunk_hunks(hunk_sequence: list[HunkRef], token_budget: int) -> list[list[HunkRef]]:
+def chunk_hunks_greedy(hunk_sequence: list[HunkRef], token_budget: int) -> list[list[HunkRef]]:
     chunks: list[list[HunkRef]] = []
     current: list[HunkRef] = []
     current_tokens = 0
@@ -52,6 +52,90 @@ def chunk_hunks(hunk_sequence: list[HunkRef], token_budget: int) -> list[list[Hu
     if current:
         chunks.append(current)
     return chunks
+
+
+def _chunk_slack_penalty(used_tokens: int, token_budget: int) -> float:
+    slack = max(0, token_budget - used_tokens)
+    return (slack * slack) / max(1, token_budget)
+
+
+def _chunk_boundary_penalty(hunk_sequence: list[HunkRef], boundary_index: int) -> float:
+    if boundary_index >= len(hunk_sequence) - 1:
+        return 0.0
+    left = hunk_sequence[boundary_index]
+    right = hunk_sequence[boundary_index + 1]
+    if left.file_path == right.file_path:
+        return 10_000.0
+    return 0.0
+
+
+def chunk_hunks_dynamic_programming(
+    hunk_sequence: list[HunkRef], token_budget: int
+) -> list[list[HunkRef]]:
+    if not hunk_sequence:
+        return []
+
+    for href in hunk_sequence:
+        if href.token_estimate > token_budget:
+            raise ValueError(
+                ErrorMsg.HUNK_TOO_LARGE(
+                    file=href.file_path,
+                    index=href.hunk_index,
+                    tokens=href.token_estimate,
+                    budget=token_budget,
+                )
+            )
+
+    n = len(hunk_sequence)
+    best_cost = [float("inf")] * (n + 1)
+    previous_cut = [-1] * (n + 1)
+    best_cost[0] = 0.0
+
+    for end in range(1, n + 1):
+        used_tokens = 0
+        files: set[str] = set()
+        for start in range(end, 0, -1):
+            href = hunk_sequence[start - 1]
+            used_tokens += href.token_estimate
+            if used_tokens > token_budget:
+                break
+
+            files.add(href.file_path)
+            file_mix_penalty = max(0, len(files) - 1) * 50.0
+            chunk_cost = (
+                100.0
+                + _chunk_slack_penalty(used_tokens, token_budget)
+                + file_mix_penalty
+                + _chunk_boundary_penalty(hunk_sequence, end - 1)
+            )
+            candidate_cost = best_cost[start - 1] + chunk_cost
+            if candidate_cost < best_cost[end]:
+                best_cost[end] = candidate_cost
+                previous_cut[end] = start - 1
+
+    chunks: list[list[HunkRef]] = []
+    cursor = n
+    while cursor > 0:
+        cut = previous_cut[cursor]
+        if cut < 0:
+            raise ValueError("failed to reconstruct dynamic-programming chunk plan")
+        chunks.append(hunk_sequence[cut:cursor])
+        cursor = cut
+
+    chunks.reverse()
+    return chunks
+
+
+def chunk_hunks(
+    hunk_sequence: list[HunkRef],
+    token_budget: int,
+    strategy: ChunkStrategy = ChunkStrategy.DYNAMIC_PROGRAMMING,
+) -> list[list[HunkRef]]:
+    match strategy:
+        case ChunkStrategy.GREEDY:
+            return chunk_hunks_greedy(hunk_sequence, token_budget)
+        case ChunkStrategy.DYNAMIC_PROGRAMMING:
+            return chunk_hunks_dynamic_programming(hunk_sequence, token_budget)
 
 
 def build_chunk_diff_from_hunks(parsed_diff: ParsedDiff, hunk_refs: list[HunkRef]) -> str:

--- a/pr_split/planner/client.py
+++ b/pr_split/planner/client.py
@@ -16,6 +16,7 @@ from ..constants import (
     CHUNK_TARGET_RATIO,
     MAX_OUTPUT_TOKENS,
     AssignmentType,
+    PartitionStrategy,
     Provider,
 )
 from ..diff_ops import ParsedDiff
@@ -30,6 +31,7 @@ from .chunker import (
     format_group_catalog,
     recompute_estimated_loc,
 )
+from .partitioning import partition_diff
 from .prompts import (
     SPLIT_TOOL_NAME,
     SPLIT_TOOL_SCHEMA,
@@ -38,6 +40,7 @@ from .prompts import (
     build_system_prompt,
     build_user_prompt,
 )
+from .scoring import score_plan
 
 _ANTHROPIC_TOOL_DEF = anthropic.types.ToolParam(
     name=SPLIT_TOOL_NAME,
@@ -261,9 +264,10 @@ def _plan_split_chunked(
     logger.info(
         logs.CALIBRATING_CHUNKS.format(overhead=overhead, budget=diff_budget, ratio=token_ratio)
     )
+    logger.info(logs.CHUNK_STRATEGY_SELECTED.format(strategy=settings.chunk_strategy))
 
     hunk_sequence = build_hunk_sequence(parsed_diff, token_ratio)
-    chunks = chunk_hunks(hunk_sequence, diff_budget)
+    chunks = chunk_hunks(hunk_sequence, diff_budget, settings.chunk_strategy)
     total_chunks = len(chunks)
 
     logger.info(logs.CHUNKED_MODE.format(chunks=total_chunks, hunks=len(hunk_sequence)))
@@ -323,7 +327,7 @@ def _plan_split_chunked(
     return accumulated
 
 
-def plan_split(
+def _plan_split_with_llm(
     parsed_diff: ParsedDiff,
     settings: Settings,
 ) -> list[Group]:
@@ -348,4 +352,30 @@ def plan_split(
     groups = _parse_groups(raw)
     recompute_estimated_loc(groups, parsed_diff)
     logger.info(logs.LLM_RESPONSE_RECEIVED.format(count=len(groups)))
+    return groups
+
+
+def plan_split(
+    parsed_diff: ParsedDiff,
+    settings: Settings,
+) -> list[Group]:
+    logger.info(logs.PLANNING_WITH_BACKEND.format(backend=settings.partition_strategy))
+    match settings.partition_strategy:
+        case PartitionStrategy.LLM:
+            groups = _plan_split_with_llm(parsed_diff, settings)
+        case PartitionStrategy.GRAPH | PartitionStrategy.CP_SAT:
+            groups = partition_diff(parsed_diff, settings)
+
+    metrics = score_plan(groups, settings.max_loc)
+    logger.info(
+        logs.PLAN_METRICS.format(
+            groups=metrics.total_groups,
+            max_loc=metrics.max_group_loc,
+            overflow=metrics.loc_overflow,
+            width=metrics.dag_width,
+            depth=metrics.dag_depth,
+            scatter=metrics.file_scatter,
+            objective=metrics.objective,
+        )
+    )
     return groups

--- a/pr_split/planner/client.py
+++ b/pr_split/planner/client.py
@@ -20,7 +20,7 @@ from ..constants import (
     Provider,
 )
 from ..diff_ops import ParsedDiff
-from ..exceptions import ErrorMsg, LLMError
+from ..exceptions import ErrorMsg, LLMError, PRSplitError
 from ..schemas import Group, GroupAssignment
 from .chunker import (
     assign_uncovered_hunks,
@@ -365,6 +365,10 @@ def plan_split(
             groups = _plan_split_with_llm(parsed_diff, settings)
         case PartitionStrategy.GRAPH | PartitionStrategy.CP_SAT:
             groups = partition_diff(parsed_diff, settings)
+        case _:
+            raise PRSplitError(
+                f"Unsupported partition strategy '{settings.partition_strategy}'"
+            )
 
     metrics = score_plan(groups, settings.max_loc)
     logger.info(

--- a/pr_split/planner/partitioning.py
+++ b/pr_split/planner/partitioning.py
@@ -15,6 +15,21 @@ if TYPE_CHECKING:
     from ..config import Settings
     from ..diff_ops import ParsedDiff
 
+_TEST_PAIR_BONUS = 40
+_AFFINITY_SAME_FILE = 500
+_AFFINITY_SHARED_DIR_MULTIPLIER = 25
+_AFFINITY_SAME_SUFFIX = 10
+_AFFINITY_ORTHOGONAL_PENALTY = 20
+_AFFINITY_LOGICAL_SHARED_DIR_BONUS = 10
+_GRAPH_ORTHOGONAL_FILE_PENALTY = 25.0
+_CP_SAT_OVERFLOW_WEIGHT = 1_000
+_CP_SAT_GROUP_WEIGHT_LOGICAL = 200
+_CP_SAT_GROUP_WEIGHT_ORTHOGONAL = 250
+_CP_SAT_CROSS_FILE_PENALTY_LOGICAL = 0
+_CP_SAT_CROSS_FILE_PENALTY_ORTHOGONAL = 400
+_CP_SAT_AFFINITY_DIVISOR_LOGICAL = 5
+_CP_SAT_AFFINITY_DIVISOR_ORTHOGONAL = 10
+
 
 @dataclass(frozen=True)
 class PartitionUnit:
@@ -77,29 +92,33 @@ def _shared_dir_depth(path_a: str, path_b: str) -> int:
     return depth
 
 
+def _normalize_test_stem(path: str) -> tuple[str, bool]:
+    stem = PurePosixPath(path).stem
+    normalized = stem.removeprefix("test_").removesuffix("_test")
+    return normalized, normalized != stem
+
+
 def _test_pair_bonus(path_a: str, path_b: str) -> int:
-    stem_a = PurePosixPath(path_a).stem.removesuffix("_test")
-    stem_b = PurePosixPath(path_b).stem.removesuffix("_test")
-    names_match = stem_a == stem_b
-    has_test_name = "test" in PurePosixPath(path_a).stem or "test" in PurePosixPath(path_b).stem
-    return 40 if names_match and has_test_name else 0
+    stem_a, is_test_a = _normalize_test_stem(path_a)
+    stem_b, is_test_b = _normalize_test_stem(path_b)
+    return _TEST_PAIR_BONUS if (is_test_a ^ is_test_b) and stem_a == stem_b else 0
 
 
 def _affinity_score(unit_a: PartitionUnit, unit_b: PartitionUnit, priority: Priority) -> int:
     if unit_a.file_path == unit_b.file_path:
-        return 500
+        return _AFFINITY_SAME_FILE
 
     score = 0
     shared_depth = _shared_dir_depth(unit_a.file_path, unit_b.file_path)
-    score += shared_depth * 25
+    score += shared_depth * _AFFINITY_SHARED_DIR_MULTIPLIER
     if PurePosixPath(unit_a.file_path).suffix == PurePosixPath(unit_b.file_path).suffix:
-        score += 10
+        score += _AFFINITY_SAME_SUFFIX
     score += _test_pair_bonus(unit_a.file_path, unit_b.file_path)
 
     if priority == Priority.ORTHOGONAL:
-        score = max(0, score - 20)
+        score = max(0, score - _AFFINITY_ORTHOGONAL_PENALTY)
     else:
-        score += 10 if shared_depth else 0
+        score += _AFFINITY_LOGICAL_SHARED_DIR_BONUS if shared_depth else 0
 
     return score
 
@@ -131,7 +150,7 @@ def _group_units_graph(
                 )
                 fill_bonus = candidate_unit.loc / max(1, settings.max_loc)
                 file_penalty = (
-                    25.0
+                    _GRAPH_ORTHOGONAL_FILE_PENALTY
                     if settings.priority == Priority.ORTHOGONAL
                     and candidate_unit.file_path not in current_files
                     else 0.0
@@ -227,10 +246,22 @@ def _group_units_cp_sat(
             is_cross_file = int(units[left].file_path != units[right].file_path)
             pair_terms.append((affinity, is_cross_file, same_group))
 
-    overflow_weight = 1_000
-    group_weight = 200 if settings.priority == Priority.LOGICAL else 250
-    cross_file_penalty = 0 if settings.priority == Priority.LOGICAL else 400
-    affinity_divisor = 5 if settings.priority == Priority.LOGICAL else 10
+    overflow_weight = _CP_SAT_OVERFLOW_WEIGHT
+    group_weight = (
+        _CP_SAT_GROUP_WEIGHT_LOGICAL
+        if settings.priority == Priority.LOGICAL
+        else _CP_SAT_GROUP_WEIGHT_ORTHOGONAL
+    )
+    cross_file_penalty = (
+        _CP_SAT_CROSS_FILE_PENALTY_LOGICAL
+        if settings.priority == Priority.LOGICAL
+        else _CP_SAT_CROSS_FILE_PENALTY_ORTHOGONAL
+    )
+    affinity_divisor = (
+        _CP_SAT_AFFINITY_DIVISOR_LOGICAL
+        if settings.priority == Priority.LOGICAL
+        else _CP_SAT_AFFINITY_DIVISOR_ORTHOGONAL
+    )
 
     model.Minimize(
         group_weight * sum(y)
@@ -341,11 +372,10 @@ def _has_alternative_path(dep_map: dict[str, set[str]], source: str, target: str
 
 def _derive_merge_order_dependencies(groups: list[Group]) -> None:
     file_occurrences: dict[str, list[tuple[int, str]]] = defaultdict(list)
-    for group_index, group in enumerate(groups):
+    for group in groups:
         for assignment in group.assignments:
             min_hunk = min(assignment.hunk_indices, default=0)
-            ordering_key = group_index * 10_000 + min_hunk
-            file_occurrences[assignment.file_path].append((ordering_key, group.id))
+            file_occurrences[assignment.file_path].append((min_hunk, group.id))
 
     dep_map = {group.id: set(group.depends_on) for group in groups}
     for occurrences in file_occurrences.values():

--- a/pr_split/planner/partitioning.py
+++ b/pr_split/planner/partitioning.py
@@ -182,7 +182,6 @@ def _group_units_cp_sat(
 
     group_slots = len(units)
     max_total_loc = max(settings.max_loc, sum(unit.loc for unit in units), 1)
-    edges = _build_affinity_edges(units, settings.priority)
 
     model = cp_model.CpModel()
     x = {
@@ -212,23 +211,37 @@ def _group_units_cp_sat(
     for group_idx in range(group_slots - 1):
         model.Add(y[group_idx] >= y[group_idx + 1])
 
-    colocated_vars: list[tuple[int, object]] = []
-    for left, right, weight in edges:
-        same_group_terms = []
-        for group_idx in range(group_slots):
-            pair_var = model.NewBoolVar(f"pair_{left}_{right}_{group_idx}")
-            model.Add(pair_var <= x[(left, group_idx)])
-            model.Add(pair_var <= x[(right, group_idx)])
-            model.Add(pair_var >= x[(left, group_idx)] + x[(right, group_idx)] - 1)
-            same_group_terms.append(pair_var)
-        same_group = model.NewBoolVar(f"same_{left}_{right}")
-        model.Add(sum(same_group_terms) == same_group)
-        colocated_vars.append((weight, same_group))
+    pair_terms: list[tuple[int, int, object]] = []
+    for left in range(len(units)):
+        for right in range(left + 1, len(units)):
+            affinity = _affinity_score(units[left], units[right], settings.priority)
+            same_group_terms = []
+            for group_idx in range(group_slots):
+                pair_var = model.NewBoolVar(f"pair_{left}_{right}_{group_idx}")
+                model.Add(pair_var <= x[(left, group_idx)])
+                model.Add(pair_var <= x[(right, group_idx)])
+                model.Add(pair_var >= x[(left, group_idx)] + x[(right, group_idx)] - 1)
+                same_group_terms.append(pair_var)
+            same_group = model.NewBoolVar(f"same_{left}_{right}")
+            model.Add(sum(same_group_terms) == same_group)
+            is_cross_file = int(units[left].file_path != units[right].file_path)
+            pair_terms.append((affinity, is_cross_file, same_group))
+
+    overflow_weight = 1_000
+    group_weight = 200 if settings.priority == Priority.LOGICAL else 250
+    cross_file_penalty = 0 if settings.priority == Priority.LOGICAL else 400
+    affinity_divisor = 5 if settings.priority == Priority.LOGICAL else 10
 
     model.Minimize(
-        1_000 * sum(y)
-        + 50 * sum(overflow)
-        - sum(weight * same_group for weight, same_group in colocated_vars)
+        group_weight * sum(y)
+        + overflow_weight * sum(overflow)
+        + cross_file_penalty
+        * sum(same_group for _, is_cross_file, same_group in pair_terms if is_cross_file)
+        - sum(
+            (affinity // affinity_divisor) * same_group
+            for affinity, _, same_group in pair_terms
+            if affinity > 0
+        )
     )
 
     solver = cp_model.CpSolver()

--- a/pr_split/planner/partitioning.py
+++ b/pr_split/planner/partitioning.py
@@ -12,6 +12,8 @@ from ..schemas import Group, GroupAssignment
 from .chunker import recompute_estimated_loc
 
 if TYPE_CHECKING:
+    from ortools.sat.python.cp_model import IntVar
+
     from ..config import Settings
     from ..diff_ops import ParsedDiff
 
@@ -174,18 +176,6 @@ def _group_units_graph(
     return grouped_units
 
 
-def _build_affinity_edges(
-    units: list[PartitionUnit], priority: Priority
-) -> list[tuple[int, int, int]]:
-    edges: list[tuple[int, int, int]] = []
-    for left in range(len(units)):
-        for right in range(left + 1, len(units)):
-            weight = _affinity_score(units[left], units[right], priority)
-            if weight > 0:
-                edges.append((left, right, weight))
-    return edges
-
-
 def _group_units_cp_sat(
     units: list[PartitionUnit], *, settings: Settings
 ) -> list[list[PartitionUnit]]:
@@ -230,7 +220,7 @@ def _group_units_cp_sat(
     for group_idx in range(group_slots - 1):
         model.Add(y[group_idx] >= y[group_idx + 1])
 
-    pair_terms: list[tuple[int, int, object]] = []
+    pair_terms: list[tuple[int, int, IntVar]] = []
     for left in range(len(units)):
         for right in range(left + 1, len(units)):
             affinity = _affinity_score(units[left], units[right], settings.priority)

--- a/pr_split/planner/partitioning.py
+++ b/pr_split/planner/partitioning.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from itertools import pairwise
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING
+
+from ..constants import AssignmentType, PartitionStrategy, Priority
+from ..exceptions import PRSplitError
+from ..schemas import Group, GroupAssignment
+from .chunker import recompute_estimated_loc
+
+if TYPE_CHECKING:
+    from ..config import Settings
+    from ..diff_ops import ParsedDiff
+
+
+@dataclass(frozen=True)
+class PartitionUnit:
+    id: str
+    file_path: str
+    hunk_indices: tuple[int, ...]
+    loc: int
+    position: int
+
+
+def build_partition_units(parsed_diff: ParsedDiff, max_loc: int) -> list[PartitionUnit]:
+    units: list[PartitionUnit] = []
+    position = 0
+    for patch_file in parsed_diff.patch_set:
+        current_indices: list[int] = []
+        current_loc = 0
+
+        for hunk_index, hunk in enumerate(patch_file):
+            hunk_loc = hunk.added + hunk.removed
+            if current_indices and current_loc + hunk_loc > max_loc:
+                units.append(
+                    PartitionUnit(
+                        id=f"{patch_file.path}:{current_indices[0]}-{current_indices[-1]}",
+                        file_path=patch_file.path,
+                        hunk_indices=tuple(current_indices),
+                        loc=current_loc,
+                        position=position,
+                    )
+                )
+                position += 1
+                current_indices = []
+                current_loc = 0
+
+            current_indices.append(hunk_index)
+            current_loc += hunk_loc
+
+        if current_indices:
+            units.append(
+                PartitionUnit(
+                    id=f"{patch_file.path}:{current_indices[0]}-{current_indices[-1]}",
+                    file_path=patch_file.path,
+                    hunk_indices=tuple(current_indices),
+                    loc=current_loc,
+                    position=position,
+                )
+            )
+            position += 1
+
+    return units
+
+
+def _shared_dir_depth(path_a: str, path_b: str) -> int:
+    parts_a = PurePosixPath(path_a).parts[:-1]
+    parts_b = PurePosixPath(path_b).parts[:-1]
+    depth = 0
+    for left, right in zip(parts_a, parts_b, strict=False):
+        if left != right:
+            break
+        depth += 1
+    return depth
+
+
+def _test_pair_bonus(path_a: str, path_b: str) -> int:
+    stem_a = PurePosixPath(path_a).stem.removesuffix("_test")
+    stem_b = PurePosixPath(path_b).stem.removesuffix("_test")
+    names_match = stem_a == stem_b
+    has_test_name = "test" in PurePosixPath(path_a).stem or "test" in PurePosixPath(path_b).stem
+    return 40 if names_match and has_test_name else 0
+
+
+def _affinity_score(unit_a: PartitionUnit, unit_b: PartitionUnit, priority: Priority) -> int:
+    if unit_a.file_path == unit_b.file_path:
+        return 500
+
+    score = 0
+    shared_depth = _shared_dir_depth(unit_a.file_path, unit_b.file_path)
+    score += shared_depth * 25
+    if PurePosixPath(unit_a.file_path).suffix == PurePosixPath(unit_b.file_path).suffix:
+        score += 10
+    score += _test_pair_bonus(unit_a.file_path, unit_b.file_path)
+
+    if priority == Priority.ORTHOGONAL:
+        score = max(0, score - 20)
+    else:
+        score += 10 if shared_depth else 0
+
+    return score
+
+
+def _group_units_graph(
+    units: list[PartitionUnit], *, settings: Settings
+) -> list[list[PartitionUnit]]:
+    remaining = set(range(len(units)))
+    grouped_units: list[list[PartitionUnit]] = []
+
+    while remaining:
+        seed = max(remaining, key=lambda idx: (units[idx].loc, -units[idx].position))
+        current_group = [seed]
+        remaining.remove(seed)
+        current_load = units[seed].loc
+
+        while remaining:
+            current_files = {units[idx].file_path for idx in current_group}
+            best_idx: int | None = None
+            best_score = 0.0
+            for candidate in remaining:
+                candidate_unit = units[candidate]
+                if current_load and current_load + candidate_unit.loc > settings.max_loc:
+                    continue
+
+                affinity = sum(
+                    _affinity_score(candidate_unit, units[group_idx], settings.priority)
+                    for group_idx in current_group
+                )
+                fill_bonus = candidate_unit.loc / max(1, settings.max_loc)
+                file_penalty = (
+                    25.0
+                    if settings.priority == Priority.ORTHOGONAL
+                    and candidate_unit.file_path not in current_files
+                    else 0.0
+                )
+                score = affinity + fill_bonus - file_penalty
+                if score > best_score:
+                    best_idx = candidate
+                    best_score = score
+
+            if best_idx is None or best_score <= 0:
+                break
+
+            current_group.append(best_idx)
+            current_load += units[best_idx].loc
+            remaining.remove(best_idx)
+
+        grouped_units.append(
+            sorted((units[idx] for idx in current_group), key=lambda unit: unit.position)
+        )
+
+    return grouped_units
+
+
+def _build_affinity_edges(
+    units: list[PartitionUnit], priority: Priority
+) -> list[tuple[int, int, int]]:
+    edges: list[tuple[int, int, int]] = []
+    for left in range(len(units)):
+        for right in range(left + 1, len(units)):
+            weight = _affinity_score(units[left], units[right], priority)
+            if weight > 0:
+                edges.append((left, right, weight))
+    return edges
+
+
+def _group_units_cp_sat(
+    units: list[PartitionUnit], *, settings: Settings
+) -> list[list[PartitionUnit]]:
+    try:
+        from ortools.sat.python import cp_model
+    except ImportError as exc:
+        raise PRSplitError(
+            "CP-SAT partitioning requires the optional 'ortools' package to be installed"
+        ) from exc
+
+    if not units:
+        return []
+
+    group_slots = len(units)
+    max_total_loc = max(settings.max_loc, sum(unit.loc for unit in units), 1)
+    edges = _build_affinity_edges(units, settings.priority)
+
+    model = cp_model.CpModel()
+    x = {
+        (unit_idx, group_idx): model.NewBoolVar(f"x_{unit_idx}_{group_idx}")
+        for unit_idx in range(len(units))
+        for group_idx in range(group_slots)
+    }
+    y = [model.NewBoolVar(f"y_{group_idx}") for group_idx in range(group_slots)]
+    overflow = [
+        model.NewIntVar(0, max_total_loc, f"overflow_{group_idx}")
+        for group_idx in range(group_slots)
+    ]
+
+    for unit_idx in range(len(units)):
+        model.Add(sum(x[(unit_idx, group_idx)] for group_idx in range(group_slots)) == 1)
+
+    for group_idx in range(group_slots):
+        load = sum(
+            units[unit_idx].loc * x[(unit_idx, group_idx)]
+            for unit_idx in range(len(units))
+        )
+        model.Add(load <= max_total_loc * y[group_idx])
+        model.Add(load - settings.max_loc <= overflow[group_idx])
+        for unit_idx in range(len(units)):
+            model.Add(x[(unit_idx, group_idx)] <= y[group_idx])
+
+    for group_idx in range(group_slots - 1):
+        model.Add(y[group_idx] >= y[group_idx + 1])
+
+    colocated_vars: list[tuple[int, object]] = []
+    for left, right, weight in edges:
+        same_group_terms = []
+        for group_idx in range(group_slots):
+            pair_var = model.NewBoolVar(f"pair_{left}_{right}_{group_idx}")
+            model.Add(pair_var <= x[(left, group_idx)])
+            model.Add(pair_var <= x[(right, group_idx)])
+            model.Add(pair_var >= x[(left, group_idx)] + x[(right, group_idx)] - 1)
+            same_group_terms.append(pair_var)
+        same_group = model.NewBoolVar(f"same_{left}_{right}")
+        model.Add(sum(same_group_terms) == same_group)
+        colocated_vars.append((weight, same_group))
+
+    model.Minimize(
+        1_000 * sum(y)
+        + 50 * sum(overflow)
+        - sum(weight * same_group for weight, same_group in colocated_vars)
+    )
+
+    solver = cp_model.CpSolver()
+    solver.parameters.max_time_in_seconds = 15.0
+    status = solver.Solve(model)
+    if status not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
+        raise PRSplitError("CP-SAT partitioning failed to find a feasible hunk assignment")
+
+    assignments: dict[int, list[PartitionUnit]] = defaultdict(list)
+    for unit_idx, unit in enumerate(units):
+        for group_idx in range(group_slots):
+            if solver.BooleanValue(x[(unit_idx, group_idx)]):
+                assignments[group_idx].append(unit)
+                break
+
+    return [
+        sorted(group_units, key=lambda unit: unit.position)
+        for _, group_units in sorted(assignments.items())
+        if group_units
+    ]
+
+
+def _build_group_title(group_index: int, units: list[PartitionUnit]) -> str:
+    file_paths = sorted({unit.file_path for unit in units})
+    if len(file_paths) == 1:
+        stem = PurePosixPath(file_paths[0]).stem.replace("_", "-")
+        return f"chore(split): review {stem}-{group_index}"
+    return f"chore(split): review-slice-{group_index}"
+
+
+def _build_group_description(backend: PartitionStrategy, units: list[PartitionUnit]) -> str:
+    file_paths = sorted({unit.file_path for unit in units})
+    files = ", ".join(file_paths)
+    return f"{backend.value} partition over {len(file_paths)} file(s): {files}"
+
+
+def _build_groups_from_units(
+    grouped_units: list[list[PartitionUnit]],
+    parsed_diff: ParsedDiff,
+    *,
+    backend: PartitionStrategy,
+) -> list[Group]:
+    file_hunk_counts = {patch_file.path: len(patch_file) for patch_file in parsed_diff.patch_set}
+    groups: list[Group] = []
+
+    for group_index, units in enumerate(grouped_units, start=1):
+        assignments: list[GroupAssignment] = []
+        grouped_by_file: dict[str, list[int]] = defaultdict(list)
+        for unit in units:
+            grouped_by_file[unit.file_path].extend(unit.hunk_indices)
+
+        for file_path, hunk_indices in grouped_by_file.items():
+            sorted_indices = sorted(set(hunk_indices))
+            file_hunk_count = file_hunk_counts[file_path]
+            if sorted_indices == list(range(file_hunk_count)):
+                assignment_type = AssignmentType.WHOLE_FILE
+            else:
+                assignment_type = AssignmentType.PARTIAL_HUNKS
+            assignments.append(
+                GroupAssignment(
+                    file_path=file_path,
+                    assignment_type=assignment_type,
+                    hunk_indices=sorted_indices,
+                )
+            )
+
+        groups.append(
+            Group(
+                id=f"pr-{group_index}",
+                title=_build_group_title(group_index, units),
+                description=_build_group_description(backend, units),
+                assignments=sorted(assignments, key=lambda assignment: assignment.file_path),
+                estimated_loc=sum(unit.loc for unit in units),
+            )
+        )
+
+    recompute_estimated_loc(groups, parsed_diff)
+    _derive_merge_order_dependencies(groups)
+    return groups
+
+
+def _has_alternative_path(dep_map: dict[str, set[str]], source: str, target: str) -> bool:
+    stack = [source]
+    seen = {source}
+    while stack:
+        current = stack.pop()
+        for parent in dep_map[current]:
+            if current == source and parent == target:
+                continue
+            if parent == target:
+                return True
+            if parent not in seen:
+                seen.add(parent)
+                stack.append(parent)
+    return False
+
+
+def _derive_merge_order_dependencies(groups: list[Group]) -> None:
+    file_occurrences: dict[str, list[tuple[int, str]]] = defaultdict(list)
+    for group_index, group in enumerate(groups):
+        for assignment in group.assignments:
+            min_hunk = min(assignment.hunk_indices, default=0)
+            ordering_key = group_index * 10_000 + min_hunk
+            file_occurrences[assignment.file_path].append((ordering_key, group.id))
+
+    dep_map = {group.id: set(group.depends_on) for group in groups}
+    for occurrences in file_occurrences.values():
+        ordered_group_ids: list[str] = []
+        for _, group_id in sorted(occurrences):
+            if group_id not in ordered_group_ids:
+                ordered_group_ids.append(group_id)
+        for parent_id, child_id in pairwise(ordered_group_ids):
+            dep_map[child_id].add(parent_id)
+
+    for group in groups:
+        reduced_deps = set(dep_map[group.id])
+        for dep in list(reduced_deps):
+            if _has_alternative_path(dep_map, group.id, dep):
+                reduced_deps.remove(dep)
+        group.depends_on = sorted(reduced_deps)
+
+
+def partition_diff(parsed_diff: ParsedDiff, settings: Settings) -> list[Group]:
+    units = build_partition_units(parsed_diff, settings.max_loc)
+    if not units:
+        return []
+
+    match settings.partition_strategy:
+        case PartitionStrategy.GRAPH:
+            grouped_units = _group_units_graph(units, settings=settings)
+        case PartitionStrategy.CP_SAT:
+            grouped_units = _group_units_cp_sat(units, settings=settings)
+        case _:
+            raise PRSplitError(f"Unsupported partition strategy '{settings.partition_strategy}'")
+
+    return _build_groups_from_units(
+        grouped_units,
+        parsed_diff,
+        backend=settings.partition_strategy,
+    )

--- a/pr_split/planner/partitioning.py
+++ b/pr_split/planner/partitioning.py
@@ -266,7 +266,7 @@ def _group_units_cp_sat(
     )
 
     solver = cp_model.CpSolver()
-    solver.parameters.max_time_in_seconds = 15.0
+    solver.parameters.max_time_in_seconds = settings.cp_sat_timeout
     status = solver.Solve(model)
     if status not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
         raise PRSplitError("CP-SAT partitioning failed to find a feasible hunk assignment")

--- a/pr_split/planner/scoring.py
+++ b/pr_split/planner/scoring.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..graph import PlanDAG
+from ..schemas import Group
+
+
+@dataclass(frozen=True)
+class PlanMetrics:
+    total_groups: int
+    max_group_loc: int
+    loc_overflow: int
+    dependency_edges: int
+    dag_depth: int
+    dag_width: int
+    file_scatter: int
+    tiny_groups: int
+    objective: int
+
+
+def _dag_depth(dag: PlanDAG) -> int:
+    depths: dict[str, int] = {}
+    for group_id in dag.topological_order():
+        parents = dag.parents(group_id)
+        depths[group_id] = 1 if not parents else 1 + max(depths[parent] for parent in parents)
+    return max(depths.values(), default=0)
+
+
+def score_plan(groups: list[Group], max_loc: int) -> PlanMetrics:
+    dag = PlanDAG(groups)
+
+    max_group_loc = max((group.estimated_loc for group in groups), default=0)
+    loc_overflow = sum(max(0, group.estimated_loc - max_loc) for group in groups)
+    dependency_edges = sum(len(group.depends_on) for group in groups)
+    dag_width = max((len(batch) for batch in dag.iter_ready()), default=0)
+    dag_depth = _dag_depth(dag)
+
+    file_groups: dict[str, set[str]] = {}
+    for group in groups:
+        for assignment in group.assignments:
+            file_groups.setdefault(assignment.file_path, set()).add(group.id)
+    file_scatter = sum(max(0, len(group_ids) - 1) for group_ids in file_groups.values())
+
+    tiny_threshold = max(1, max_loc // 4)
+    tiny_groups = sum(1 for group in groups if 0 < group.estimated_loc < tiny_threshold)
+
+    objective = (
+        loc_overflow * 1000
+        + dependency_edges * 20
+        + file_scatter * 50
+        + tiny_groups * 10
+        + dag_depth * 5
+        + len(groups)
+        - dag_width * 2
+    )
+
+    return PlanMetrics(
+        total_groups=len(groups),
+        max_group_loc=max_group_loc,
+        loc_overflow=loc_overflow,
+        dependency_edges=dependency_edges,
+        dag_depth=dag_depth,
+        dag_width=dag_width,
+        file_scatter=file_scatter,
+        tiny_groups=tiny_groups,
+        objective=objective,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,10 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["ruff>=0.9.0"]
-test = ["pytest>=8.3.0"]
+test = [
+    "ortools>=9.15.6755",
+    "pytest>=8.3.0",
+]
 
 [project.scripts]
 pr-split = "pr_split.cli:app"
@@ -37,6 +40,7 @@ testpaths = ["tests"]
 
 [dependency-groups]
 dev = [
+    "ortools>=9.15.6755",
     "pytest-cov>=7.0.0",
     "ty>=0.0.19",
 ]

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from pr_split.constants import AssignmentType
+from pr_split.constants import AssignmentType, ChunkStrategy
 from pr_split.diff_ops.parser import parse_diff
 from pr_split.planner.chunker import (
     assign_uncovered_hunks,
@@ -10,6 +10,8 @@ from pr_split.planner.chunker import (
     build_chunk_stats_from_hunks,
     build_hunk_sequence,
     chunk_hunks,
+    chunk_hunks_dynamic_programming,
+    chunk_hunks_greedy,
     format_group_catalog,
     recompute_estimated_loc,
 )
@@ -129,6 +131,40 @@ class TestChunkHunks:
         refs = [HunkRef("a.py", 0, 50), HunkRef("b.py", 0, 50)]
         chunks = chunk_hunks(refs, 100)
         assert len(chunks) == 1
+
+    def test_strategy_override_uses_greedy(self) -> None:
+        refs = [
+            HunkRef("a.py", 0, 30),
+            HunkRef("b.py", 0, 60),
+            HunkRef("b.py", 1, 40),
+        ]
+        greedy = chunk_hunks(refs, 100, ChunkStrategy.GREEDY)
+        dp = chunk_hunks(refs, 100, ChunkStrategy.DYNAMIC_PROGRAMMING)
+        assert [ref.file_path for ref in greedy[0]] == ["a.py", "b.py"]
+        assert [ref.file_path for ref in dp[-1]] == ["b.py", "b.py"]
+
+
+class TestChunkHunksDynamicProgramming:
+    def test_prefers_not_to_split_same_file(self) -> None:
+        refs = [
+            HunkRef("a.py", 0, 30),
+            HunkRef("b.py", 0, 60),
+            HunkRef("b.py", 1, 40),
+        ]
+        chunks = chunk_hunks_dynamic_programming(refs, 100)
+        assert len(chunks) == 2
+        assert [ref.file_path for ref in chunks[0]] == ["a.py"]
+        assert [ref.file_path for ref in chunks[1]] == ["b.py", "b.py"]
+
+    def test_greedy_helper_retains_previous_behavior(self) -> None:
+        refs = [
+            HunkRef("a.py", 0, 30),
+            HunkRef("b.py", 0, 60),
+            HunkRef("b.py", 1, 40),
+        ]
+        chunks = chunk_hunks_greedy(refs, 100)
+        assert len(chunks) == 2
+        assert [ref.file_path for ref in chunks[0]] == ["a.py", "b.py"]
 
 
 class TestBuildChunkDiffFromHunks:

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -143,6 +143,11 @@ class TestChunkHunks:
         assert [ref.file_path for ref in greedy[0]] == ["a.py", "b.py"]
         assert [ref.file_path for ref in dp[-1]] == ["b.py", "b.py"]
 
+    def test_unknown_strategy_raises(self) -> None:
+        refs = [HunkRef("a.py", 0, 100)]
+        with pytest.raises(ValueError, match="Unknown chunk strategy"):
+            chunk_hunks(refs, 100, "invalid")
+
 
 class TestChunkHunksDynamicProgramming:
     def test_prefers_not_to_split_same_file(self) -> None:

--- a/tests/test_chunker_exhaustive.py
+++ b/tests/test_chunker_exhaustive.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from itertools import product
+
+from pr_split.planner.chunker import (
+    _chunk_boundary_penalty,
+    _chunk_slack_penalty,
+    chunk_hunks_dynamic_programming,
+)
+from pr_split.types_defs import HunkRef
+
+
+def _chunk_plan_cost(
+    hunk_sequence: list[HunkRef],
+    chunks: list[list[HunkRef]],
+    token_budget: int,
+) -> float:
+    cost = 0.0
+    end_index = 0
+    for chunk in chunks:
+        used_tokens = sum(ref.token_estimate for ref in chunk)
+        file_mix_penalty = max(0, len({ref.file_path for ref in chunk}) - 1) * 50.0
+        end_index += len(chunk)
+        cost += (
+            100.0
+            + _chunk_slack_penalty(used_tokens, token_budget)
+            + file_mix_penalty
+            + _chunk_boundary_penalty(hunk_sequence, end_index - 1)
+        )
+    return cost
+
+
+def _all_valid_chunkings(
+    hunk_sequence: list[HunkRef],
+    token_budget: int,
+) -> list[list[list[HunkRef]]]:
+    def _walk(start: int) -> list[list[list[HunkRef]]]:
+        if start == len(hunk_sequence):
+            return [[]]
+
+        results: list[list[list[HunkRef]]] = []
+        used_tokens = 0
+        for end in range(start + 1, len(hunk_sequence) + 1):
+            used_tokens += hunk_sequence[end - 1].token_estimate
+            if used_tokens > token_budget:
+                break
+            chunk = hunk_sequence[start:end]
+            for suffix in _walk(end):
+                results.append([chunk, *suffix])
+        return results
+
+    return _walk(0)
+
+
+def _make_hunk_sequence(
+    file_names: tuple[str, ...],
+    token_estimates: tuple[int, ...],
+) -> list[HunkRef]:
+    return [
+        HunkRef(file_path=file_path, hunk_index=index, token_estimate=token_estimate)
+        for index, (file_path, token_estimate) in enumerate(
+            zip(file_names, token_estimates, strict=True)
+        )
+    ]
+
+
+class TestChunkHunksDynamicProgrammingExhaustive:
+    def test_matches_bruteforce_optimum_for_small_instances(self) -> None:
+        file_variants = ("a.py", "b.py")
+        token_variants = (1, 2, 3)
+
+        checked_cases = 0
+        for length in range(1, 5):
+            for file_names in product(file_variants, repeat=length):
+                for token_estimates in product(token_variants, repeat=length):
+                    hunk_sequence = _make_hunk_sequence(file_names, token_estimates)
+                    for token_budget in range(2, 6):
+                        if any(token > token_budget for token in token_estimates):
+                            continue
+
+                        actual_chunks = chunk_hunks_dynamic_programming(
+                            hunk_sequence, token_budget
+                        )
+                        actual_cost = _chunk_plan_cost(
+                            hunk_sequence,
+                            actual_chunks,
+                            token_budget,
+                        )
+                        brute_force_cost = min(
+                            _chunk_plan_cost(hunk_sequence, candidate, token_budget)
+                            for candidate in _all_valid_chunkings(hunk_sequence, token_budget)
+                        )
+
+                        assert actual_cost == brute_force_cost
+                        checked_cases += 1
+
+        assert checked_cases > 5_000

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
-from pr_split.constants import AssignmentType
+from pr_split.config import Settings
+from pr_split.constants import AssignmentType, PartitionStrategy, Provider
+from pr_split.diff_ops.parser import parse_diff
 from pr_split.exceptions import LLMError
 from pr_split.planner.client import (
     RawToolOutput,
     _extract_raw_output,
     _merge_chunk_groups,
     _parse_groups,
+    plan_split,
 )
 from pr_split.schemas import Group, GroupAssignment
 
@@ -206,3 +211,46 @@ class TestMergeChunkGroupsExtended:
         result = _merge_chunk_groups([g1], [g1_update, g2])
         assert len(result) == 2
         assert len(result[0].assignments) == 1
+
+
+class TestPlanSplitBackendSelection:
+    @patch("pr_split.planner.client.partition_diff")
+    @patch("pr_split.planner.client.score_plan")
+    def test_graph_backend_uses_partition_diff(
+        self,
+        mock_score,
+        mock_partition,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        parsed = parse_diff(
+            """\
+diff --git a/a.py b/a.py
+new file mode 100644
+--- /dev/null
++++ b/a.py
+@@ -0,0 +1 @@
++x
+"""
+        )
+        mock_partition.return_value = [Group(id="pr-1", title="t", description="d")]
+        mock_score.return_value = type(
+            "Metrics",
+            (),
+            {
+                "total_groups": 1,
+                "max_group_loc": 1,
+                "loc_overflow": 0,
+                "dag_width": 1,
+                "dag_depth": 1,
+                "file_scatter": 0,
+                "objective": 1,
+            },
+        )()
+        settings = Settings(
+            provider=Provider.ANTHROPIC,
+            partition_strategy=PartitionStrategy.GRAPH,
+        )
+        groups = plan_split(parsed, settings)
+        assert len(groups) == 1
+        mock_partition.assert_called_once()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,7 +7,7 @@ import pytest
 from pr_split.config import Settings
 from pr_split.constants import AssignmentType, PartitionStrategy, Provider
 from pr_split.diff_ops.parser import parse_diff
-from pr_split.exceptions import LLMError
+from pr_split.exceptions import LLMError, PRSplitError
 from pr_split.planner.client import (
     RawToolOutput,
     _extract_raw_output,
@@ -254,3 +254,23 @@ new file mode 100644
         groups = plan_split(parsed, settings)
         assert len(groups) == 1
         mock_partition.assert_called_once()
+
+    def test_unsupported_partition_strategy_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        parsed = parse_diff(
+            """\
+diff --git a/a.py b/a.py
+new file mode 100644
+--- /dev/null
++++ b/a.py
+@@ -0,0 +1 @@
++x
+"""
+        )
+        settings = Settings(provider=Provider.ANTHROPIC)
+        settings.partition_strategy = "invalid"
+
+        with pytest.raises(PRSplitError, match="Unsupported partition strategy"):
+            plan_split(parsed, settings)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -69,6 +69,14 @@ class TestSettingsApiKeyValidation:
         s = Settings(partition_strategy=PartitionStrategy.GRAPH)
         assert s.partition_strategy == PartitionStrategy.GRAPH
 
+    def test_cp_sat_partition_does_not_require_api_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        s = Settings(partition_strategy=PartitionStrategy.CP_SAT)
+        assert s.partition_strategy == PartitionStrategy.CP_SAT
+
 
 class TestSettingsMaxContextTokens:
     def test_anthropic_max_context(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ from pr_split.config import Settings
 from pr_split.constants import (
     ANTHROPIC_MAX_CONTEXT_TOKENS,
     DEFAULT_CHUNK_STRATEGY,
+    DEFAULT_CP_SAT_TIMEOUT_SECONDS,
     DEFAULT_MODEL,
     DEFAULT_PARTITION_STRATEGY,
     OPENAI_MAX_CONTEXT_TOKENS,
@@ -36,6 +37,7 @@ class TestSettingsDefaults:
         s = Settings(provider=Provider.ANTHROPIC)
         assert s.chunk_strategy == DEFAULT_CHUNK_STRATEGY
         assert s.partition_strategy == DEFAULT_PARTITION_STRATEGY
+        assert s.cp_sat_timeout == DEFAULT_CP_SAT_TIMEOUT_SECONDS
 
 
 class TestSettingsApiKeyValidation:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,9 +5,12 @@ import pytest
 from pr_split.config import Settings
 from pr_split.constants import (
     ANTHROPIC_MAX_CONTEXT_TOKENS,
+    DEFAULT_CHUNK_STRATEGY,
     DEFAULT_MODEL,
+    DEFAULT_PARTITION_STRATEGY,
     OPENAI_MAX_CONTEXT_TOKENS,
     OPENAI_MODEL,
+    PartitionStrategy,
     Provider,
 )
 
@@ -27,6 +30,12 @@ class TestSettingsDefaults:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         s = Settings(provider=Provider.ANTHROPIC, model="custom-model")
         assert s.model == "custom-model"
+
+    def test_default_strategies(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        s = Settings(provider=Provider.ANTHROPIC)
+        assert s.chunk_strategy == DEFAULT_CHUNK_STRATEGY
+        assert s.partition_strategy == DEFAULT_PARTITION_STRATEGY
 
 
 class TestSettingsApiKeyValidation:
@@ -51,6 +60,14 @@ class TestSettingsApiKeyValidation:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
         s = Settings(provider=Provider.OPENAI)
         assert s.api_key == "sk-test-key"
+
+    def test_graph_partition_does_not_require_api_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        s = Settings(partition_strategy=PartitionStrategy.GRAPH)
+        assert s.partition_strategy == PartitionStrategy.GRAPH
 
 
 class TestSettingsMaxContextTokens:

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -4,13 +4,17 @@ from pr_split.constants import (
     BRANCH_PREFIX,
     CHUNK_RETRY_LIMIT,
     CHUNK_TARGET_RATIO,
+    DEFAULT_CHUNK_STRATEGY,
     DEFAULT_MAX_LOC,
+    DEFAULT_PARTITION_STRATEGY,
     FORK_REF_PREFIX,
     MAX_OUTPUT_TOKENS,
     PLAN_DIR,
     PLAN_FILE,
     PR_REF_PREFIX,
     AssignmentType,
+    ChunkStrategy,
+    PartitionStrategy,
     Priority,
     Provider,
     PRState,
@@ -30,6 +34,19 @@ class TestPriority:
     def test_values(self) -> None:
         assert Priority.ORTHOGONAL == "orthogonal"
         assert Priority.LOGICAL == "logical"
+
+
+class TestChunkStrategy:
+    def test_values(self) -> None:
+        assert ChunkStrategy.GREEDY == "greedy"
+        assert ChunkStrategy.DYNAMIC_PROGRAMMING == "dynamic_programming"
+
+
+class TestPartitionStrategy:
+    def test_values(self) -> None:
+        assert PartitionStrategy.LLM == "llm"
+        assert PartitionStrategy.GRAPH == "graph"
+        assert PartitionStrategy.CP_SAT == "cp_sat"
 
 
 class TestPRState:
@@ -55,6 +72,10 @@ class TestConstants:
 
     def test_default_max_loc(self) -> None:
         assert DEFAULT_MAX_LOC == 400
+
+    def test_default_strategies(self) -> None:
+        assert DEFAULT_CHUNK_STRATEGY == ChunkStrategy.DYNAMIC_PROGRAMMING
+        assert DEFAULT_PARTITION_STRATEGY == PartitionStrategy.LLM
 
     def test_chunk_constants(self) -> None:
         assert CHUNK_TARGET_RATIO > 0

--- a/tests/test_partitioning.py
+++ b/tests/test_partitioning.py
@@ -5,7 +5,6 @@ import pytest
 from pr_split.config import Settings
 from pr_split.constants import PartitionStrategy, Priority
 from pr_split.diff_ops.parser import parse_diff
-from pr_split.exceptions import PRSplitError
 from pr_split.planner.partitioning import build_partition_units, partition_diff
 
 SAMPLE_DIFF = """\
@@ -99,18 +98,13 @@ class TestPartitionDiffGraph:
 
 
 class TestPartitionDiffCpSat:
-    def test_missing_ortools_raises_clean_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_cp_sat_backend_returns_groups(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pytest.importorskip("ortools.sat.python.cp_model")
         parsed = parse_diff(SAMPLE_DIFF)
         settings = _settings(
             monkeypatch,
             max_loc=10,
             partition_strategy=PartitionStrategy.CP_SAT,
         )
-        try:
-            import ortools  # noqa: F401
-        except ImportError:
-            with pytest.raises(PRSplitError, match="ortools"):
-                partition_diff(parsed, settings)
-        else:
-            groups = partition_diff(parsed, settings)
-            assert groups
+        groups = partition_diff(parsed, settings)
+        assert groups

--- a/tests/test_partitioning.py
+++ b/tests/test_partitioning.py
@@ -107,4 +107,5 @@ class TestPartitionDiffCpSat:
             partition_strategy=PartitionStrategy.CP_SAT,
         )
         groups = partition_diff(parsed, settings)
-        assert groups
+        assert len(groups) == 2
+        assert all(group.depends_on == [] for group in groups)

--- a/tests/test_partitioning.py
+++ b/tests/test_partitioning.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import pytest
+
+from pr_split.config import Settings
+from pr_split.constants import PartitionStrategy, Priority
+from pr_split.diff_ops.parser import parse_diff
+from pr_split.exceptions import PRSplitError
+from pr_split.planner.partitioning import build_partition_units, partition_diff
+
+SAMPLE_DIFF = """\
+diff --git a/a.py b/a.py
+new file mode 100644
+--- /dev/null
++++ b/a.py
+@@ -0,0 +1,3 @@
++line1
++line2
++line3
+diff --git a/b.py b/b.py
+new file mode 100644
+--- /dev/null
++++ b/b.py
+@@ -0,0 +1,4 @@
++lineA
++lineB
++lineC
++lineD
+"""
+
+TWO_HUNK_DIFF = """\
+diff --git a/c.py b/c.py
+--- a/c.py
++++ b/c.py
+@@ -1,3 +1,4 @@
+ old1
++new1
+ old2
+ old3
+@@ -10,3 +11,4 @@
+ old10
++new10
+ old11
+ old12
+"""
+
+
+def _settings(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    max_loc: int,
+    partition_strategy: PartitionStrategy,
+    priority: Priority = Priority.ORTHOGONAL,
+) -> Settings:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    return Settings(
+        max_loc=max_loc,
+        partition_strategy=partition_strategy,
+        priority=priority,
+    )
+
+
+class TestBuildPartitionUnits:
+    def test_splits_large_file_by_hunks(self) -> None:
+        parsed = parse_diff(TWO_HUNK_DIFF)
+        units = build_partition_units(parsed, 1)
+        assert len(units) == 2
+        assert units[0].file_path == "c.py"
+        assert units[0].hunk_indices == (0,)
+        assert units[1].hunk_indices == (1,)
+
+
+class TestPartitionDiffGraph:
+    def test_orthogonal_mode_keeps_unrelated_files_separate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        parsed = parse_diff(SAMPLE_DIFF)
+        settings = _settings(
+            monkeypatch,
+            max_loc=10,
+            partition_strategy=PartitionStrategy.GRAPH,
+        )
+        groups = partition_diff(parsed, settings)
+        assert len(groups) == 2
+        assert all(group.depends_on == [] for group in groups)
+
+    def test_split_file_groups_get_merge_order_dependency(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        parsed = parse_diff(TWO_HUNK_DIFF)
+        settings = _settings(
+            monkeypatch,
+            max_loc=1,
+            partition_strategy=PartitionStrategy.GRAPH,
+        )
+        groups = partition_diff(parsed, settings)
+        assert len(groups) == 2
+        assert groups[1].depends_on == ["pr-1"]
+
+
+class TestPartitionDiffCpSat:
+    def test_missing_ortools_raises_clean_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        parsed = parse_diff(SAMPLE_DIFF)
+        settings = _settings(
+            monkeypatch,
+            max_loc=10,
+            partition_strategy=PartitionStrategy.CP_SAT,
+        )
+        try:
+            import ortools  # noqa: F401
+        except ImportError:
+            with pytest.raises(PRSplitError, match="ortools"):
+                partition_diff(parsed, settings)
+        else:
+            groups = partition_diff(parsed, settings)
+            assert groups

--- a/tests/test_partitioning_extensive.py
+++ b/tests/test_partitioning_extensive.py
@@ -6,14 +6,18 @@ import sys
 import pytest
 
 from pr_split.config import Settings
-from pr_split.constants import PartitionStrategy, Priority
+from pr_split.constants import AssignmentType, PartitionStrategy, Priority
 from pr_split.diff_ops.parser import parse_diff
 from pr_split.exceptions import PRSplitError
 from pr_split.graph import PlanDAG
-from pr_split.planner.partitioning import partition_diff
+from pr_split.planner.partitioning import (
+    _derive_merge_order_dependencies,
+    _test_pair_bonus,
+    partition_diff,
+)
 from pr_split.planner.scoring import score_plan
 from pr_split.planner.validator import validate_plan
-from pr_split.schemas import Group
+from pr_split.schemas import Group, GroupAssignment
 
 UNRELATED_DIFF = """\
 diff --git a/a.py b/a.py
@@ -279,3 +283,46 @@ def test_partitioning_matrix(
     metrics = score_plan(groups, max_loc)
     assert metrics.total_groups == expected_groups
     assert metrics.loc_overflow == 0
+
+
+class TestPartitioningHeuristics:
+    def test_test_pair_bonus_matches_test_prefix_and_suffix(self) -> None:
+        assert _test_pair_bonus("tests/test_auth.py", "src/auth.py") == 40
+        assert _test_pair_bonus("src/auth_test.py", "src/auth.py") == 40
+
+    def test_test_pair_bonus_avoids_false_positive_substrings(self) -> None:
+        assert _test_pair_bonus("src/latest.py", "src/late.py") == 0
+        assert _test_pair_bonus("src/contest.py", "src/con.py") == 0
+
+    def test_merge_order_dependencies_ignore_group_creation_order(self) -> None:
+        groups = [
+            Group(
+                id="pr-2",
+                title="later",
+                description="later hunk",
+                assignments=[
+                    GroupAssignment(
+                        file_path="src/app.py",
+                        assignment_type=AssignmentType.PARTIAL_HUNKS,
+                        hunk_indices=[1],
+                    )
+                ],
+            ),
+            Group(
+                id="pr-1",
+                title="earlier",
+                description="earlier hunk",
+                assignments=[
+                    GroupAssignment(
+                        file_path="src/app.py",
+                        assignment_type=AssignmentType.PARTIAL_HUNKS,
+                        hunk_indices=[0],
+                    )
+                ],
+            ),
+        ]
+
+        _derive_merge_order_dependencies(groups)
+
+        assert groups[0].depends_on == ["pr-1"]
+        assert groups[1].depends_on == []

--- a/tests/test_partitioning_extensive.py
+++ b/tests/test_partitioning_extensive.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import builtins
+import sys
+
+import pytest
+
+from pr_split.config import Settings
+from pr_split.constants import PartitionStrategy, Priority
+from pr_split.diff_ops.parser import parse_diff
+from pr_split.exceptions import PRSplitError
+from pr_split.graph import PlanDAG
+from pr_split.planner.partitioning import partition_diff
+from pr_split.planner.scoring import score_plan
+from pr_split.planner.validator import validate_plan
+from pr_split.schemas import Group
+
+UNRELATED_DIFF = """\
+diff --git a/a.py b/a.py
+new file mode 100644
+--- /dev/null
++++ b/a.py
+@@ -0,0 +1,3 @@
++line1
++line2
++line3
+diff --git a/b.py b/b.py
+new file mode 100644
+--- /dev/null
++++ b/b.py
+@@ -0,0 +1,4 @@
++lineA
++lineB
++lineC
++lineD
+"""
+
+RELATED_DIFF = """\
+diff --git a/src/auth.py b/src/auth.py
+new file mode 100644
+--- /dev/null
++++ b/src/auth.py
+@@ -0,0 +1,3 @@
++def login():
++    return True
++
+diff --git a/src/auth_test.py b/src/auth_test.py
+new file mode 100644
+--- /dev/null
++++ b/src/auth_test.py
+@@ -0,0 +1,3 @@
++def test_login():
++    assert login()
++
+"""
+
+TWO_HUNK_DIFF = """\
+diff --git a/c.py b/c.py
+--- a/c.py
++++ b/c.py
+@@ -1,3 +1,4 @@
+ old1
++new1
+ old2
+ old3
+@@ -10,3 +11,4 @@
+ old10
++new10
+ old11
+ old12
+"""
+
+
+def _settings(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    max_loc: int,
+    partition_strategy: PartitionStrategy,
+    priority: Priority = Priority.ORTHOGONAL,
+) -> Settings:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    return Settings(
+        max_loc=max_loc,
+        partition_strategy=partition_strategy,
+        priority=priority,
+    )
+
+
+def _group_signature(groups: list[Group]) -> tuple[tuple[tuple[str, tuple[int, ...]], ...], ...]:
+    normalized: list[tuple[tuple[str, tuple[int, ...]], ...]] = []
+    for group in groups:
+        assignments = tuple(
+            sorted(
+                (assignment.file_path, tuple(assignment.hunk_indices))
+                for assignment in group.assignments
+            )
+        )
+        normalized.append(assignments)
+    return tuple(normalized)
+
+
+def _assert_valid_plan(groups: list[Group], diff_text: str, max_loc: int) -> None:
+    parsed = parse_diff(diff_text)
+    warnings = validate_plan(groups, parsed, PlanDAG(groups), max_loc)
+    assert warnings == []
+
+
+class TestPartitionDiffGraphExtensive:
+    def test_orthogonal_keeps_unrelated_files_separate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = _settings(
+            monkeypatch,
+            max_loc=10,
+            partition_strategy=PartitionStrategy.GRAPH,
+            priority=Priority.ORTHOGONAL,
+        )
+        groups = partition_diff(parse_diff(UNRELATED_DIFF), settings)
+        assert len(groups) == 2
+        assert all(len(group.assignments) == 1 for group in groups)
+        _assert_valid_plan(groups, UNRELATED_DIFF, 10)
+
+    def test_logical_groups_related_files_together(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = _settings(
+            monkeypatch,
+            max_loc=10,
+            partition_strategy=PartitionStrategy.GRAPH,
+            priority=Priority.LOGICAL,
+        )
+        groups = partition_diff(parse_diff(RELATED_DIFF), settings)
+        assert len(groups) == 1
+        assert len(groups[0].assignments) == 2
+        _assert_valid_plan(groups, RELATED_DIFF, 10)
+
+    def test_same_file_hunks_split_with_dependency_when_budget_tight(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = _settings(
+            monkeypatch,
+            max_loc=1,
+            partition_strategy=PartitionStrategy.GRAPH,
+        )
+        groups = partition_diff(parse_diff(TWO_HUNK_DIFF), settings)
+        assert len(groups) == 2
+        assert groups[1].depends_on == ["pr-1"]
+        _assert_valid_plan(groups, TWO_HUNK_DIFF, 1)
+
+    def test_is_deterministic_across_runs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        settings = _settings(
+            monkeypatch,
+            max_loc=10,
+            partition_strategy=PartitionStrategy.GRAPH,
+            priority=Priority.LOGICAL,
+        )
+        parsed = parse_diff(RELATED_DIFF)
+        signatures = {_group_signature(partition_diff(parsed, settings)) for _ in range(3)}
+        assert len(signatures) == 1
+
+
+class TestPartitionDiffCpSatExtensive:
+    def test_missing_ortools_raises_clean_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        parsed = parse_diff(UNRELATED_DIFF)
+        settings = _settings(
+            monkeypatch,
+            max_loc=10,
+            partition_strategy=PartitionStrategy.CP_SAT,
+        )
+
+        for module_name in list(sys.modules):
+            if module_name == "ortools" or module_name.startswith("ortools."):
+                monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+        real_import = builtins.__import__
+
+        def _fake_import(name: str, *args, **kwargs):
+            if name == "ortools.sat.python" or name.startswith("ortools"):
+                raise ImportError("ortools intentionally unavailable")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _fake_import)
+
+        with pytest.raises(PRSplitError, match="ortools"):
+            partition_diff(parsed, settings)
+
+    def test_orthogonal_keeps_unrelated_files_separate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pytest.importorskip("ortools.sat.python.cp_model")
+        settings = _settings(
+            monkeypatch,
+            max_loc=10,
+            partition_strategy=PartitionStrategy.CP_SAT,
+            priority=Priority.ORTHOGONAL,
+        )
+        groups = partition_diff(parse_diff(UNRELATED_DIFF), settings)
+        assert len(groups) == 2
+        assert all(len(group.assignments) == 1 for group in groups)
+        _assert_valid_plan(groups, UNRELATED_DIFF, 10)
+
+    def test_logical_groups_related_files_together(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pytest.importorskip("ortools.sat.python.cp_model")
+        settings = _settings(
+            monkeypatch,
+            max_loc=10,
+            partition_strategy=PartitionStrategy.CP_SAT,
+            priority=Priority.LOGICAL,
+        )
+        groups = partition_diff(parse_diff(RELATED_DIFF), settings)
+        assert len(groups) == 1
+        assert len(groups[0].assignments) == 2
+        _assert_valid_plan(groups, RELATED_DIFF, 10)
+
+    def test_same_file_hunks_split_when_budget_is_tight(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pytest.importorskip("ortools.sat.python.cp_model")
+        settings = _settings(
+            monkeypatch,
+            max_loc=1,
+            partition_strategy=PartitionStrategy.CP_SAT,
+            priority=Priority.ORTHOGONAL,
+        )
+        groups = partition_diff(parse_diff(TWO_HUNK_DIFF), settings)
+        assert len(groups) == 2
+        assert groups[1].depends_on == ["pr-1"]
+        _assert_valid_plan(groups, TWO_HUNK_DIFF, 1)
+
+    def test_is_deterministic_across_runs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pytest.importorskip("ortools.sat.python.cp_model")
+        settings = _settings(
+            monkeypatch,
+            max_loc=10,
+            partition_strategy=PartitionStrategy.CP_SAT,
+            priority=Priority.LOGICAL,
+        )
+        parsed = parse_diff(RELATED_DIFF)
+        signatures = {_group_signature(partition_diff(parsed, settings)) for _ in range(3)}
+        assert len(signatures) == 1
+
+
+@pytest.mark.parametrize(
+    ("partition_strategy", "priority", "diff_text", "max_loc", "expected_groups"),
+    [
+        (PartitionStrategy.GRAPH, Priority.ORTHOGONAL, UNRELATED_DIFF, 10, 2),
+        (PartitionStrategy.GRAPH, Priority.LOGICAL, RELATED_DIFF, 10, 1),
+        (PartitionStrategy.GRAPH, Priority.ORTHOGONAL, TWO_HUNK_DIFF, 1, 2),
+        (PartitionStrategy.CP_SAT, Priority.ORTHOGONAL, UNRELATED_DIFF, 10, 2),
+        (PartitionStrategy.CP_SAT, Priority.LOGICAL, RELATED_DIFF, 10, 1),
+        (PartitionStrategy.CP_SAT, Priority.ORTHOGONAL, TWO_HUNK_DIFF, 1, 2),
+    ],
+)
+def test_partitioning_matrix(
+    monkeypatch: pytest.MonkeyPatch,
+    partition_strategy: PartitionStrategy,
+    priority: Priority,
+    diff_text: str,
+    max_loc: int,
+    expected_groups: int,
+) -> None:
+    if partition_strategy is PartitionStrategy.CP_SAT:
+        pytest.importorskip("ortools.sat.python.cp_model")
+
+    settings = _settings(
+        monkeypatch,
+        max_loc=max_loc,
+        partition_strategy=partition_strategy,
+        priority=priority,
+    )
+    parsed = parse_diff(diff_text)
+    groups = partition_diff(parsed, settings)
+    assert len(groups) == expected_groups
+    _assert_valid_plan(groups, diff_text, max_loc)
+
+    metrics = score_plan(groups, max_loc)
+    assert metrics.total_groups == expected_groups
+    assert metrics.loc_overflow == 0

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pr_split.constants import AssignmentType
+from pr_split.planner.scoring import score_plan
+from pr_split.schemas import Group, GroupAssignment
+
+
+def _group(
+    gid: str,
+    file_path: str,
+    hunk_indices: list[int],
+    loc: int,
+    depends_on: list[str] | None = None,
+) -> Group:
+    return Group(
+        id=gid,
+        title=gid,
+        description=gid,
+        depends_on=depends_on or [],
+        assignments=[
+            GroupAssignment(
+                file_path=file_path,
+                assignment_type=AssignmentType.PARTIAL_HUNKS,
+                hunk_indices=hunk_indices,
+            )
+        ],
+        estimated_loc=loc,
+    )
+
+
+class TestScorePlan:
+    def test_counts_basic_metrics(self) -> None:
+        groups = [
+            _group("g1", "a.py", [0], 120),
+            _group("g2", "b.py", [0], 80, depends_on=["g1"]),
+        ]
+        metrics = score_plan(groups, 100)
+        assert metrics.total_groups == 2
+        assert metrics.max_group_loc == 120
+        assert metrics.loc_overflow == 20
+        assert metrics.dependency_edges == 1
+        assert metrics.dag_depth == 2
+
+    def test_file_scatter_detects_same_file_in_multiple_groups(self) -> None:
+        groups = [
+            _group("g1", "shared.py", [0], 40),
+            _group("g2", "shared.py", [1], 30),
+        ]
+        metrics = score_plan(groups, 100)
+        assert metrics.file_scatter == 1
+
+    def test_tiny_groups_are_counted(self) -> None:
+        groups = [
+            _group("g1", "a.py", [0], 10),
+            _group("g2", "b.py", [0], 90),
+        ]
+        metrics = score_plan(groups, 100)
+        assert metrics.tiny_groups == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,23 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "absl-py"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/c7/8de93764ad66968d19329a7e0c147a2bb3c7054c554d4a119111b8f9440f/absl_py-2.4.0.tar.gz", hash = "sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4", size = 116543, upload-time = "2026-01-28T10:17:05.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl", hash = "sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d", size = 135750, upload-time = "2026-01-28T10:17:04.19Z" },
+]
 
 [[package]]
 name = "annotated-doc"
@@ -288,6 +305,15 @@ wheels = [
 ]
 
 [[package]]
+name = "immutabledict"
+version = "4.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/e6/718471048fea0366c3e3d1df3acfd914ca66d571cdffcf6d37bbcd725708/immutabledict-4.3.1.tar.gz", hash = "sha256:f844a669106cfdc73f47b1a9da003782fb17dc955a54c80972e0d93d1c63c514", size = 7806, upload-time = "2026-02-15T10:32:34.668Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/ce/f9018bf69ae91b273b6391a095e7c93fa5e1617f25b6ba81ad4b20c9df10/immutabledict-4.3.1-py3-none-any.whl", hash = "sha256:c9facdc0ff30fdb8e35bd16532026cac472a549e182c94fa201b51b25e4bf7bf", size = 5000, upload-time = "2026-02-15T10:32:33.672Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -399,6 +425,67 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/8b/c265f4823726ab832de836cdd184d0986dcf94480f81e8739692a7ac7af2/numpy-2.4.3.tar.gz", hash = "sha256:483a201202b73495f00dbc83796c6ae63137a9bdade074f7648b3e32613412dd", size = 20727743, upload-time = "2026-03-09T07:58:53.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ed/6388632536f9788cea23a3a1b629f25b43eaacd7d7377e5d6bc7b9deb69b/numpy-2.4.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:61b0cbabbb6126c8df63b9a3a0c4b1f44ebca5e12ff6997b80fcf267fb3150ef", size = 16669628, upload-time = "2026-03-09T07:56:24.252Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1b/ee2abfc68e1ce728b2958b6ba831d65c62e1b13ce3017c13943f8f9b5b2e/numpy-2.4.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7395e69ff32526710748f92cd8c9849b361830968ea3e24a676f272653e8983e", size = 14696872, upload-time = "2026-03-09T07:56:26.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d1/780400e915ff5638166f11ca9dc2c5815189f3d7cf6f8759a1685e586413/numpy-2.4.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:abdce0f71dcb4a00e4e77f3faf05e4616ceccfe72ccaa07f47ee79cda3b7b0f4", size = 5203489, upload-time = "2026-03-09T07:56:29.414Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/bb/baffa907e9da4cc34a6e556d6d90e032f6d7a75ea47968ea92b4858826c4/numpy-2.4.3-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:48da3a4ee1336454b07497ff7ec83903efa5505792c4e6d9bf83d99dc07a1e18", size = 6550814, upload-time = "2026-03-09T07:56:32.225Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/12/8c9f0c6c95f76aeb20fc4a699c33e9f827fa0d0f857747c73bb7b17af945/numpy-2.4.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32e3bef222ad6b052280311d1d60db8e259e4947052c3ae7dd6817451fc8a4c5", size = 15666601, upload-time = "2026-03-09T07:56:34.461Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/79/cc665495e4d57d0aa6fbcc0aa57aa82671dfc78fbf95fe733ed86d98f52a/numpy-2.4.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7dd01a46700b1967487141a66ac1a3cf0dd8ebf1f08db37d46389401512ca97", size = 16621358, upload-time = "2026-03-09T07:56:36.852Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/40/b4ecb7224af1065c3539f5ecfff879d090de09608ad1008f02c05c770cb3/numpy-2.4.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:76f0f283506c28b12bba319c0fab98217e9f9b54e6160e9c79e9f7348ba32e9c", size = 17016135, upload-time = "2026-03-09T07:56:39.337Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/b1/6a88e888052eed951afed7a142dcdf3b149a030ca59b4c71eef085858e43/numpy-2.4.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:737f630a337364665aba3b5a77e56a68cc42d350edd010c345d65a3efa3addcc", size = 18345816, upload-time = "2026-03-09T07:56:42.31Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/8f/103a60c5f8c3d7fc678c19cd7b2476110da689ccb80bc18050efbaeae183/numpy-2.4.3-cp312-cp312-win32.whl", hash = "sha256:26952e18d82a1dbbc2f008d402021baa8d6fc8e84347a2072a25e08b46d698b9", size = 5960132, upload-time = "2026-03-09T07:56:44.851Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/7c/f5ee1bf6ed888494978046a809df2882aad35d414b622893322df7286879/numpy-2.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:65f3c2455188f09678355f5cae1f959a06b778bc66d535da07bf2ef20cd319d5", size = 12316144, upload-time = "2026-03-09T07:56:47.057Z" },
+    { url = "https://files.pythonhosted.org/packages/71/46/8d1cb3f7a00f2fb6394140e7e6623696e54c6318a9d9691bb4904672cf42/numpy-2.4.3-cp312-cp312-win_arm64.whl", hash = "sha256:2abad5c7fef172b3377502bde47892439bae394a71bc329f31df0fd829b41a9e", size = 10220364, upload-time = "2026-03-09T07:56:49.849Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d0/1fe47a98ce0df229238b77611340aff92d52691bcbc10583303181abf7fc/numpy-2.4.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b346845443716c8e542d54112966383b448f4a3ba5c66409771b8c0889485dd3", size = 16665297, upload-time = "2026-03-09T07:56:52.296Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d9/4e7c3f0e68dfa91f21c6fb6cf839bc829ec920688b1ce7ec722b1a6202fb/numpy-2.4.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2629289168f4897a3c4e23dc98d6f1731f0fc0fe52fb9db19f974041e4cc12b9", size = 14691853, upload-time = "2026-03-09T07:56:54.992Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/66/bd096b13a87549683812b53ab211e6d413497f84e794fb3c39191948da97/numpy-2.4.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:bb2e3cf95854233799013779216c57e153c1ee67a0bf92138acca0e429aefaee", size = 5198435, upload-time = "2026-03-09T07:56:57.184Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2f/687722910b5a5601de2135c891108f51dfc873d8e43c8ed9f4ebb440b4a2/numpy-2.4.3-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:7f3408ff897f8ab07a07fbe2823d7aee6ff644c097cc1f90382511fe982f647f", size = 6546347, upload-time = "2026-03-09T07:56:59.531Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ec/7971c4e98d86c564750393fab8d7d83d0a9432a9d78bb8a163a6dc59967a/numpy-2.4.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:decb0eb8a53c3b009b0962378065589685d66b23467ef5dac16cbe818afde27f", size = 15664626, upload-time = "2026-03-09T07:57:01.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/eb/7daecbea84ec935b7fc732e18f532073064a3816f0932a40a17f3349185f/numpy-2.4.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5f51900414fc9204a0e0da158ba2ac52b75656e7dce7e77fb9f84bfa343b4cc", size = 16608916, upload-time = "2026-03-09T07:57:04.008Z" },
+    { url = "https://files.pythonhosted.org/packages/df/58/2a2b4a817ffd7472dca4421d9f0776898b364154e30c95f42195041dc03b/numpy-2.4.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6bd06731541f89cdc01b261ba2c9e037f1543df7472517836b78dfb15bd6e476", size = 17015824, upload-time = "2026-03-09T07:57:06.347Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ca/627a828d44e78a418c55f82dd4caea8ea4a8ef24e5144d9e71016e52fb40/numpy-2.4.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22654fe6be0e5206f553a9250762c653d3698e46686eee53b399ab90da59bd92", size = 18334581, upload-time = "2026-03-09T07:57:09.114Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c0/76f93962fc79955fcba30a429b62304332345f22d4daec1cb33653425643/numpy-2.4.3-cp313-cp313-win32.whl", hash = "sha256:d71e379452a2f670ccb689ec801b1218cd3983e253105d6e83780967e899d687", size = 5958618, upload-time = "2026-03-09T07:57:11.432Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3c/88af0040119209b9b5cb59485fa48b76f372c73068dbf9254784b975ac53/numpy-2.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:0a60e17a14d640f49146cb38e3f105f571318db7826d9b6fef7e4dce758faecd", size = 12312824, upload-time = "2026-03-09T07:57:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ce/3d07743aced3d173f877c3ef6a454c2174ba42b584ab0b7e6d99374f51ed/numpy-2.4.3-cp313-cp313-win_arm64.whl", hash = "sha256:c9619741e9da2059cd9c3f206110b97583c7152c1dc9f8aafd4beb450ac1c89d", size = 10221218, upload-time = "2026-03-09T07:57:16.183Z" },
+    { url = "https://files.pythonhosted.org/packages/62/09/d96b02a91d09e9d97862f4fc8bfebf5400f567d8eb1fe4b0cc4795679c15/numpy-2.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7aa4e54f6469300ebca1d9eb80acd5253cdfa36f2c03d79a35883687da430875", size = 14819570, upload-time = "2026-03-09T07:57:18.564Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/ca/0b1aba3905fdfa3373d523b2b15b19029f4f3031c87f4066bd9d20ef6c6b/numpy-2.4.3-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:d1b90d840b25874cf5cd20c219af10bac3667db3876d9a495609273ebe679070", size = 5326113, upload-time = "2026-03-09T07:57:21.052Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/63/406e0fd32fcaeb94180fd6a4c41e55736d676c54346b7efbce548b94a914/numpy-2.4.3-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:a749547700de0a20a6718293396ec237bb38218049cfce788e08fcb716e8cf73", size = 6646370, upload-time = "2026-03-09T07:57:22.804Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d0/10f7dc157d4b37af92720a196be6f54f889e90dcd30dce9dc657ed92c257/numpy-2.4.3-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94f3c4a151a2e529adf49c1d54f0f57ff8f9b233ee4d44af623a81553ab86368", size = 15723499, upload-time = "2026-03-09T07:57:24.693Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f1/d1c2bf1161396629701bc284d958dc1efa3a5a542aab83cf11ee6eb4cba5/numpy-2.4.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22c31dc07025123aedf7f2db9e91783df13f1776dc52c6b22c620870dc0fab22", size = 16657164, upload-time = "2026-03-09T07:57:27.676Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/cca19230b740af199ac47331a21c71e7a3d0ba59661350483c1600d28c37/numpy-2.4.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:148d59127ac95979d6f07e4d460f934ebdd6eed641db9c0db6c73026f2b2101a", size = 17081544, upload-time = "2026-03-09T07:57:30.664Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c5/9602b0cbb703a0936fb40f8a95407e8171935b15846de2f0776e08af04c7/numpy-2.4.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a97cbf7e905c435865c2d939af3d93f99d18eaaa3cabe4256f4304fb51604349", size = 18380290, upload-time = "2026-03-09T07:57:33.763Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/81/9f24708953cd30be9ee36ec4778f4b112b45165812f2ada4cc5ea1c1f254/numpy-2.4.3-cp313-cp313t-win32.whl", hash = "sha256:be3b8487d725a77acccc9924f65fd8bce9af7fac8c9820df1049424a2115af6c", size = 6082814, upload-time = "2026-03-09T07:57:36.491Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9e/52f6eaa13e1a799f0ab79066c17f7016a4a8ae0c1aefa58c82b4dab690b4/numpy-2.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1ec84fd7c8e652b0f4aaaf2e6e9cc8eaa9b1b80a537e06b2e3a2fb176eedcb26", size = 12452673, upload-time = "2026-03-09T07:57:38.281Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/04/b8cece6ead0b30c9fbd99bb835ad7ea0112ac5f39f069788c5558e3b1ab2/numpy-2.4.3-cp313-cp313t-win_arm64.whl", hash = "sha256:120df8c0a81ebbf5b9020c91439fccd85f5e018a927a39f624845be194a2be02", size = 10290907, upload-time = "2026-03-09T07:57:40.747Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ae/3936f79adebf8caf81bd7a599b90a561334a658be4dcc7b6329ebf4ee8de/numpy-2.4.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5884ce5c7acfae1e4e1b6fde43797d10aa506074d25b531b4f54bde33c0c31d4", size = 16664563, upload-time = "2026-03-09T07:57:43.817Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/62/760f2b55866b496bb1fa7da2a6db076bef908110e568b02fcfc1422e2a3a/numpy-2.4.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:297837823f5bc572c5f9379b0c9f3a3365f08492cbdc33bcc3af174372ebb168", size = 14702161, upload-time = "2026-03-09T07:57:46.169Z" },
+    { url = "https://files.pythonhosted.org/packages/32/af/a7a39464e2c0a21526fb4fb76e346fb172ebc92f6d1c7a07c2c139cc17b1/numpy-2.4.3-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a111698b4a3f8dcbe54c64a7708f049355abd603e619013c346553c1fd4ca90b", size = 5208738, upload-time = "2026-03-09T07:57:48.506Z" },
+    { url = "https://files.pythonhosted.org/packages/29/8c/2a0cf86a59558fa078d83805589c2de490f29ed4fb336c14313a161d358a/numpy-2.4.3-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:4bd4741a6a676770e0e97fe9ab2e51de01183df3dcbcec591d26d331a40de950", size = 6543618, upload-time = "2026-03-09T07:57:50.591Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b8/612ce010c0728b1c363fa4ea3aa4c22fe1c5da1de008486f8c2f5cb92fae/numpy-2.4.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54f29b877279d51e210e0c80709ee14ccbbad647810e8f3d375561c45ef613dd", size = 15680676, upload-time = "2026-03-09T07:57:52.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/7e/4f120ecc54ba26ddf3dc348eeb9eb063f421de65c05fc961941798feea18/numpy-2.4.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:679f2a834bae9020f81534671c56fd0cc76dd7e5182f57131478e23d0dc59e24", size = 16613492, upload-time = "2026-03-09T07:57:54.91Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/86/1b6020db73be330c4b45d5c6ee4295d59cfeef0e3ea323959d053e5a6909/numpy-2.4.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d84f0f881cb2225c2dfd7f78a10a5645d487a496c6668d6cc39f0f114164f3d0", size = 17031789, upload-time = "2026-03-09T07:57:57.641Z" },
+    { url = "https://files.pythonhosted.org/packages/07/3a/3b90463bf41ebc21d1b7e06079f03070334374208c0f9a1f05e4ae8455e7/numpy-2.4.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d213c7e6e8d211888cc359bab7199670a00f5b82c0978b9d1c75baf1eddbeac0", size = 18339941, upload-time = "2026-03-09T07:58:00.577Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/74/6d736c4cd962259fd8bae9be27363eb4883a2f9069763747347544c2a487/numpy-2.4.3-cp314-cp314-win32.whl", hash = "sha256:52077feedeff7c76ed7c9f1a0428558e50825347b7545bbb8523da2cd55c547a", size = 6007503, upload-time = "2026-03-09T07:58:03.331Z" },
+    { url = "https://files.pythonhosted.org/packages/48/39/c56ef87af669364356bb011922ef0734fc49dad51964568634c72a009488/numpy-2.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:0448e7f9caefb34b4b7dd2b77f21e8906e5d6f0365ad525f9f4f530b13df2afc", size = 12444915, upload-time = "2026-03-09T07:58:06.353Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1f/ab8528e38d295fd349310807496fabb7cf9fe2e1f70b97bc20a483ea9d4a/numpy-2.4.3-cp314-cp314-win_arm64.whl", hash = "sha256:b44fd60341c4d9783039598efadd03617fa28d041fc37d22b62d08f2027fa0e7", size = 10494875, upload-time = "2026-03-09T07:58:08.734Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ef/b7c35e4d5ef141b836658ab21a66d1a573e15b335b1d111d31f26c8ef80f/numpy-2.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0a195f4216be9305a73c0e91c9b026a35f2161237cf1c6de9b681637772ea657", size = 14822225, upload-time = "2026-03-09T07:58:11.034Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8d/7730fa9278cf6648639946cc816e7cc89f0d891602584697923375f801ed/numpy-2.4.3-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:cd32fbacb9fd1bf041bf8e89e4576b6f00b895f06d00914820ae06a616bdfef7", size = 5328769, upload-time = "2026-03-09T07:58:13.67Z" },
+    { url = "https://files.pythonhosted.org/packages/47/01/d2a137317c958b074d338807c1b6a383406cdf8b8e53b075d804cc3d211d/numpy-2.4.3-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:2e03c05abaee1f672e9d67bc858f300b5ccba1c21397211e8d77d98350972093", size = 6649461, upload-time = "2026-03-09T07:58:15.912Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/34/812ce12bc0f00272a4b0ec0d713cd237cb390666eb6206323d1cc9cedbb2/numpy-2.4.3-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d1ce23cce91fcea443320a9d0ece9b9305d4368875bab09538f7a5b4131938a", size = 15725809, upload-time = "2026-03-09T07:58:17.787Z" },
+    { url = "https://files.pythonhosted.org/packages/25/c0/2aed473a4823e905e765fee3dc2cbf504bd3e68ccb1150fbdabd5c39f527/numpy-2.4.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c59020932feb24ed49ffd03704fbab89f22aa9c0d4b180ff45542fe8918f5611", size = 16655242, upload-time = "2026-03-09T07:58:20.476Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c8/7e052b2fc87aa0e86de23f20e2c42bd261c624748aa8efd2c78f7bb8d8c6/numpy-2.4.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9684823a78a6cd6ad7511fc5e25b07947d1d5b5e2812c93fe99d7d4195130720", size = 17080660, upload-time = "2026-03-09T07:58:23.067Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/3d/0876746044db2adcb11549f214d104f2e1be00f07a67edbb4e2812094847/numpy-2.4.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0200b25c687033316fb39f0ff4e3e690e8957a2c3c8d22499891ec58c37a3eb5", size = 18380384, upload-time = "2026-03-09T07:58:25.839Z" },
+    { url = "https://files.pythonhosted.org/packages/07/12/8160bea39da3335737b10308df4f484235fd297f556745f13092aa039d3b/numpy-2.4.3-cp314-cp314t-win32.whl", hash = "sha256:5e10da9e93247e554bb1d22f8edc51847ddd7dde52d85ce31024c1b4312bfba0", size = 6154547, upload-time = "2026-03-09T07:58:28.289Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f3/76534f61f80d74cc9cdf2e570d3d4eeb92c2280a27c39b0aaf471eda7b48/numpy-2.4.3-cp314-cp314t-win_amd64.whl", hash = "sha256:45f003dbdffb997a03da2d1d0cb41fbd24a87507fb41605c0420a3db5bd4667b", size = 12633645, upload-time = "2026-03-09T07:58:30.384Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b6/7c0d4334c15983cec7f92a69e8ce9b1e6f31857e5ee3a413ac424e6bd63d/numpy-2.4.3-cp314-cp314t-win_arm64.whl", hash = "sha256:4d382735cecd7bcf090172489a525cd7d4087bc331f7df9f60ddc9a296cf208e", size = 10565454, upload-time = "2026-03-09T07:58:33.031Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.24.0"
 source = { registry = "https://pypi.org/simple" }
@@ -418,12 +505,98 @@ wheels = [
 ]
 
 [[package]]
+name = "ortools"
+version = "9.15.6755"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "immutabledict" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "protobuf" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/fc/9fa53f1a13710e6183df4d00fe4988c79a55b501e282645d49f1e250437f/ortools-9.15.6755-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:ae1c6e1fd844b4d756b22eb6c0ed574ea4342ee206d807c4f903039e748228fa", size = 23926322, upload-time = "2026-01-14T15:39:01.626Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b6/7e6618ef7a88e8eb706a8a876806b4d336f1bef8c574f8a02d2da3e483ef/ortools-9.15.6755-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e16686c2b457fa6242c474ab890ee1712347ab53678e0d2fab307ae03e97a4b", size = 21912940, upload-time = "2026-01-14T15:39:04.403Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a9/37cb31fc5ffbec2650ebb0d2538a83842b5693a788a0ec6057559dab1169/ortools-9.15.6755-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3cd6bec0a2e00e3891a53e3b436f45a1000269f302085572f49e9856b7f8eaf0", size = 27646561, upload-time = "2026-01-14T15:37:57.414Z" },
+    { url = "https://files.pythonhosted.org/packages/49/0f/6d6d722102a0ceccf4a5038e2bc91d023da84a6dba98482a4634df3d27ab/ortools-9.15.6755-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:033836c0eb33bc72697a299e0caedbb25fc9d1cee0b13832d69cb30405f57b3e", size = 29838435, upload-time = "2026-01-14T15:38:01.047Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a2/5aaf12e34bcd47ae16e70ae81b5c7fbc209da0615c0b79a93c9a0b1cda02/ortools-9.15.6755-cp312-cp312-win_amd64.whl", hash = "sha256:487796301fd9dad55f9cf21f9313c834697f74306d1a59f002e152862f8eb1b5", size = 23883161, upload-time = "2026-01-14T15:39:45.104Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/53/e21c54ff10002cc2e2b9748012ffc324ec32ea4acdcc85e190a920ab2766/ortools-9.15.6755-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:27a10474e62c9dceed37cfa0e4845c5ffaf792138ebf5b61483771b96f1290b6", size = 23927705, upload-time = "2026-01-14T15:39:07.29Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e6/f7019048ffdf41f8a1bff6815b2203cf7b9117ba9e26bf46c4585421d1c4/ortools-9.15.6755-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:076565b803c85c4f87863e0616f537dd37f99c03e6f092e4068404f7b425d2b0", size = 21914246, upload-time = "2026-01-14T15:39:10.584Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/ad/aaacd340918b03e22c42f6ae4a9c72aac09810b4b398e99a7eeee58d9c42/ortools-9.15.6755-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b85bd20259b146abce5e0721ce1bfd8fd273efc904216aa3be178c31b6d34057", size = 27646600, upload-time = "2026-01-14T15:38:04.79Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b9/28d5efb832190b6edfccc5a703e88e64779c1eda34a42ea96d03307236c0/ortools-9.15.6755-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ebd5aea00374e3aad7a78de59058aca5e871a26a3c385cd0860ef1d685d03c9a", size = 29838741, upload-time = "2026-01-14T15:38:07.945Z" },
+    { url = "https://files.pythonhosted.org/packages/be/22/ab894b6f846b4b1a89795c1ba966834e56cac394c4cf2b72433909739982/ortools-9.15.6755-cp313-cp313-win_amd64.whl", hash = "sha256:caac1d48b967adb877da2abcaf82c28f0f908a7cc208a6a1bbe01bc69590816c", size = 23908100, upload-time = "2026-01-14T15:39:48.398Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/53/ada4146ae491d7798c6eb045d93135158c0b66030853c7cd9607768dda59/ortools-9.15.6755-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82b4a8e6e4f9380b453ab5fa4382ea7ee91e628f9b8be89d9ad760b33fca3323", size = 27681510, upload-time = "2026-01-14T15:38:11.033Z" },
+    { url = "https://files.pythonhosted.org/packages/32/e6/239e96912fc8c4e0e917e72ec413983bc042cd9a0b20c3c6a7e43fc3002b/ortools-9.15.6755-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2d1f2fb2088e8953ccb902e68ffd06032cce0c7dcf7268b6135f3b6c553ca52b", size = 29850935, upload-time = "2026-01-14T15:38:14.595Z" },
+    { url = "https://files.pythonhosted.org/packages/53/ef/53a172ad12cf0d762b9a5af681b1f13f1b4105b38bf65c2b383d530ed97f/ortools-9.15.6755-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:acdf06a167933307608e7eba23a9490255933504df44c8de5f62c48656c29688", size = 23916963, upload-time = "2026-01-14T15:39:13.282Z" },
+    { url = "https://files.pythonhosted.org/packages/13/54/ed73ec00369fb6d6c71049d62e4b7c87c918b61f86ddd55a11c20ada395e/ortools-9.15.6755-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1a0677270b0cd317a6b8dae42514264eaf5da5756c5bc7215eeea409424577df", size = 21923649, upload-time = "2026-01-14T15:39:16.831Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e0/ac57dd43eaadd73748bb542b30912e16c7dbf3a75f393f69efb8a1a2f032/ortools-9.15.6755-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:899b92afe3f775ab5867b9a8aa2850f81f2d95232db9b4ceec3456d69e6b8528", size = 27657273, upload-time = "2026-01-14T15:38:18.375Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e0/11144feb4ddadc491dc9d833d3a2080e6556245f912bebe2c0c7e174f2a1/ortools-9.15.6755-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7181183cdcafe2b0d83ca5505b65048c7953dc7b5ad479361dded607964cc1b3", size = 29843939, upload-time = "2026-01-14T15:38:21.457Z" },
+    { url = "https://files.pythonhosted.org/packages/96/97/771515ba3a05da3903b7da55a190d9f88f36a08c4bf848852e0ea4e3a731/ortools-9.15.6755-cp314-cp314-win_amd64.whl", hash = "sha256:afabb869e5fabeb704bd8147b22bf8139dee042e55fabd0d447a996428009e0c", size = 24673633, upload-time = "2026-01-14T15:39:51.212Z" },
+    { url = "https://files.pythonhosted.org/packages/46/99/0932d6d7d6ad326adf68f4ce9063ef07db7e9859859dddbcd200102aedff/ortools-9.15.6755-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9d07cddca201e25e2e219006a9d6cda10c7e9ee2c712c50d19d508f9ed8a888", size = 27682088, upload-time = "2026-01-14T15:38:25.174Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4d/bd75961e2c82db69bb41dd2c4a82131ca580e997485be2d5f59f8d26f31e/ortools-9.15.6755-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:990838ad66a052e72a50e69da500878710e3420e91717fe88bf3071995caba9e", size = 29851493, upload-time = "2026-01-14T15:38:28.168Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/0c/b28ed414f080ee0ad153f848586d61d1878f91689950f037f976ce15f6c8/pandas-3.0.1.tar.gz", hash = "sha256:4186a699674af418f655dbd420ed87f50d56b4cd6603784279d9eef6627823c8", size = 4641901, upload-time = "2026-02-17T22:20:16.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/51/b467209c08dae2c624873d7491ea47d2b47336e5403309d433ea79c38571/pandas-3.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:476f84f8c20c9f5bc47252b66b4bb25e1a9fc2fa98cead96744d8116cb85771d", size = 10344357, upload-time = "2026-02-17T22:18:38.262Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f1/e2567ffc8951ab371db2e40b2fe068e36b81d8cf3260f06ae508700e5504/pandas-3.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0ab749dfba921edf641d4036c4c21c0b3ea70fea478165cb98a998fb2a261955", size = 9884543, upload-time = "2026-02-17T22:18:41.476Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/39/327802e0b6d693182403c144edacbc27eb82907b57062f23ef5a4c4a5ea7/pandas-3.0.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8e36891080b87823aff3640c78649b91b8ff6eea3c0d70aeabd72ea43ab069b", size = 10396030, upload-time = "2026-02-17T22:18:43.822Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/fe/89d77e424365280b79d99b3e1e7d606f5165af2f2ecfaf0c6d24c799d607/pandas-3.0.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:532527a701281b9dd371e2f582ed9094f4c12dd9ffb82c0c54ee28d8ac9520c4", size = 10876435, upload-time = "2026-02-17T22:18:45.954Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a6/2a75320849dd154a793f69c951db759aedb8d1dd3939eeacda9bdcfa1629/pandas-3.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:356e5c055ed9b0da1580d465657bc7d00635af4fd47f30afb23025352ba764d1", size = 11405133, upload-time = "2026-02-17T22:18:48.533Z" },
+    { url = "https://files.pythonhosted.org/packages/58/53/1d68fafb2e02d7881df66aa53be4cd748d25cbe311f3b3c85c93ea5d30ca/pandas-3.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9d810036895f9ad6345b8f2a338dd6998a74e8483847403582cab67745bff821", size = 11932065, upload-time = "2026-02-17T22:18:50.837Z" },
+    { url = "https://files.pythonhosted.org/packages/75/08/67cc404b3a966b6df27b38370ddd96b3b023030b572283d035181854aac5/pandas-3.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:536232a5fe26dd989bd633e7a0c450705fdc86a207fec7254a55e9a22950fe43", size = 9741627, upload-time = "2026-02-17T22:18:53.905Z" },
+    { url = "https://files.pythonhosted.org/packages/86/4f/caf9952948fb00d23795f09b893d11f1cacb384e666854d87249530f7cbe/pandas-3.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:0f463ebfd8de7f326d38037c7363c6dacb857c5881ab8961fb387804d6daf2f7", size = 9052483, upload-time = "2026-02-17T22:18:57.31Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/48/aad6ec4f8d007534c091e9a7172b3ec1b1ee6d99a9cbb936b5eab6c6cf58/pandas-3.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5272627187b5d9c20e55d27caf5f2cd23e286aba25cadf73c8590e432e2b7262", size = 10317509, upload-time = "2026-02-17T22:18:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/14/5990826f779f79148ae9d3a2c39593dc04d61d5d90541e71b5749f35af95/pandas-3.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:661e0f665932af88c7877f31da0dc743fe9c8f2524bdffe23d24fdcb67ef9d56", size = 9860561, upload-time = "2026-02-17T22:19:02.265Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/80/f01ff54664b6d70fed71475543d108a9b7c888e923ad210795bef04ffb7d/pandas-3.0.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75e6e292ff898679e47a2199172593d9f6107fd2dd3617c22c2946e97d5df46e", size = 10365506, upload-time = "2026-02-17T22:19:05.017Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/85/ab6d04733a7d6ff32bfc8382bf1b07078228f5d6ebec5266b91bfc5c4ff7/pandas-3.0.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1ff8cf1d2896e34343197685f432450ec99a85ba8d90cce2030c5eee2ef98791", size = 10873196, upload-time = "2026-02-17T22:19:07.204Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a9/9301c83d0b47c23ac5deab91c6b39fd98d5b5db4d93b25df8d381451828f/pandas-3.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:eca8b4510f6763f3d37359c2105df03a7a221a508f30e396a51d0713d462e68a", size = 11370859, upload-time = "2026-02-17T22:19:09.436Z" },
+    { url = "https://files.pythonhosted.org/packages/59/fe/0c1fc5bd2d29c7db2ab372330063ad555fb83e08422829c785f5ec2176ca/pandas-3.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:06aff2ad6f0b94a17822cf8b83bbb563b090ed82ff4fe7712db2ce57cd50d9b8", size = 11924584, upload-time = "2026-02-17T22:19:11.562Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/7d/216a1588b65a7aa5f4535570418a599d943c85afb1d95b0876fc00aa1468/pandas-3.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:9fea306c783e28884c29057a1d9baa11a349bbf99538ec1da44c8476563d1b25", size = 9742769, upload-time = "2026-02-17T22:19:13.926Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/cb/810a22a6af9a4e97c8ab1c946b47f3489c5bca5adc483ce0ffc84c9cc768/pandas-3.0.1-cp313-cp313-win_arm64.whl", hash = "sha256:a8d37a43c52917427e897cb2e429f67a449327394396a81034a4449b99afda59", size = 9043855, upload-time = "2026-02-17T22:19:16.09Z" },
+    { url = "https://files.pythonhosted.org/packages/92/fa/423c89086cca1f039cf1253c3ff5b90f157b5b3757314aa635f6bf3e30aa/pandas-3.0.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d54855f04f8246ed7b6fc96b05d4871591143c46c0b6f4af874764ed0d2d6f06", size = 10752673, upload-time = "2026-02-17T22:19:18.304Z" },
+    { url = "https://files.pythonhosted.org/packages/22/23/b5a08ec1f40020397f0faba72f1e2c11f7596a6169c7b3e800abff0e433f/pandas-3.0.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4e1b677accee34a09e0dc2ce5624e4a58a1870ffe56fc021e9caf7f23cd7668f", size = 10404967, upload-time = "2026-02-17T22:19:20.726Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/81/94841f1bb4afdc2b52a99daa895ac2c61600bb72e26525ecc9543d453ebc/pandas-3.0.1-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a9cabbdcd03f1b6cd254d6dda8ae09b0252524be1592594c00b7895916cb1324", size = 10320575, upload-time = "2026-02-17T22:19:24.919Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/8b/2ae37d66a5342a83adadfd0cb0b4bf9c3c7925424dd5f40d15d6cfaa35ee/pandas-3.0.1-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ae2ab1f166668b41e770650101e7090824fd34d17915dd9cd479f5c5e0065e9", size = 10710921, upload-time = "2026-02-17T22:19:27.181Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/61/772b2e2757855e232b7ccf7cb8079a5711becb3a97f291c953def15a833f/pandas-3.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6bf0603c2e30e2cafac32807b06435f28741135cb8697eae8b28c7d492fc7d76", size = 11334191, upload-time = "2026-02-17T22:19:29.411Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/08/b16c6df3ef555d8495d1d265a7963b65be166785d28f06a350913a4fac78/pandas-3.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6c426422973973cae1f4a23e51d4ae85974f44871b24844e4f7de752dd877098", size = 11782256, upload-time = "2026-02-17T22:19:32.34Z" },
+    { url = "https://files.pythonhosted.org/packages/55/80/178af0594890dee17e239fca96d3d8670ba0f5ff59b7d0439850924a9c09/pandas-3.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:b03f91ae8c10a85c1613102c7bef5229b5379f343030a3ccefeca8a33414cf35", size = 10485047, upload-time = "2026-02-17T22:19:34.605Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/8b/4bb774a998b97e6c2fd62a9e6cfdaae133b636fd1c468f92afb4ae9a447a/pandas-3.0.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:99d0f92ed92d3083d140bf6b97774f9f13863924cf3f52a70711f4e7588f9d0a", size = 10322465, upload-time = "2026-02-17T22:19:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/72/3a/5b39b51c64159f470f1ca3b1c2a87da290657ca022f7cd11442606f607d1/pandas-3.0.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3b66857e983208654294bb6477b8a63dee26b37bdd0eb34d010556e91261784f", size = 9910632, upload-time = "2026-02-17T22:19:39.001Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/f7/b449ffb3f68c11da12fc06fbf6d2fa3a41c41e17d0284d23a79e1c13a7e4/pandas-3.0.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:56cf59638bf24dc9bdf2154c81e248b3289f9a09a6d04e63608c159022352749", size = 10440535, upload-time = "2026-02-17T22:19:41.157Z" },
+    { url = "https://files.pythonhosted.org/packages/55/77/6ea82043db22cb0f2bbfe7198da3544000ddaadb12d26be36e19b03a2dc5/pandas-3.0.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1a9f55e0f46951874b863d1f3906dcb57df2d9be5c5847ba4dfb55b2c815249", size = 10893940, upload-time = "2026-02-17T22:19:43.493Z" },
+    { url = "https://files.pythonhosted.org/packages/03/30/f1b502a72468c89412c1b882a08f6eed8a4ee9dc033f35f65d0663df6081/pandas-3.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1849f0bba9c8a2fb0f691d492b834cc8dadf617e29015c66e989448d58d011ee", size = 11442711, upload-time = "2026-02-17T22:19:46.074Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f0/ebb6ddd8fc049e98cabac5c2924d14d1dda26a20adb70d41ea2e428d3ec4/pandas-3.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3d288439e11b5325b02ae6e9cc83e6805a62c40c5a6220bea9beb899c073b1c", size = 11963918, upload-time = "2026-02-17T22:19:48.838Z" },
+    { url = "https://files.pythonhosted.org/packages/09/f8/8ce132104074f977f907442790eaae24e27bce3b3b454e82faa3237ff098/pandas-3.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:93325b0fe372d192965f4cca88d97667f49557398bbf94abdda3bf1b591dbe66", size = 9862099, upload-time = "2026-02-17T22:19:51.081Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b7/6af9aac41ef2456b768ef0ae60acf8abcebb450a52043d030a65b4b7c9bd/pandas-3.0.1-cp314-cp314-win_arm64.whl", hash = "sha256:97ca08674e3287c7148f4858b01136f8bdfe7202ad25ad04fec602dd1d29d132", size = 9185333, upload-time = "2026-02-17T22:19:53.266Z" },
+    { url = "https://files.pythonhosted.org/packages/66/fc/848bb6710bc6061cb0c5badd65b92ff75c81302e0e31e496d00029fe4953/pandas-3.0.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:58eeb1b2e0fb322befcf2bbc9ba0af41e616abadb3d3414a6bc7167f6cbfce32", size = 10772664, upload-time = "2026-02-17T22:19:55.806Z" },
+    { url = "https://files.pythonhosted.org/packages/69/5c/866a9bbd0f79263b4b0db6ec1a341be13a1473323f05c122388e0f15b21d/pandas-3.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cd9af1276b5ca9e298bd79a26bda32fa9cc87ed095b2a9a60978d2ca058eaf87", size = 10421286, upload-time = "2026-02-17T22:19:58.091Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a4/2058fb84fb1cfbfb2d4a6d485e1940bb4ad5716e539d779852494479c580/pandas-3.0.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94f87a04984d6b63788327cd9f79dda62b7f9043909d2440ceccf709249ca988", size = 10342050, upload-time = "2026-02-17T22:20:01.376Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1b/674e89996cc4be74db3c4eb09240c4bb549865c9c3f5d9b086ff8fcfbf00/pandas-3.0.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:85fe4c4df62e1e20f9db6ebfb88c844b092c22cd5324bdcf94bfa2fc1b391221", size = 10740055, upload-time = "2026-02-17T22:20:04.328Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/f8/e954b750764298c22fa4614376531fe63c521ef517e7059a51f062b87dca/pandas-3.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:331ca75a2f8672c365ae25c0b29e46f5ac0c6551fdace8eec4cd65e4fac271ff", size = 11357632, upload-time = "2026-02-17T22:20:06.647Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/02/c6e04b694ffd68568297abd03588b6d30295265176a5c01b7459d3bc35a3/pandas-3.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:15860b1fdb1973fffade772fdb931ccf9b2f400a3f5665aef94a00445d7d8dd5", size = 11810974, upload-time = "2026-02-17T22:20:08.946Z" },
+    { url = "https://files.pythonhosted.org/packages/89/41/d7dfb63d2407f12055215070c42fc6ac41b66e90a2946cdc5e759058398b/pandas-3.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:44f1364411d5670efa692b146c748f4ed013df91ee91e9bec5677fb1fd58b937", size = 10884622, upload-time = "2026-02-17T22:20:11.711Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b0/34937815889fa982613775e4b97fddd13250f11012d769949c5465af2150/pandas-3.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:108dd1790337a494aa80e38def654ca3f0968cf4f362c85f44c15e471667102d", size = 9452085, upload-time = "2026-02-17T22:20:14.331Z" },
 ]
 
 [[package]]
@@ -455,11 +628,13 @@ dev = [
     { name = "ruff" },
 ]
 test = [
+    { name = "ortools" },
     { name = "pytest" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "ortools" },
     { name = "pytest-cov" },
     { name = "ty" },
 ]
@@ -469,6 +644,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.42.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "openai", specifier = ">=2.24.0" },
+    { name = "ortools", marker = "extra == 'test'", specifier = ">=9.15.6755" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pydantic-settings", specifier = ">=2.7.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.0" },
@@ -481,8 +657,24 @@ provides-extras = ["dev", "test"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "ortools", specifier = ">=9.15.6755" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ty", specifier = ">=0.0.19" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/25/7c72c307aafc96fa87062aa6291d9f7c94836e43214d43722e86037aac02/protobuf-6.33.5.tar.gz", hash = "sha256:6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c", size = 444465, upload-time = "2026-01-29T21:51:33.494Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/79/af92d0a8369732b027e6d6084251dd8e782c685c72da161bd4a2e00fbabb/protobuf-6.33.5-cp310-abi3-win32.whl", hash = "sha256:d71b040839446bac0f4d162e758bea99c8251161dae9d0983a3b88dee345153b", size = 425769, upload-time = "2026-01-29T21:51:21.751Z" },
+    { url = "https://files.pythonhosted.org/packages/55/75/bb9bc917d10e9ee13dee8607eb9ab963b7cf8be607c46e7862c748aa2af7/protobuf-6.33.5-cp310-abi3-win_amd64.whl", hash = "sha256:3093804752167bcab3998bec9f1048baae6e29505adaf1afd14a37bddede533c", size = 437118, upload-time = "2026-01-29T21:51:24.022Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/6b/e48dfc1191bc5b52950246275bf4089773e91cb5ba3592621723cdddca62/protobuf-6.33.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:a5cb85982d95d906df1e2210e58f8e4f1e3cdc088e52c921a041f9c9a0386de5", size = 427766, upload-time = "2026-01-29T21:51:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b1/c79468184310de09d75095ed1314b839eb2f72df71097db9d1404a1b2717/protobuf-6.33.5-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:9b71e0281f36f179d00cbcb119cb19dec4d14a81393e5ea220f64b286173e190", size = 324638, upload-time = "2026-01-29T21:51:26.423Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
+    { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
 ]
 
 [[package]]
@@ -622,6 +814,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
@@ -784,6 +988,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -909,6 +1122,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add explicit chunking and partition strategy settings so planning is no longer hardcoded to the LLM path
- replace greedy large-diff chunking with a dynamic-programming strategy while preserving greedy as an option
- add plan scoring plus deterministic graph partitioning and optional CP-SAT partitioning backends
- document the new planner backends and cover them with new tests

## Testing
- uv run pytest -q
- uv run ruff check pr_split/config.py pr_split/constants.py pr_split/cli.py pr_split/logs.py pr_split/planner/__init__.py pr_split/planner/client.py pr_split/planner/chunker.py pr_split/planner/partitioning.py pr_split/planner/scoring.py tests/test_chunker.py tests/test_client.py tests/test_partitioning.py tests/test_scoring.py tests/test_constants.py tests/test_config.py