### PR TITLE
feat: enrich PR descriptions and show live review status

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -257,7 +257,7 @@ _gh_semaphore = Semaphore(_GH_API_CONCURRENCY)
 
 
 def _build_pr_body(group: Group, all_groups: list[Group]) -> str:
-    sections = [group.description, ""]
+    sections = [group.description]
 
     files = [a.file_path for a in group.assignments]
     if files:
@@ -482,6 +482,18 @@ def status() -> None:
     branch_map = {r.group_id: r.branch_name for r in git_state.branches}
     pr_map = {r.group_id: r for r in git_state.prs}
 
+    live_states: dict[int, dict[str, str]] = {}
+    pr_numbers = [r.pr_number for r in git_state.prs]
+    if pr_numbers:
+        with ThreadPoolExecutor(max_workers=_GH_API_CONCURRENCY) as executor:
+            futures = {executor.submit(get_pr_state, n): n for n in pr_numbers}
+            for future in as_completed(futures):
+                pr_num = futures[future]
+                try:
+                    live_states[pr_num] = future.result()
+                except Exception:
+                    live_states[pr_num] = {}
+
     table = Table(title="PR Split Status")
     table.add_column("ID")
     table.add_column("Title")
@@ -497,9 +509,9 @@ def status() -> None:
         pr_state = ""
         review = ""
         if pr_record:
-            live = get_pr_state(pr_record.pr_number)
+            live = live_states.get(pr_record.pr_number, {})
             pr_state = live.get("state", pr_record.state.value).upper()
-            review = live.get("reviewDecision", "").replace("_", " ").title()
+            review = (live.get("reviewDecision") or "").replace("_", " ").title()
         table.add_row(group.id, group.title, branch_name, pr_info, pr_state, review)
 
     console.print(table)

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -45,7 +45,7 @@ from .git_ops import (
     remove_worktree,
 )
 from .git_ops.branches import run_git
-from .git_ops.prs import close_pr, create_pr
+from .git_ops.prs import close_pr, create_pr, get_pr_state
 from .graph import PlanDAG
 from .plan_store import load_plan, plan_exists, save_plan
 from .planner import plan_split, validate_plan
@@ -256,6 +256,31 @@ _GH_API_CONCURRENCY = 3
 _gh_semaphore = Semaphore(_GH_API_CONCURRENCY)
 
 
+def _build_pr_body(group: Group, all_groups: list[Group]) -> str:
+    sections = [group.description, ""]
+
+    files = [a.file_path for a in group.assignments]
+    if files:
+        file_list = "\n".join(f"- `{f}`" for f in files)
+        sections.append(f"## Files changed\n\n{file_list}")
+
+    sections.append(
+        f"## Diff stats\n\n"
+        f"**+{group.estimated_added}** additions, "
+        f"**-{group.estimated_removed}** deletions "
+        f"({group.estimated_loc} LOC)"
+    )
+
+    deps = group.depends_on
+    if deps:
+        dep_list = ", ".join(f"`{d}`" for d in deps)
+        sections.append(f"## Dependencies\n\nThis PR depends on: {dep_list}")
+
+    sections.append(_render_dag_markdown(all_groups, group.id))
+
+    return "\n\n".join(sections)
+
+
 def _push_and_create_single_pr(
     group: Group,
     record: BranchRecord,
@@ -263,8 +288,7 @@ def _push_and_create_single_pr(
 ) -> PRRecord:
     push_branch(record.branch_name)
     logger.info(logs.CREATING_PR.format(group=group.id))
-    dag_md = _render_dag_markdown(all_groups, group.id)
-    body = f"{group.description}\n\n{dag_md}"
+    body = _build_pr_body(group, all_groups)
     with _gh_semaphore:
         pr_number, pr_url = create_pr(
             head=record.branch_name,
@@ -464,13 +488,19 @@ def status() -> None:
     table.add_column("Branch")
     table.add_column("PR")
     table.add_column("State")
+    table.add_column("Review")
 
     for group in plan.groups:
         branch_name = branch_map.get(group.id, "")
         pr_record = pr_map.get(group.id)
         pr_info = f"#{pr_record.pr_number}" if pr_record else ""
-        pr_state = pr_record.state.value if pr_record else ""
-        table.add_row(group.id, group.title, branch_name, pr_info, pr_state)
+        pr_state = ""
+        review = ""
+        if pr_record:
+            live = get_pr_state(pr_record.pr_number)
+            pr_state = live.get("state", pr_record.state.value).upper()
+            review = live.get("reviewDecision", "").replace("_", " ").title()
+        table.add_row(group.id, group.title, branch_name, pr_info, pr_state, review)
 
     console.print(table)
 

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -482,7 +482,7 @@ def status() -> None:
     branch_map = {r.group_id: r.branch_name for r in git_state.branches}
     pr_map = {r.group_id: r for r in git_state.prs}
 
-    live_states: dict[int, dict[str, str]] = {}
+    live_states: dict[int, dict[str, str | None]] = {}
     pr_numbers = [r.pr_number for r in git_state.prs]
     if pr_numbers:
         with ThreadPoolExecutor(max_workers=_GH_API_CONCURRENCY) as executor:

--- a/pr_split/git_ops/__init__.py
+++ b/pr_split/git_ops/__init__.py
@@ -18,4 +18,5 @@ from .prs import (
     create_pr,
     fetch_fork_branch,
     fetch_fork_pr,
+    get_pr_state,
 )

--- a/pr_split/git_ops/prs.py
+++ b/pr_split/git_ops/prs.py
@@ -52,13 +52,14 @@ def create_pr(head: str, base: str, title: str, body: str) -> tuple[int, str]:
     return pr_number, pr_url
 
 
-def get_pr_state(pr_number: int) -> dict[str, str]:
+def get_pr_state(pr_number: int) -> dict[str, str | None]:
     try:
         raw = _run_gh(
             "pr", "view", str(pr_number), "--json", "state,reviewDecision"
         )
         return json.loads(raw)
-    except (GitOperationError, json.JSONDecodeError):
+    except (GitOperationError, json.JSONDecodeError) as exc:
+        logger.debug(f"Failed to fetch live state for PR #{pr_number}: {exc}")
         return {}
 
 

--- a/pr_split/git_ops/prs.py
+++ b/pr_split/git_ops/prs.py
@@ -52,6 +52,16 @@ def create_pr(head: str, base: str, title: str, body: str) -> tuple[int, str]:
     return pr_number, pr_url
 
 
+def get_pr_state(pr_number: int) -> dict[str, str]:
+    try:
+        raw = _run_gh(
+            "pr", "view", str(pr_number), "--json", "state,mergeable,reviewDecision"
+        )
+        return json.loads(raw)
+    except (GitOperationError, json.JSONDecodeError):
+        return {}
+
+
 def close_pr(pr_number: int) -> None:
     _run_gh("pr", "close", str(pr_number))
     logger.info(logs.PR_CLOSED.format(number=pr_number))

--- a/pr_split/git_ops/prs.py
+++ b/pr_split/git_ops/prs.py
@@ -55,7 +55,7 @@ def create_pr(head: str, base: str, title: str, body: str) -> tuple[int, str]:
 def get_pr_state(pr_number: int) -> dict[str, str]:
     try:
         raw = _run_gh(
-            "pr", "view", str(pr_number), "--json", "state,mergeable,reviewDecision"
+            "pr", "view", str(pr_number), "--json", "state,reviewDecision"
         )
         return json.loads(raw)
     except (GitOperationError, json.JSONDecodeError):


### PR DESCRIPTION
## Summary
- **PR description enrichment**: Each created PR now includes Files Changed, Diff Stats (+/-/LOC), Dependencies, and the dependency graph — not just the description
- **Live status command**: `status` now queries GitHub for real PR state (OPEN/CLOSED/MERGED) and review decision (Approved/Changes Requested/etc.) instead of showing stale stored state
- Add `get_pr_state()` helper to git_ops/prs.py using `gh pr view --json`
- Extract `_build_pr_body()` for cleaner PR body construction

## Test plan
- [x] All 293 tests pass
- [ ] Manual: run `split` and verify PR bodies include files, stats, deps, and DAG
- [ ] Manual: run `status` and verify live state/review columns reflect GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)