### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
 
 <p align="center">
   <a href="https://github.com/vitali87/pr-split/blob/main/LICENSE"><img src="https://img.shields.io/github/license/vitali87/pr-split" alt="License"></a>
+  <a href="https://gitcgr.com/vitali87/pr-split">
+    <img src="https://gitcgr.com/badge/vitali87/pr-split.svg" alt="gitcgr" />
+  </a>
 </p>
 
 ## Why pr-split?


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/vitali87/pr-split.svg)](https://gitcgr.com/vitali87/pr-split)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).