### PR TITLE
feat: add execute command to create PRs from a saved dry-run plan

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -595,7 +595,17 @@ def execute() -> None:
         )
         raise typer.Exit(1)
 
-    _validate_inputs(plan.dev_branch, plan.base_branch)
+    if not branch_exists(plan.base_branch):
+        console.print(
+            f"[red]{ErrorMsg.BRANCH_NOT_FOUND(branch=plan.base_branch)}[/red]"
+        )
+        raise typer.Exit(1)
+    if not is_worktree_clean():
+        console.print(f"[red]{ErrorMsg.DIRTY_WORKTREE()}[/red]")
+        raise typer.Exit(1)
+    if not check_gh_auth():
+        console.print(f"[red]{ErrorMsg.GH_AUTH_FAILED()}[/red]")
+        raise typer.Exit(1)
 
     parsed_diff = parse_diff(plan.raw_diff)
 

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -561,6 +561,43 @@ def clean() -> None:
     logger.success(logs.CLEAN_COMPLETE.format(branches=deleted_branches, prs=closed_prs))
 
 
+@app.command(help="Execute a previously saved dry-run plan, creating branches and PRs.")
+def execute() -> None:
+    if not plan_exists():
+        console.print(ErrorMsg.NO_PLAN())
+        raise typer.Exit(1)
+
+    plan_file = load_plan()
+    plan = plan_file.plan
+
+    if plan_file.git_state.branches or plan_file.git_state.prs:
+        console.print("[red]This plan already has branches/PRs. Use 'pr-split clean' first.[/red]")
+        raise typer.Exit(1)
+
+    if not check_gh_auth():
+        console.print(f"[red]{ErrorMsg.GH_AUTH_FAILED()}[/red]")
+        raise typer.Exit(1)
+
+    _present_plan(plan.groups)
+    typer.confirm("Proceed with creating branches and PRs?", abort=True)
+
+    raw_diff = extract_diff(plan.dev_branch, plan.base_branch)
+    parsed_diff = parse_diff(raw_diff)
+
+    merge_base_ref = plan.merge_base_sha or merge_base(plan.base_branch, plan.dev_branch)
+    namespace = derive_split_namespace(plan.dev_branch)
+    branch_records = _create_branches_and_commits(
+        plan.groups, parsed_diff, plan.base_branch, merge_base_ref, namespace, author=plan.author
+    )
+    pr_records = _push_and_create_prs(plan.groups, branch_records)
+
+    save_plan(PlanFile(
+        plan=plan,
+        git_state=GitState(branches=branch_records, prs=pr_records),
+    ))
+    logger.success(f"Execute complete: {len(plan.groups)} PRs created from saved plan")
+
+
 _AUTO_MERGE_POLL_INTERVAL = 10
 _AUTO_MERGE_POLL_TIMEOUT = 600
 

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -451,6 +451,8 @@ def split(
         groups=groups,
         author=author,
         merge_base_sha=merge_base_ref,
+        dev_branch_arg=dev_branch_arg,
+        raw_diff=raw_diff,
     )
 
     if dry_run:
@@ -561,7 +563,9 @@ def clean() -> None:
     logger.success(logs.CLEAN_COMPLETE.format(branches=deleted_branches, prs=closed_prs))
 
 
-@app.command(help="Execute a previously saved dry-run plan, creating branches and PRs.")
+@app.command(
+    help="Execute a previously saved dry-run plan, creating branches and PRs.",
+)
 def execute() -> None:
     if not plan_exists():
         console.print(ErrorMsg.NO_PLAN())
@@ -571,23 +575,43 @@ def execute() -> None:
     plan = plan_file.plan
 
     if plan_file.git_state.branches or plan_file.git_state.prs:
-        console.print("[red]This plan already has branches/PRs. Use 'pr-split clean' first.[/red]")
+        console.print(
+            "[red]This plan already has branches/PRs."
+            " Use 'pr-split clean' first.[/red]"
+        )
         raise typer.Exit(1)
 
-    if not check_gh_auth():
-        console.print(f"[red]{ErrorMsg.GH_AUTH_FAILED()}[/red]")
+    if not plan.raw_diff:
+        console.print(
+            "[red]Plan is missing saved diff data."
+            " Re-run 'pr-split split --dry-run' to regenerate.[/red]"
+        )
         raise typer.Exit(1)
+
+    if not plan.merge_base_sha:
+        console.print(
+            "[red]Plan is missing merge base SHA."
+            " Re-run 'pr-split split --dry-run' to regenerate.[/red]"
+        )
+        raise typer.Exit(1)
+
+    _validate_inputs(plan.dev_branch, plan.base_branch)
+
+    parsed_diff = parse_diff(plan.raw_diff)
 
     _present_plan(plan.groups)
     typer.confirm("Proceed with creating branches and PRs?", abort=True)
 
-    raw_diff = extract_diff(plan.dev_branch, plan.base_branch)
-    parsed_diff = parse_diff(raw_diff)
-
-    merge_base_ref = plan.merge_base_sha or merge_base(plan.base_branch, plan.dev_branch)
-    namespace = derive_split_namespace(plan.dev_branch)
+    namespace = derive_split_namespace(
+        plan.dev_branch_arg or plan.dev_branch
+    )
     branch_records = _create_branches_and_commits(
-        plan.groups, parsed_diff, plan.base_branch, merge_base_ref, namespace, author=plan.author
+        plan.groups,
+        parsed_diff,
+        plan.base_branch,
+        plan.merge_base_sha,
+        namespace,
+        author=plan.author,
     )
     pr_records = _push_and_create_prs(plan.groups, branch_records)
 
@@ -595,7 +619,9 @@ def execute() -> None:
         plan=plan,
         git_state=GitState(branches=branch_records, prs=pr_records),
     ))
-    logger.success(f"Execute complete: {len(plan.groups)} PRs created from saved plan")
+    logger.success(
+        f"Execute complete: {len(plan.groups)} PRs created from saved plan"
+    )
 
 
 _AUTO_MERGE_POLL_INTERVAL = 10

--- a/pr_split/schemas.py
+++ b/pr_split/schemas.py
@@ -43,6 +43,8 @@ class SplitPlan(BaseModel):
     groups: list[Group] = Field(default_factory=list)
     author: str | None = None
     merge_base_sha: str | None = None
+    dev_branch_arg: str | None = None
+    raw_diff: str | None = None
 
 
 class BranchRecord(BaseModel):


### PR DESCRIPTION
## Summary
- Add `pr-split execute` command that creates branches and PRs from a previously saved dry-run plan
- Guards against executing a plan that already has branches/PRs
- Re-extracts the diff and uses the saved merge_base_sha for consistency
- Shows the plan and asks for confirmation before proceeding

## Test plan
- [x] All 293 tests pass
- [ ] Manual: run `split --dry-run`, then `execute` — verify PRs created from saved plan
- [ ] Manual: run `execute` without a plan — verify error message
- [ ] Manual: run `execute` on an already-executed plan — verify rejection