### PR TITLE
feat: parallelize branch push and PR creation

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import shutil
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
+from threading import Semaphore
 from typing import Annotated
 
 import typer
@@ -177,35 +179,55 @@ def _create_branches_and_commits(
     return branch_records
 
 
-def _push_and_create_prs(
-    groups: list[Group],
-    branch_records: list[BranchRecord],
-) -> list[PRRecord]:
-    pr_records: list[PRRecord] = []
-    record_map = {r.group_id: r for r in branch_records}
+_GH_MAX_WORKERS = 5
+_gh_semaphore = Semaphore(_GH_MAX_WORKERS)
 
-    for group in groups:
-        record = record_map[group.id]
 
-        push_branch(record.branch_name)
-        logger.info(logs.CREATING_PR.format(group=group.id))
-        dag_md = _render_dag_markdown(groups, group.id)
-        body = f"{group.description}\n\n{dag_md}"
+def _push_and_create_single_pr(
+    group: Group,
+    record: BranchRecord,
+    all_groups: list[Group],
+) -> PRRecord:
+    push_branch(record.branch_name)
+    logger.info(logs.CREATING_PR.format(group=group.id))
+    dag_md = _render_dag_markdown(all_groups, group.id)
+    body = f"{group.description}\n\n{dag_md}"
+    with _gh_semaphore:
         pr_number, pr_url = create_pr(
             head=record.branch_name,
             base=record.base_branch,
             title=group.title,
             body=body,
         )
-        pr_records.append(
-            PRRecord(
-                group_id=group.id,
-                pr_number=pr_number,
-                pr_url=pr_url,
-            )
-        )
+    return PRRecord(
+        group_id=group.id,
+        pr_number=pr_number,
+        pr_url=pr_url,
+    )
 
-    return pr_records
+
+def _push_and_create_prs(
+    groups: list[Group],
+    branch_records: list[BranchRecord],
+) -> list[PRRecord]:
+    record_map = {r.group_id: r for r in branch_records}
+
+    with ThreadPoolExecutor(max_workers=_GH_MAX_WORKERS) as executor:
+        futures = {
+            executor.submit(
+                _push_and_create_single_pr,
+                group,
+                record_map[group.id],
+                groups,
+            ): group.id
+            for group in groups
+        }
+        results: dict[str, PRRecord] = {}
+        for future in as_completed(futures):
+            group_id = futures[future]
+            results[group_id] = future.result()
+
+    return [results[g.id] for g in groups]
 
 
 def _resolve_fork_ref(dev_branch: str) -> ForkPRInfo | None:

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import itertools
 import shutil
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from threading import Semaphore
 from typing import Annotated
@@ -179,8 +180,9 @@ def _create_branches_and_commits(
     return branch_records
 
 
-_GH_MAX_WORKERS = 5
-_gh_semaphore = Semaphore(_GH_MAX_WORKERS)
+_PUSH_MAX_WORKERS = 10
+_GH_API_CONCURRENCY = 3
+_gh_semaphore = Semaphore(_GH_API_CONCURRENCY)
 
 
 def _push_and_create_single_pr(
@@ -211,23 +213,17 @@ def _push_and_create_prs(
     branch_records: list[BranchRecord],
 ) -> list[PRRecord]:
     record_map = {r.group_id: r for r in branch_records}
+    records_in_order = [record_map[g.id] for g in groups]
 
-    with ThreadPoolExecutor(max_workers=_GH_MAX_WORKERS) as executor:
-        futures = {
-            executor.submit(
-                _push_and_create_single_pr,
-                group,
-                record_map[group.id],
-                groups,
-            ): group.id
-            for group in groups
-        }
-        results: dict[str, PRRecord] = {}
-        for future in as_completed(futures):
-            group_id = futures[future]
-            results[group_id] = future.result()
+    with ThreadPoolExecutor(max_workers=_PUSH_MAX_WORKERS) as executor:
+        results = list(executor.map(
+            _push_and_create_single_pr,
+            groups,
+            records_in_order,
+            itertools.repeat(groups),
+        ))
 
-    return [results[g.id] for g in groups]
+    return results
 
 
 def _resolve_fork_ref(dev_branch: str) -> ForkPRInfo | None:

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -231,8 +231,8 @@ def _push_and_create_prs(
                 errors.append((group_id, exc))
 
     if errors:
-        failed = [gid for gid, _ in errors]
-        raise PRSplitError(f"{len(errors)} PR(s) failed: {failed}")
+        error_details = "\n".join([f"- {gid}: {exc}" for gid, exc in errors])
+        raise PRSplitError(f"{len(errors)} PR(s) failed:\n{error_details}")
 
     return [results[g.id] for g in groups]
 

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import itertools
 import shutil
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from threading import Semaphore
 from typing import Annotated
@@ -182,7 +181,6 @@ def _create_branches_and_commits(
 
 _PUSH_MAX_WORKERS = 5
 _GH_API_CONCURRENCY = 3
-_push_semaphore = Semaphore(_PUSH_MAX_WORKERS)
 _gh_semaphore = Semaphore(_GH_API_CONCURRENCY)
 
 
@@ -191,8 +189,7 @@ def _push_and_create_single_pr(
     record: BranchRecord,
     all_groups: list[Group],
 ) -> PRRecord:
-    with _push_semaphore:
-        push_branch(record.branch_name)
+    push_branch(record.branch_name)
     logger.info(logs.CREATING_PR.format(group=group.id))
     dag_md = _render_dag_markdown(all_groups, group.id)
     body = f"{group.description}\n\n{dag_md}"
@@ -215,17 +212,29 @@ def _push_and_create_prs(
     branch_records: list[BranchRecord],
 ) -> list[PRRecord]:
     record_map = {r.group_id: r for r in branch_records}
-    records_in_order = [record_map[g.id] for g in groups]
 
     with ThreadPoolExecutor(max_workers=_PUSH_MAX_WORKERS) as executor:
-        results = list(executor.map(
-            _push_and_create_single_pr,
-            groups,
-            records_in_order,
-            itertools.repeat(groups),
-        ))
+        future_to_group_id = {
+            executor.submit(
+                _push_and_create_single_pr, group, record_map[group.id], groups
+            ): group.id
+            for group in groups
+        }
+        results: dict[str, PRRecord] = {}
+        errors: list[tuple[str, BaseException]] = []
+        for future in as_completed(future_to_group_id):
+            group_id = future_to_group_id[future]
+            try:
+                results[group_id] = future.result()
+            except Exception as exc:
+                logger.error(f"Failed to push/create PR for {group_id}: {exc}")
+                errors.append((group_id, exc))
 
-    return results
+    if errors:
+        failed = [gid for gid, _ in errors]
+        raise PRSplitError(f"{len(errors)} PR(s) failed: {failed}")
+
+    return [results[g.id] for g in groups]
 
 
 def _resolve_fork_ref(dev_branch: str) -> ForkPRInfo | None:

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -221,7 +221,7 @@ def _push_and_create_prs(
             for group in groups
         }
         results: dict[str, PRRecord] = {}
-        errors: list[tuple[str, BaseException]] = []
+        errors: list[tuple[str, Exception]] = []
         for future in as_completed(future_to_group_id):
             group_id = future_to_group_id[future]
             try:

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -180,8 +180,9 @@ def _create_branches_and_commits(
     return branch_records
 
 
-_PUSH_MAX_WORKERS = 10
+_PUSH_MAX_WORKERS = 5
 _GH_API_CONCURRENCY = 3
+_push_semaphore = Semaphore(_PUSH_MAX_WORKERS)
 _gh_semaphore = Semaphore(_GH_API_CONCURRENCY)
 
 
@@ -190,7 +191,8 @@ def _push_and_create_single_pr(
     record: BranchRecord,
     all_groups: list[Group],
 ) -> PRRecord:
-    push_branch(record.branch_name)
+    with _push_semaphore:
+        push_branch(record.branch_name)
     logger.info(logs.CREATING_PR.format(group=group.id))
     dag_md = _render_dag_markdown(all_groups, group.id)
     body = f"{group.description}\n\n{dag_md}"

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -199,23 +199,35 @@ class TestPushAndCreatePrs:
         self, mock_push: MagicMock, mock_create: MagicMock
     ) -> None:
         """Verify that multiple groups are processed concurrently."""
-        import time
+        import threading
 
-        def sleep_then_create(**kwargs) -> tuple[int, str]:
-            time.sleep(0.1)
+        # Barrier for 3 parties proves at least 3 threads run simultaneously
+        # (matches _GH_API_CONCURRENCY=3). Timeout prevents hanging if
+        # execution is actually sequential.
+        barrier = threading.Barrier(3, timeout=5)
+        max_concurrent = {"value": 0}
+        lock = threading.Lock()
+        active = {"count": 0}
+
+        def barrier_create(**kwargs) -> tuple[int, str]:
+            with lock:
+                active["count"] += 1
+                if active["count"] > max_concurrent["value"]:
+                    max_concurrent["value"] = active["count"]
+            try:
+                barrier.wait()
+            except threading.BrokenBarrierError:
+                pass
+            with lock:
+                active["count"] -= 1
             return (1, "https://github.com/pr/1")
 
-        mock_create.side_effect = sleep_then_create
+        mock_create.side_effect = barrier_create
 
         groups = [_group(f"pr-{i}", f"feat: {i}") for i in range(1, 6)]
         records = [_branch_record(f"pr-{i}", f"pr-split/ns/pr-{i}") for i in range(1, 6)]
-
-        start_time = time.monotonic()
         _push_and_create_prs(groups, records)
-        duration = time.monotonic() - start_time
 
         assert mock_push.call_count == 5
         assert mock_create.call_count == 5
-        # 5 tasks sleeping 0.1s each; sequential would be >0.5s.
-        # GH API semaphore=3, so ~2 batches (0.2s) + overhead.
-        assert duration < 0.4
+        assert max_concurrent["value"] >= 3

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from pr_split.cli import (
     _push_and_create_prs,
-    _push_and_create_single_pr,
     _render_dag,
     _render_dag_markdown,
     _resolve_fork_ref,
@@ -200,14 +200,18 @@ class TestPushAndCreatePrs:
         self, mock_push: MagicMock, mock_create: MagicMock
     ) -> None:
         """Verify that multiple groups are processed (concurrent threads)."""
+        lock = threading.Lock()
         call_count = {"push": 0, "create": 0}
 
         def counting_push(branch: str) -> None:
-            call_count["push"] += 1
+            with lock:
+                call_count["push"] += 1
 
         def counting_create(**kwargs) -> tuple[int, str]:
-            call_count["create"] += 1
-            return (call_count["create"], f"https://github.com/pr/{call_count['create']}")
+            with lock:
+                call_count["create"] += 1
+                n = call_count["create"]
+            return (n, f"https://github.com/pr/{n}")
 
         mock_push.side_effect = counting_push
         mock_create.side_effect = counting_create

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -199,26 +198,24 @@ class TestPushAndCreatePrs:
     def test_concurrent_execution(
         self, mock_push: MagicMock, mock_create: MagicMock
     ) -> None:
-        """Verify that multiple groups are processed (concurrent threads)."""
-        lock = threading.Lock()
-        call_count = {"push": 0, "create": 0}
+        """Verify that multiple groups are processed concurrently."""
+        import time
 
-        def counting_push(branch: str) -> None:
-            with lock:
-                call_count["push"] += 1
+        def sleep_then_create(**kwargs) -> tuple[int, str]:
+            time.sleep(0.1)
+            return (1, "https://github.com/pr/1")
 
-        def counting_create(**kwargs) -> tuple[int, str]:
-            with lock:
-                call_count["create"] += 1
-                n = call_count["create"]
-            return (n, f"https://github.com/pr/{n}")
-
-        mock_push.side_effect = counting_push
-        mock_create.side_effect = counting_create
+        mock_create.side_effect = sleep_then_create
 
         groups = [_group(f"pr-{i}", f"feat: {i}") for i in range(1, 6)]
         records = [_branch_record(f"pr-{i}", f"pr-split/ns/pr-{i}") for i in range(1, 6)]
-        result = _push_and_create_prs(groups, records)
-        assert len(result) == 5
-        assert call_count["push"] == 5
-        assert call_count["create"] == 5
+
+        start_time = time.monotonic()
+        _push_and_create_prs(groups, records)
+        duration = time.monotonic() - start_time
+
+        assert mock_push.call_count == 5
+        assert mock_create.call_count == 5
+        # 5 tasks sleeping 0.1s each; sequential would be >0.5s.
+        # GH API semaphore=3, so ~2 batches (0.2s) + overhead.
+        assert duration < 0.4

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -199,27 +200,23 @@ class TestPushAndCreatePrs:
         self, mock_push: MagicMock, mock_create: MagicMock
     ) -> None:
         """Verify that multiple groups are processed concurrently."""
-        import threading
-
-        # Barrier for 3 parties proves at least 3 threads run simultaneously
-        # (matches _GH_API_CONCURRENCY=3). Timeout prevents hanging if
-        # execution is actually sequential.
         barrier = threading.Barrier(3, timeout=5)
-        max_concurrent = {"value": 0}
         lock = threading.Lock()
-        active = {"count": 0}
+        max_concurrent_val = 0
+        active_count = 0
 
         def barrier_create(**kwargs) -> tuple[int, str]:
+            nonlocal max_concurrent_val, active_count
             with lock:
-                active["count"] += 1
-                if active["count"] > max_concurrent["value"]:
-                    max_concurrent["value"] = active["count"]
+                active_count += 1
+                if active_count > max_concurrent_val:
+                    max_concurrent_val = active_count
             try:
                 barrier.wait()
             except threading.BrokenBarrierError:
                 pass
             with lock:
-                active["count"] -= 1
+                active_count -= 1
             return (1, "https://github.com/pr/1")
 
         mock_create.side_effect = barrier_create
@@ -230,4 +227,4 @@ class TestPushAndCreatePrs:
 
         assert mock_push.call_count == 6
         assert mock_create.call_count == 6
-        assert max_concurrent["value"] >= 3
+        assert max_concurrent_val >= 3

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -224,10 +224,10 @@ class TestPushAndCreatePrs:
 
         mock_create.side_effect = barrier_create
 
-        groups = [_group(f"pr-{i}", f"feat: {i}") for i in range(1, 6)]
-        records = [_branch_record(f"pr-{i}", f"pr-split/ns/pr-{i}") for i in range(1, 6)]
+        groups = [_group(f"pr-{i}", f"feat: {i}") for i in range(1, 7)]
+        records = [_branch_record(f"pr-{i}", f"pr-split/ns/pr-{i}") for i in range(1, 7)]
         _push_and_create_prs(groups, records)
 
-        assert mock_push.call_count == 5
-        assert mock_create.call_count == 5
+        assert mock_push.call_count == 6
+        assert mock_create.call_count == 6
         assert max_concurrent["value"] >= 3

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -4,8 +4,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from pr_split.cli import _render_dag, _render_dag_markdown, _resolve_fork_ref
-from pr_split.schemas import Group
+from pr_split.cli import (
+    _push_and_create_prs,
+    _push_and_create_single_pr,
+    _render_dag,
+    _render_dag_markdown,
+    _resolve_fork_ref,
+)
+from pr_split.schemas import BranchRecord, Group, PRRecord
 
 
 def _group(gid: str, title: str, depends_on: list[str] | None = None) -> Group:
@@ -129,3 +135,86 @@ class TestResolveForkRefExtended:
         mock_fetch.return_value = {"pr_number": 7, "local_ref": "ref", "base_branch": "main", "author": "a", "fork_full_name": "u/r"}
         result = _resolve_fork_ref("7")
         mock_fetch.assert_called_once_with(7)
+
+
+def _branch_record(group_id: str, branch_name: str) -> BranchRecord:
+    return BranchRecord(
+        group_id=group_id,
+        branch_name=branch_name,
+        base_branch="main",
+        commit_sha="abc123",
+    )
+
+
+class TestPushAndCreatePrs:
+    @patch("pr_split.cli.create_pr", return_value=(1, "https://github.com/pr/1"))
+    @patch("pr_split.cli.push_branch")
+    def test_returns_records_for_all_groups(
+        self, mock_push: MagicMock, mock_create: MagicMock
+    ) -> None:
+        groups = [_group("pr-1", "feat: a"), _group("pr-2", "feat: b")]
+        records = [
+            _branch_record("pr-1", "pr-split/ns/pr-1"),
+            _branch_record("pr-2", "pr-split/ns/pr-2"),
+        ]
+        result = _push_and_create_prs(groups, records)
+        assert len(result) == 2
+        assert result[0].group_id == "pr-1"
+        assert result[1].group_id == "pr-2"
+
+    @patch("pr_split.cli.create_pr", return_value=(1, "https://github.com/pr/1"))
+    @patch("pr_split.cli.push_branch")
+    def test_pushes_all_branches(
+        self, mock_push: MagicMock, mock_create: MagicMock
+    ) -> None:
+        groups = [_group("pr-1", "feat: a"), _group("pr-2", "feat: b")]
+        records = [
+            _branch_record("pr-1", "pr-split/ns/pr-1"),
+            _branch_record("pr-2", "pr-split/ns/pr-2"),
+        ]
+        _push_and_create_prs(groups, records)
+        pushed = {call.args[0] for call in mock_push.call_args_list}
+        assert pushed == {"pr-split/ns/pr-1", "pr-split/ns/pr-2"}
+
+    @patch("pr_split.cli.create_pr", return_value=(5, "https://github.com/pr/5"))
+    @patch("pr_split.cli.push_branch")
+    def test_preserves_group_order(
+        self, mock_push: MagicMock, mock_create: MagicMock
+    ) -> None:
+        groups = [
+            _group("pr-3", "c"),
+            _group("pr-1", "a"),
+            _group("pr-2", "b"),
+        ]
+        records = [
+            _branch_record("pr-3", "pr-split/ns/pr-3"),
+            _branch_record("pr-1", "pr-split/ns/pr-1"),
+            _branch_record("pr-2", "pr-split/ns/pr-2"),
+        ]
+        result = _push_and_create_prs(groups, records)
+        assert [r.group_id for r in result] == ["pr-3", "pr-1", "pr-2"]
+
+    @patch("pr_split.cli.create_pr")
+    @patch("pr_split.cli.push_branch")
+    def test_concurrent_execution(
+        self, mock_push: MagicMock, mock_create: MagicMock
+    ) -> None:
+        """Verify that multiple groups are processed (concurrent threads)."""
+        call_count = {"push": 0, "create": 0}
+
+        def counting_push(branch: str) -> None:
+            call_count["push"] += 1
+
+        def counting_create(**kwargs) -> tuple[int, str]:
+            call_count["create"] += 1
+            return (call_count["create"], f"https://github.com/pr/{call_count['create']}")
+
+        mock_push.side_effect = counting_push
+        mock_create.side_effect = counting_create
+
+        groups = [_group(f"pr-{i}", f"feat: {i}") for i in range(1, 6)]
+        records = [_branch_record(f"pr-{i}", f"pr-split/ns/pr-{i}") for i in range(1, 6)]
+        result = _push_and_create_prs(groups, records)
+        assert len(result) == 5
+        assert call_count["push"] == 5
+        assert call_count["create"] == 5


### PR DESCRIPTION
## Summary
- Replace sequential push + PR creation with `ThreadPoolExecutor` (max 5 workers) using `as_completed` for per-future error handling
- GitHub API calls (PR creation) gated by a `Semaphore(3)` to avoid rate limits
- Extract `_push_and_create_single_pr()` helper for per-group work (push branch + create PR)
- Partial failures are logged and accumulated — all threads complete before raising
- Add 4 tests covering record creation, branch pushing, order preservation, and concurrent execution (barrier-based)

## Test plan
- [x] All 284 tests pass (280 existing + 4 new)
- [ ] Manual test with a real multi-group split to verify concurrent push/PR creation
- [ ] Monitor GitHub API rate limit headers during concurrent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)