### PR TITLE
feat: support custom PR body template via .pr-split/template.md

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -282,15 +282,19 @@ def _build_pr_body(group: Group, all_groups: list[Group]) -> str:
     }
 
     if _PR_TEMPLATE_PATH.exists():
-        template = _PR_TEMPLATE_PATH.read_text(encoding="utf-8")
         try:
+            template = _PR_TEMPLATE_PATH.read_text(encoding="utf-8")
             return template.format(**template_vars)
-        except (KeyError, ValueError) as exc:
+        except (KeyError, ValueError, IndexError) as exc:
             available = ", ".join(f"{{{k}}}" for k in sorted(template_vars))
             raise PRSplitError(
                 f"Invalid PR template at {_PR_TEMPLATE_PATH}: {exc}. "
                 f"Available placeholders: {available}. "
                 "Escape literal braces with {{ and }}."
+            ) from exc
+        except OSError as exc:
+            raise PRSplitError(
+                f"Could not read PR template at {_PR_TEMPLATE_PATH}: {exc}"
             ) from exc
 
     sections = [group.description]

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -283,7 +283,15 @@ def _build_pr_body(group: Group, all_groups: list[Group]) -> str:
 
     if _PR_TEMPLATE_PATH.exists():
         template = _PR_TEMPLATE_PATH.read_text(encoding="utf-8")
-        return template.format(**template_vars)
+        try:
+            return template.format(**template_vars)
+        except (KeyError, ValueError) as exc:
+            available = ", ".join(f"{{{k}}}" for k in sorted(template_vars))
+            raise PRSplitError(
+                f"Invalid PR template at {_PR_TEMPLATE_PATH}: {exc}. "
+                f"Available placeholders: {available}. "
+                "Escape literal braces with {{ and }}."
+            ) from exc
 
     sections = [group.description]
     if files:

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -568,9 +568,9 @@ def _cleanup_git_state(git_state: GitState) -> tuple[int, int]:
         except PRSplitError:
             logger.warning(f"Could not delete branch {branch_record.branch_name}")
 
-    plan_dir = Path(PLAN_DIR)
-    if plan_dir.exists():
-        shutil.rmtree(plan_dir)
+    plan_path = Path(PLAN_FILE)
+    if plan_path.exists():
+        plan_path.unlink()
 
     return closed_prs, deleted_branches
 

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -260,28 +260,43 @@ _GH_API_CONCURRENCY = 3
 _gh_semaphore = Semaphore(_GH_API_CONCURRENCY)
 
 
+_PR_TEMPLATE_PATH = Path(PLAN_DIR) / "template.md"
+
+
 def _build_pr_body(group: Group, all_groups: list[Group]) -> str:
-    sections = [group.description]
-
     files = [a.file_path for a in group.assignments]
-    if files:
-        file_list = "\n".join(f"- `{f}`" for f in files)
-        sections.append(f"## Files changed\n\n{file_list}")
+    file_list = "\n".join(f"- `{f}`" for f in files)
+    dep_list = ", ".join(f"`{d}`" for d in group.depends_on)
+    dag_md = _render_dag_markdown(all_groups, group.id)
 
+    template_vars = {
+        "description": group.description,
+        "files": file_list,
+        "added": group.estimated_added,
+        "removed": group.estimated_removed,
+        "loc": group.estimated_loc,
+        "dependencies": dep_list,
+        "dag": dag_md,
+        "id": group.id,
+        "title": group.title,
+    }
+
+    if _PR_TEMPLATE_PATH.exists():
+        template = _PR_TEMPLATE_PATH.read_text(encoding="utf-8")
+        return template.format(**template_vars)
+
+    sections = [group.description]
+    if files:
+        sections.append(f"## Files changed\n\n{file_list}")
     sections.append(
         f"## Diff stats\n\n"
         f"**+{group.estimated_added}** additions, "
         f"**-{group.estimated_removed}** deletions "
         f"({group.estimated_loc} LOC)"
     )
-
-    deps = group.depends_on
-    if deps:
-        dep_list = ", ".join(f"`{d}`" for d in deps)
+    if group.depends_on:
         sections.append(f"## Dependencies\n\nThis PR depends on: {dep_list}")
-
-    sections.append(_render_dag_markdown(all_groups, group.id))
-
+    sections.append(dag_md)
     return "\n\n".join(sections)
 
 

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -264,29 +264,26 @@ _PR_TEMPLATE_PATH = Path(PLAN_DIR) / "template.md"
 
 
 def _build_pr_body(group: Group, all_groups: list[Group]) -> str:
-    files = [a.file_path for a in group.assignments]
-    file_list = "\n".join(f"- `{f}`" for f in files)
-    dep_list = ", ".join(f"`{d}`" for d in group.depends_on)
-    dag_md = _render_dag_markdown(all_groups, group.id)
-
-    template_vars = {
-        "description": group.description,
-        "files": file_list,
-        "added": group.estimated_added,
-        "removed": group.estimated_removed,
-        "loc": group.estimated_loc,
-        "dependencies": dep_list,
-        "dag": dag_md,
-        "id": group.id,
-        "title": group.title,
-    }
-
     if _PR_TEMPLATE_PATH.exists():
+        files = [a.file_path for a in group.assignments]
+        template_vars = {
+            "description": group.description,
+            "files": "\n".join(f"- `{f}`" for f in files),
+            "added": group.estimated_added,
+            "removed": group.estimated_removed,
+            "loc": group.estimated_loc,
+            "dependencies": ", ".join(f"`{d}`" for d in group.depends_on),
+            "dag": _render_dag_markdown(all_groups, group.id),
+            "id": group.id,
+            "title": group.title,
+        }
         try:
             template = _PR_TEMPLATE_PATH.read_text(encoding="utf-8")
             return template.format(**template_vars)
         except (KeyError, ValueError, IndexError) as exc:
-            available = ", ".join(f"{{{k}}}" for k in sorted(template_vars))
+            available = ", ".join(
+                f"{{{k}}}" for k in sorted(template_vars)
+            )
             raise PRSplitError(
                 f"Invalid PR template at {_PR_TEMPLATE_PATH}: {exc}. "
                 f"Available placeholders: {available}. "
@@ -297,8 +294,10 @@ def _build_pr_body(group: Group, all_groups: list[Group]) -> str:
                 f"Could not read PR template at {_PR_TEMPLATE_PATH}: {exc}"
             ) from exc
 
+    files = [a.file_path for a in group.assignments]
     sections = [group.description]
     if files:
+        file_list = "\n".join(f"- `{f}`" for f in files)
         sections.append(f"## Files changed\n\n{file_list}")
     sections.append(
         f"## Diff stats\n\n"
@@ -307,8 +306,9 @@ def _build_pr_body(group: Group, all_groups: list[Group]) -> str:
         f"({group.estimated_loc} LOC)"
     )
     if group.depends_on:
+        dep_list = ", ".join(f"`{d}`" for d in group.depends_on)
         sections.append(f"## Dependencies\n\nThis PR depends on: {dep_list}")
-    sections.append(dag_md)
+    sections.append(_render_dag_markdown(all_groups, group.id))
     return "\n\n".join(sections)
 
 

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from pr_split.cli import _build_pr_body, _cleanup_git_state
 from pr_split.constants import AssignmentType
@@ -83,6 +86,34 @@ class TestBuildPrBody:
         group = _group("pr-1", "root")
         body = _build_pr_body(group, [group])
         assert "## Files changed" not in body
+
+    def test_custom_template(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        template_dir = tmp_path / ".pr-split"
+        template_dir.mkdir()
+        template_file = template_dir / "template.md"
+        template_file.write_text("{description}\n\nFiles: {files}\nLOC: {loc}")
+        monkeypatch.setattr("pr_split.cli._PR_TEMPLATE_PATH", template_file)
+
+        group = _group("pr-1", "feat: auth", files=["auth.py"], added=10, removed=5)
+        body = _build_pr_body(group, [group])
+        assert "desc for pr-1" in body
+        assert "auth.py" in body
+        assert "15" in body
+
+    def test_custom_template_invalid_placeholder(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        template_dir = tmp_path / ".pr-split"
+        template_dir.mkdir()
+        template_file = template_dir / "template.md"
+        template_file.write_text("{nonexistent}")
+        monkeypatch.setattr("pr_split.cli._PR_TEMPLATE_PATH", template_file)
+
+        group = _group("pr-1", "feat: auth", files=["auth.py"])
+        with pytest.raises(PRSplitError, match="Invalid PR template"):
+            _build_pr_body(group, [group])
 
 
 class TestCleanupGitState:


### PR DESCRIPTION
## Summary
- Users can create `.pr-split/template.md` with Python format placeholders to customize PR body
- Available variables: {description}, {files}, {added}, {removed}, {loc}, {dependencies}, {dag}, {id}, {title}
- Falls back to the default built-in format if no template file exists
- Template is read at PR creation time, so it can be changed between runs

Example template:
```markdown
{description}

### Changed files
{files}

**Stats:** +{added}/-{removed} ({loc} lines)

{dag}
```

## Test plan
- [x] All 293 tests pass
- [ ] Manual: create `.pr-split/template.md`, run split, verify custom PR body
- [ ] Manual: run split without template, verify default format unchanged