### PR TITLE
feat: add merge command to merge split PRs in dependency order

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -603,6 +603,7 @@ def merge_all(
     dag = PlanDAG(plan.groups)
     merged: list[str] = []
     skipped: list[str] = []
+    skipped_ids: set[str] = set()
     failed: list[str] = []
 
     stopped = False
@@ -611,6 +612,7 @@ def merge_all(
         for group_id in batch:
             pr_record = pr_map.get(group_id)
             if not pr_record:
+                skipped_ids.add(group_id)
                 skipped.append(f"{group_id} (no PR)")
                 continue
 
@@ -619,6 +621,7 @@ def merge_all(
                 logger.warning(
                     f"PR #{pr_record.pr_number} ({group_id}) state could not be fetched, skipping"
                 )
+                skipped_ids.add(group_id)
                 skipped.append(f"{group_id} (fetch error)")
                 continue
 
@@ -631,11 +634,13 @@ def merge_all(
 
             if state != "OPEN":
                 logger.warning(f"PR #{pr_record.pr_number} ({group_id}) is {state}, skipping")
+                skipped_ids.add(group_id)
                 skipped.append(f"{group_id} ({state})")
                 continue
 
             if live.get("isDraft"):
                 logger.warning(f"PR #{pr_record.pr_number} ({group_id}) is a draft, skipping")
+                skipped_ids.add(group_id)
                 skipped.append(f"{group_id} (draft)")
                 continue
 
@@ -645,6 +650,7 @@ def merge_all(
                 logger.warning(
                     f"PR #{pr_record.pr_number} ({group_id}) review not approved ({label}), skipping"
                 )
+                skipped_ids.add(group_id)
                 skipped.append(f"{group_id} ({label})")
                 continue
 
@@ -661,7 +667,7 @@ def merge_all(
         if auto and not stopped:
             queued = [
                 gid for gid in batch
-                if gid not in merged and gid not in [s.split(" ")[0] for s in skipped]
+                if gid not in merged and gid not in skipped_ids
             ]
             if queued:
                 logger.info(f"Waiting for auto-merge to complete: {', '.join(queued)}")

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import shutil
 import tempfile
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from threading import Lock, Semaphore
@@ -557,6 +558,29 @@ def clean() -> None:
     logger.success(logs.CLEAN_COMPLETE.format(branches=deleted_branches, prs=closed_prs))
 
 
+_AUTO_MERGE_POLL_INTERVAL = 10
+_AUTO_MERGE_POLL_TIMEOUT = 600
+
+
+def _poll_for_merged(
+    group_ids: list[str], pr_map: dict[str, PRRecord]
+) -> None:
+    pending = set(group_ids)
+    deadline = time.monotonic() + _AUTO_MERGE_POLL_TIMEOUT
+    while pending and time.monotonic() < deadline:
+        time.sleep(_AUTO_MERGE_POLL_INTERVAL)
+        for gid in list(pending):
+            pr_record = pr_map[gid]
+            live = get_pr_state(pr_record.pr_number)
+            state = (live.get("state") or "").upper()
+            if state == "MERGED":
+                logger.info(f"PR #{pr_record.pr_number} ({gid}) merged")
+                pending.discard(gid)
+    if pending:
+        remaining = ", ".join(pending)
+        logger.warning(f"Timed out waiting for auto-merge: {remaining}")
+
+
 @app.command(name="merge", help="Merge all split PRs in dependency order. Skips already-merged PRs. Stops when a PR can't be merged.")
 def merge_all(
     auto: Annotated[
@@ -577,11 +601,6 @@ def merge_all(
         raise typer.Exit(0)
 
     dag = PlanDAG(plan.groups)
-
-    if auto and any(dag.children(gid) for gid in pr_map):
-        console.print("[red]--auto cannot be used with stacked (dependent) PRs.[/red]")
-        raise typer.Exit(1)
-
     merged: list[str] = []
     skipped: list[str] = []
     failed: list[str] = []
@@ -629,12 +648,23 @@ def merge_all(
 
             try:
                 merge_pr(pr_record.pr_number, auto=auto)
-                merged.append(group_id)
+                if not auto:
+                    merged.append(group_id)
             except PRSplitError as exc:
                 logger.error(f"Failed to merge PR #{pr_record.pr_number} ({group_id}): {exc}")
                 failed.append(group_id)
                 stopped = True
                 break
+
+        if auto and not stopped:
+            queued = [
+                gid for gid in batch
+                if gid not in merged and gid not in [s.split(" ")[0] for s in skipped]
+            ]
+            if queued:
+                logger.info(f"Waiting for auto-merge to complete: {', '.join(queued)}")
+                _poll_for_merged(queued, pr_map)
+                merged.extend(queued)
 
         if stopped or any(gid not in merged for gid in batch):
             if not stopped:

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -578,6 +578,12 @@ def _poll_for_merged(
                 logger.info(f"PR #{pr_record.pr_number} ({gid}) merged")
                 actually_merged.add(gid)
                 pending.discard(gid)
+            elif state in ("CLOSED", ""):
+                reason = "closed" if state == "CLOSED" else "fetch error"
+                logger.warning(
+                    f"PR #{pr_record.pr_number} ({gid}) {reason} while polling, aborting wait"
+                )
+                pending.discard(gid)
     if pending:
         remaining = ", ".join(pending)
         logger.warning(f"Timed out waiting for auto-merge: {remaining}")
@@ -677,7 +683,7 @@ def merge_all(
                 actually_merged = _poll_for_merged(queued, pr_map)
                 merged.extend(actually_merged)
 
-        if stopped or any(gid not in merged for gid in batch):
+        if stopped or any(gid not in merged and gid not in skipped_ids for gid in batch):
             if not stopped:
                 console.print(
                     "[yellow]Some PRs in this batch were not merged. "

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -557,8 +557,12 @@ def clean() -> None:
     logger.success(logs.CLEAN_COMPLETE.format(branches=deleted_branches, prs=closed_prs))
 
 
-@app.command(name="merge", help="Merge all split PRs in dependency order. Skips already-merged, closed, or changes-requested PRs. Stops on first failure.")
-def merge_all() -> None:
+@app.command(name="merge", help="Merge all split PRs in dependency order. Skips already-merged PRs. Stops when a PR can't be merged.")
+def merge_all(
+    auto: Annotated[
+        bool, typer.Option("--auto", help="Queue merges to run after CI checks pass")
+    ] = False,
+) -> None:
     if not plan_exists():
         console.print(ErrorMsg.NO_PLAN())
         raise typer.Exit(0)
@@ -577,6 +581,7 @@ def merge_all() -> None:
     skipped: list[str] = []
     failed: list[str] = []
 
+    stopped = False
     for batch in dag.iter_ready():
         for group_id in batch:
             pr_record = pr_map.get(group_id)
@@ -585,6 +590,13 @@ def merge_all() -> None:
                 continue
 
             live = get_pr_state(pr_record.pr_number)
+            if not live:
+                logger.warning(
+                    f"PR #{pr_record.pr_number} ({group_id}) state could not be fetched, skipping"
+                )
+                skipped.append(f"{group_id} (fetch error)")
+                continue
+
             state = (live.get("state") or "").upper()
 
             if state == "MERGED":
@@ -606,19 +618,26 @@ def merge_all() -> None:
                 continue
 
             try:
-                merge_pr(pr_record.pr_number)
+                merge_pr(pr_record.pr_number, auto=auto)
                 merged.append(group_id)
             except PRSplitError as exc:
                 logger.error(f"Failed to merge PR #{pr_record.pr_number} ({group_id}): {exc}")
                 failed.append(group_id)
+                stopped = True
+                break
+
+        if stopped or any(gid not in merged for gid in batch):
+            if not stopped:
                 console.print(
-                    f"[red]Merge failed for {group_id}. "
+                    "[yellow]Some PRs in this batch were not merged. "
+                    "Stopping to avoid merging dependent PRs out of order.[/yellow]"
+                )
+            else:
+                console.print(
+                    f"[red]Merge failed. "
                     f"Stopping to avoid merging dependent PRs out of order.[/red]"
                 )
-                break
-        else:
-            continue
-        break
+            break
 
     console.print()
     if merged:

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -564,8 +564,9 @@ _AUTO_MERGE_POLL_TIMEOUT = 600
 
 def _poll_for_merged(
     group_ids: list[str], pr_map: dict[str, PRRecord]
-) -> None:
+) -> set[str]:
     pending = set(group_ids)
+    actually_merged: set[str] = set()
     deadline = time.monotonic() + _AUTO_MERGE_POLL_TIMEOUT
     while pending and time.monotonic() < deadline:
         time.sleep(_AUTO_MERGE_POLL_INTERVAL)
@@ -575,10 +576,12 @@ def _poll_for_merged(
             state = (live.get("state") or "").upper()
             if state == "MERGED":
                 logger.info(f"PR #{pr_record.pr_number} ({gid}) merged")
+                actually_merged.add(gid)
                 pending.discard(gid)
     if pending:
         remaining = ", ".join(pending)
         logger.warning(f"Timed out waiting for auto-merge: {remaining}")
+    return actually_merged
 
 
 @app.command(name="merge", help="Merge all split PRs in dependency order. Skips already-merged PRs. Stops when a PR can't be merged.")
@@ -671,8 +674,8 @@ def merge_all(
             ]
             if queued:
                 logger.info(f"Waiting for auto-merge to complete: {', '.join(queued)}")
-                _poll_for_merged(queued, pr_map)
-                merged.extend(queued)
+                actually_merged = _poll_for_merged(queued, pr_map)
+                merged.extend(actually_merged)
 
         if stopped or any(gid not in merged for gid in batch):
             if not stopped:

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -577,6 +577,11 @@ def merge_all(
         raise typer.Exit(0)
 
     dag = PlanDAG(plan.groups)
+
+    if auto and any(dag.children(gid) for gid in pr_map):
+        console.print("[red]--auto cannot be used with stacked (dependent) PRs.[/red]")
+        raise typer.Exit(1)
+
     merged: list[str] = []
     skipped: list[str] = []
     failed: list[str] = []
@@ -607,6 +612,11 @@ def merge_all(
             if state != "OPEN":
                 logger.warning(f"PR #{pr_record.pr_number} ({group_id}) is {state}, skipping")
                 skipped.append(f"{group_id} ({state})")
+                continue
+
+            if live.get("isDraft"):
+                logger.warning(f"PR #{pr_record.pr_number} ({group_id}) is a draft, skipping")
+                skipped.append(f"{group_id} (draft)")
                 continue
 
             review = live.get("reviewDecision") or ""
@@ -646,5 +656,6 @@ def merge_all(
         console.print(f"[yellow]Skipped ({len(skipped)}): {', '.join(skipped)}[/yellow]")
     if failed:
         console.print(f"[red]Failed ({len(failed)}): {', '.join(failed)}[/red]")
-    if not failed:
-        logger.success(f"Merge complete: {len(merged)} PRs merged")
+    if failed or stopped:
+        raise typer.Exit(1)
+    logger.success(f"Merge complete: {len(merged)} PRs merged")

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -45,7 +45,7 @@ from .git_ops import (
     remove_worktree,
 )
 from .git_ops.branches import run_git
-from .git_ops.prs import close_pr, create_pr, get_pr_state
+from .git_ops.prs import close_pr, create_pr, get_pr_state, merge_pr
 from .graph import PlanDAG
 from .plan_store import load_plan, plan_exists, save_plan
 from .planner import plan_split, validate_plan
@@ -555,3 +555,77 @@ def clean() -> None:
 
     closed_prs, deleted_branches = _cleanup_git_state(git_state)
     logger.success(logs.CLEAN_COMPLETE.format(branches=deleted_branches, prs=closed_prs))
+
+
+@app.command(name="merge")
+def merge_all() -> None:
+    if not plan_exists():
+        console.print(ErrorMsg.NO_PLAN())
+        raise typer.Exit(0)
+
+    plan_file = load_plan()
+    plan = plan_file.plan
+    git_state = plan_file.git_state
+    pr_map = {r.group_id: r for r in git_state.prs}
+
+    if not pr_map:
+        console.print("[yellow]No PRs found in plan. Nothing to merge.[/yellow]")
+        raise typer.Exit(0)
+
+    dag = PlanDAG(plan.groups)
+    merged: list[str] = []
+    skipped: list[str] = []
+    failed: list[str] = []
+
+    for batch in dag.iter_ready():
+        for group_id in batch:
+            pr_record = pr_map.get(group_id)
+            if not pr_record:
+                skipped.append(f"{group_id} (no PR)")
+                continue
+
+            live = get_pr_state(pr_record.pr_number)
+            state = (live.get("state") or "").upper()
+
+            if state == "MERGED":
+                logger.info(f"PR #{pr_record.pr_number} ({group_id}) already merged")
+                merged.append(group_id)
+                continue
+
+            if state != "OPEN":
+                logger.warning(f"PR #{pr_record.pr_number} ({group_id}) is {state}, skipping")
+                skipped.append(f"{group_id} ({state})")
+                continue
+
+            review = live.get("reviewDecision") or ""
+            if review == "CHANGES_REQUESTED":
+                logger.warning(
+                    f"PR #{pr_record.pr_number} ({group_id}) has changes requested, skipping"
+                )
+                skipped.append(f"{group_id} (changes requested)")
+                continue
+
+            try:
+                merge_pr(pr_record.pr_number)
+                merged.append(group_id)
+            except PRSplitError as exc:
+                logger.error(f"Failed to merge PR #{pr_record.pr_number} ({group_id}): {exc}")
+                failed.append(group_id)
+                console.print(
+                    f"[red]Merge failed for {group_id}. "
+                    f"Stopping to avoid merging dependent PRs out of order.[/red]"
+                )
+                break
+        else:
+            continue
+        break
+
+    console.print()
+    if merged:
+        console.print(f"[green]Merged ({len(merged)}): {', '.join(merged)}[/green]")
+    if skipped:
+        console.print(f"[yellow]Skipped ({len(skipped)}): {', '.join(skipped)}[/yellow]")
+    if failed:
+        console.print(f"[red]Failed ({len(failed)}): {', '.join(failed)}[/red]")
+    if not failed:
+        logger.success(f"Merge complete: {len(merged)} PRs merged")

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -343,7 +343,7 @@ def _resolve_fork_ref(dev_branch: str) -> ForkPRInfo | None:
     return None
 
 
-@app.command()
+@app.command(help="Split a large PR into smaller dependency-ordered PRs.")
 def split(
     dev_branch: Annotated[str, typer.Argument(help="Branch name, PR number, or user:branch")],
     base: Annotated[str, typer.Option(help="Base branch")] = "main",
@@ -469,7 +469,7 @@ def split(
     logger.success(f"Split complete: {len(groups)} PRs created")
 
 
-@app.command()
+@app.command(help="Show the current split plan with live PR state and review status.")
 def status() -> None:
     if not plan_exists():
         console.print(ErrorMsg.NO_PLAN())
@@ -542,7 +542,7 @@ def _cleanup_git_state(git_state: GitState) -> tuple[int, int]:
     return closed_prs, deleted_branches
 
 
-@app.command()
+@app.command(help="Close all split PRs and delete their branches.")
 def clean() -> None:
     if not plan_exists():
         console.print(ErrorMsg.NO_PLAN())
@@ -557,7 +557,7 @@ def clean() -> None:
     logger.success(logs.CLEAN_COMPLETE.format(branches=deleted_branches, prs=closed_prs))
 
 
-@app.command(name="merge")
+@app.command(name="merge", help="Merge all split PRs in dependency order. Skips already-merged, closed, or changes-requested PRs. Stops on first failure.")
 def merge_all() -> None:
     if not plan_exists():
         console.print(ErrorMsg.NO_PLAN())

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -483,7 +483,7 @@ def status() -> None:
     branch_map = {r.group_id: r.branch_name for r in git_state.branches}
     pr_map = {r.group_id: r for r in git_state.prs}
 
-    live_states: dict[int, dict[str, str | None]] = {}
+    live_states: dict[int, dict[str, str | bool | None]] = {}
     pr_numbers = [r.pr_number for r in git_state.prs]
     if pr_numbers:
         with ThreadPoolExecutor(max_workers=_GH_API_CONCURRENCY) as executor:
@@ -606,6 +606,7 @@ def merge_all(
     failed: list[str] = []
 
     stopped = False
+    exited_early = False
     for batch in dag.iter_ready():
         for group_id in batch:
             pr_record = pr_map.get(group_id)
@@ -639,11 +640,12 @@ def merge_all(
                 continue
 
             review = live.get("reviewDecision") or ""
-            if review == "CHANGES_REQUESTED":
+            if review in ("CHANGES_REQUESTED", "REVIEW_REQUIRED"):
+                label = review.lower().replace("_", " ")
                 logger.warning(
-                    f"PR #{pr_record.pr_number} ({group_id}) has changes requested, skipping"
+                    f"PR #{pr_record.pr_number} ({group_id}) review not approved ({label}), skipping"
                 )
-                skipped.append(f"{group_id} (changes requested)")
+                skipped.append(f"{group_id} ({label})")
                 continue
 
             try:
@@ -674,9 +676,10 @@ def merge_all(
                 )
             else:
                 console.print(
-                    f"[red]Merge failed. "
-                    f"Stopping to avoid merging dependent PRs out of order.[/red]"
+                    "[red]Merge failed. "
+                    "Stopping to avoid merging dependent PRs out of order.[/red]"
                 )
+            exited_early = True
             break
 
     console.print()
@@ -686,6 +689,6 @@ def merge_all(
         console.print(f"[yellow]Skipped ({len(skipped)}): {', '.join(skipped)}[/yellow]")
     if failed:
         console.print(f"[red]Failed ({len(failed)}): {', '.join(failed)}[/red]")
-    if failed or stopped:
+    if failed or stopped or exited_early:
         raise typer.Exit(1)
     logger.success(f"Merge complete: {len(merged)} PRs merged")

--- a/pr_split/git_ops/__init__.py
+++ b/pr_split/git_ops/__init__.py
@@ -19,4 +19,5 @@ from .prs import (
     fetch_fork_branch,
     fetch_fork_pr,
     get_pr_state,
+    merge_pr,
 )

--- a/pr_split/git_ops/prs.py
+++ b/pr_split/git_ops/prs.py
@@ -55,7 +55,7 @@ def create_pr(head: str, base: str, title: str, body: str) -> tuple[int, str]:
 def get_pr_state(pr_number: int) -> dict[str, str | None]:
     try:
         raw = _run_gh(
-            "pr", "view", str(pr_number), "--json", "state,reviewDecision"
+            "pr", "view", str(pr_number), "--json", "state,reviewDecision,isDraft"
         )
         return json.loads(raw)
     except (GitOperationError, json.JSONDecodeError) as exc:

--- a/pr_split/git_ops/prs.py
+++ b/pr_split/git_ops/prs.py
@@ -52,7 +52,7 @@ def create_pr(head: str, base: str, title: str, body: str) -> tuple[int, str]:
     return pr_number, pr_url
 
 
-def get_pr_state(pr_number: int) -> dict[str, str | None]:
+def get_pr_state(pr_number: int) -> dict[str, str | bool | None]:
     try:
         raw = _run_gh(
             "pr", "view", str(pr_number), "--json", "state,reviewDecision,isDraft"

--- a/pr_split/git_ops/prs.py
+++ b/pr_split/git_ops/prs.py
@@ -63,9 +63,12 @@ def get_pr_state(pr_number: int) -> dict[str, str | None]:
         return {}
 
 
-def merge_pr(pr_number: int) -> None:
-    _run_gh("pr", "merge", str(pr_number), "--merge", "--delete-branch")
-    logger.info(f"Merged PR #{pr_number}")
+def merge_pr(pr_number: int, *, auto: bool = False) -> None:
+    args = ["pr", "merge", str(pr_number), "--merge", "--delete-branch"]
+    if auto:
+        args.append("--auto")
+    _run_gh(*args)
+    logger.info(f"{'Queued' if auto else 'Merged'} PR #{pr_number}")
 
 
 def close_pr(pr_number: int) -> None:

--- a/pr_split/git_ops/prs.py
+++ b/pr_split/git_ops/prs.py
@@ -63,6 +63,11 @@ def get_pr_state(pr_number: int) -> dict[str, str | None]:
         return {}
 
 
+def merge_pr(pr_number: int) -> None:
+    _run_gh("pr", "merge", str(pr_number), "--merge", "--delete-branch")
+    logger.info(f"Merged PR #{pr_number}")
+
+
 def close_pr(pr_number: int) -> None:
     _run_gh("pr", "close", str(pr_number))
     logger.info(logs.PR_CLOSED.format(number=pr_number))


### PR DESCRIPTION
## Summary
- Add `pr-split merge` command that merges all split PRs in topological (dependency) order
- Walks the DAG using `iter_ready()` — merges each batch before moving to dependents
- Queries live PR state before each merge: skips already-merged, closed, or changes-requested PRs
- Stops immediately on merge failure to avoid merging dependent PRs out of order
- Reports summary (merged, skipped, failed) at the end
- Add `merge_pr()` helper using `gh pr merge --merge --delete-branch`
- Add help text to all CLI commands (split, status, clean, merge)

## Test plan
- [x] All 293 tests pass
- [ ] Manual: create a split, approve all PRs, run `pr-split merge` — verify correct order
- [ ] Manual: run merge with one unapproved PR — verify it's skipped and dependents stop
- [ ] Manual: run merge with already-merged PRs — verify they're skipped gracefully