### PR TITLE
feat: detect existing plan and offer cleanup before re-splitting

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -368,7 +368,10 @@ def split(
             console.print(
                 "[yellow]An existing split plan with branches/PRs was found.[/yellow]"
             )
-            if typer.confirm("Clean up existing branches and PRs before re-splitting?"):
+            console.print(
+                "[red]Warning: this will permanently close PRs and delete remote branches.[/red]"
+            )
+            if typer.confirm("Clean up and proceed with re-splitting?"):
                 closed_prs, deleted_branches = _cleanup_git_state(existing.git_state)
                 logger.success(
                     logs.CLEAN_COMPLETE.format(branches=deleted_branches, prs=closed_prs)

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -361,6 +361,24 @@ def split(
 
     _validate_inputs(dev_branch, base, dry_run=dry_run)
 
+    if plan_exists():
+        existing = load_plan()
+        has_git_state = existing.git_state.branches or existing.git_state.prs
+        if has_git_state:
+            console.print(
+                "[yellow]An existing split plan with branches/PRs was found.[/yellow]"
+            )
+            if typer.confirm("Clean up existing branches and PRs before re-splitting?"):
+                closed_prs, deleted_branches = _cleanup_git_state(existing.git_state)
+                logger.info(
+                    logs.CLEAN_COMPLETE.format(branches=deleted_branches, prs=closed_prs)
+                )
+            else:
+                console.print("[red]Aborting. Run 'pr-split clean' manually first.[/red]")
+                raise typer.Exit(1)
+        else:
+            logger.info("Overwriting existing dry-run plan")
+
     raw_diff = extract_diff(dev_branch, base)
     parsed_diff = parse_diff(raw_diff)
     stats = parsed_diff.stats
@@ -392,6 +410,8 @@ def split(
     logger.info(logs.PRESENTING_PLAN)
     _present_plan(groups)
 
+    merge_base_ref = merge_base(base, dev_branch)
+
     split_plan = SplitPlan(
         dev_branch=dev_branch,
         base_branch=base,
@@ -399,6 +419,7 @@ def split(
         priority=priority,
         groups=groups,
         author=author,
+        merge_base_sha=merge_base_ref,
     )
 
     if dry_run:
@@ -409,7 +430,6 @@ def split(
     typer.confirm("Proceed with creating branches and PRs?", abort=True)
 
     namespace = derive_split_namespace(dev_branch_arg)
-    merge_base_ref = merge_base(base, dev_branch)
     branch_records = _create_branches_and_commits(
         groups, parsed_diff, base, merge_base_ref, namespace, author=author
     )
@@ -452,17 +472,7 @@ def status() -> None:
     console.print(table)
 
 
-@app.command()
-def clean() -> None:
-    if not plan_exists():
-        console.print(ErrorMsg.NO_PLAN())
-        raise typer.Exit(0)
-
-    plan_file = load_plan()
-    git_state = plan_file.git_state
-
-    typer.confirm("Delete all pr-split branches and close PRs?", abort=True)
-
+def _cleanup_git_state(git_state: GitState) -> tuple[int, int]:
     closed_prs = 0
     for pr_record in git_state.prs:
         try:
@@ -483,5 +493,22 @@ def clean() -> None:
     plan_dir = Path(PLAN_DIR)
     if plan_dir.exists():
         shutil.rmtree(plan_dir)
+
+    return closed_prs, deleted_branches
+
+
+@app.command()
+def clean() -> None:
+    if not plan_exists():
+        console.print(ErrorMsg.NO_PLAN())
+        raise typer.Exit(0)
+
+    plan_file = load_plan()
+    git_state = plan_file.git_state
+
+    typer.confirm("Delete all pr-split branches and close PRs?", abort=True)
+
+    closed_prs, deleted_branches = _cleanup_git_state(git_state)
+    logger.success(logs.CLEAN_COMPLETE.format(branches=deleted_branches, prs=closed_prs))
 
     logger.success(logs.CLEAN_COMPLETE.format(branches=deleted_branches, prs=closed_prs))

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -370,7 +370,7 @@ def split(
             )
             if typer.confirm("Clean up existing branches and PRs before re-splitting?"):
                 closed_prs, deleted_branches = _cleanup_git_state(existing.git_state)
-                logger.info(
+                logger.success(
                     logs.CLEAN_COMPLETE.format(branches=deleted_branches, prs=closed_prs)
                 )
             else:
@@ -509,6 +509,4 @@ def clean() -> None:
     typer.confirm("Delete all pr-split branches and close PRs?", abort=True)
 
     closed_prs, deleted_branches = _cleanup_git_state(git_state)
-    logger.success(logs.CLEAN_COMPLETE.format(branches=deleted_branches, prs=closed_prs))
-
     logger.success(logs.CLEAN_COMPLETE.format(branches=deleted_branches, prs=closed_prs))

--- a/pr_split/schemas.py
+++ b/pr_split/schemas.py
@@ -42,7 +42,7 @@ class SplitPlan(BaseModel):
     priority: Priority
     groups: list[Group] = Field(default_factory=list)
     author: str | None = None
-    merge_base_sha: str = ""
+    merge_base_sha: str | None = None
 
 
 class BranchRecord(BaseModel):

--- a/pr_split/schemas.py
+++ b/pr_split/schemas.py
@@ -42,6 +42,7 @@ class SplitPlan(BaseModel):
     priority: Priority
     groups: list[Group] = Field(default_factory=list)
     author: str | None = None
+    merge_base_sha: str = ""
 
 
 class BranchRecord(BaseModel):


### PR DESCRIPTION
## Summary
- When running `split` with an existing plan that has branches/PRs, prompt user to clean up first
- Dry-run plans (no git state) are silently overwritten
- Extract `_cleanup_git_state()` from `clean` command for reuse
- Add `merge_base_sha` to `SplitPlan` schema for future drift detection
- Compute merge_base_ref earlier so it's available in both dry-run and execution paths

## Test plan
- [x] All 293 tests pass
- [ ] Manual: run `split` twice — second run detects existing plan and offers cleanup
- [ ] Manual: run `split --dry-run` twice — silently overwrites without prompting
- [ ] Manual: decline cleanup on re-split — aborts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)