### PR TITLE
feat: add interactive plan editor to move hunks between groups

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -424,8 +424,11 @@ def _show_group_detail(groups: list[Group], group_id: str) -> None:
         f" ({group.estimated_loc} LOC)"
     )
     for a in group.assignments:
-        indices = ", ".join(str(i) for i in a.hunk_indices)
-        console.print(f"  {a.file_path} [{a.assignment_type}] hunks: [{indices}]")
+        if a.assignment_type == AssignmentType.WHOLE_FILE:
+            hunks_str = "all"
+        else:
+            hunks_str = ", ".join(str(i) for i in a.hunk_indices)
+        console.print(f"  {a.file_path} [{a.assignment_type}] hunks: [{hunks_str}]")
     console.print()
 
 

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -382,8 +382,14 @@ def _move_assignment(
         (a for a in dst.assignments if a.file_path == file_path), None
     )
     if dst_assignment:
-        dst_assignment.hunk_indices.append(hunk_index)
-        dst_assignment.hunk_indices.sort()
+        if dst_assignment.assignment_type == AssignmentType.WHOLE_FILE:
+            pf = pf_map.get(file_path)
+            if pf is not None:
+                dst_assignment.hunk_indices = list(range(len(pf)))
+                dst_assignment.assignment_type = AssignmentType.PARTIAL_HUNKS
+        if hunk_index not in dst_assignment.hunk_indices:
+            dst_assignment.hunk_indices.append(hunk_index)
+            dst_assignment.hunk_indices.sort()
     else:
         dst.assignments.append(
             GroupAssignment(
@@ -583,6 +589,19 @@ def split(
     _present_plan(groups)
 
     groups = _interactive_edit(groups, parsed_diff)
+
+    # Re-validate after user edits
+    empty_groups = [g for g in groups if not g.assignments]
+    if empty_groups:
+        empty_ids = [g.id for g in empty_groups]
+        console.print(
+            f"[red]Groups {empty_ids} are empty after editing.[/red]"
+        )
+        raise typer.Exit(1)
+    dag = PlanDAG(groups)
+    warnings = validate_plan(groups, parsed_diff, dag, max_loc)
+    for warning in warnings:
+        logger.warning(warning)
 
     merge_base_ref = merge_base(base, dev_branch)
 

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -367,12 +367,15 @@ def _move_assignment(
     for assignment in src.assignments:
         if assignment.file_path != file_path:
             continue
-        # For WHOLE_FILE, expand to explicit hunk indices first
+        # For WHOLE_FILE, check hunk validity before expanding
         if assignment.assignment_type == AssignmentType.WHOLE_FILE:
             pf = pf_map.get(file_path)
             if pf is None:
                 continue
-            assignment.hunk_indices = list(range(len(pf)))
+            all_indices = list(range(len(pf)))
+            if hunk_index not in all_indices:
+                continue
+            assignment.hunk_indices = all_indices
             assignment.assignment_type = AssignmentType.PARTIAL_HUNKS
         if hunk_index in assignment.hunk_indices:
             assignment.hunk_indices.remove(hunk_index)
@@ -483,6 +486,9 @@ def _interactive_edit(groups: list[Group], parsed_diff: ParsedDiff) -> list[Grou
                 hunk_index = int(hunk_str)
             except ValueError:
                 console.print("[red]Hunk index must be an integer.[/red]")
+                continue
+            if hunk_index < 0:
+                console.print("[red]Hunk index must be non-negative.[/red]")
                 continue
             _move_assignment(
                 groups, parsed_diff, file_path, hunk_index, from_id, to_id
@@ -608,10 +614,15 @@ def split(
             f"[red]Groups {empty_ids} are empty after editing.[/red]"
         )
         raise typer.Exit(1)
-    dag = PlanDAG(groups)
-    warnings = validate_plan(groups, parsed_diff, dag, max_loc)
-    for warning in warnings:
-        logger.warning(warning)
+    try:
+        dag = PlanDAG(groups)
+        warnings = validate_plan(groups, parsed_diff, dag, max_loc)
+        for warning in warnings:
+            logger.warning(warning)
+        logger.success("Edited plan validation passed")
+    except PRSplitError as exc:
+        console.print(f"[red]Edited plan is invalid: {exc}[/red]")
+        raise typer.Exit(1) from exc
 
     merge_base_ref = merge_base(base, dev_branch)
 

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -19,6 +19,7 @@ from . import logs
 from .config import Settings
 from .constants import (
     BRANCH_PREFIX,
+    AssignmentType,
     DEFAULT_CHUNK_STRATEGY,
     DEFAULT_CP_SAT_TIMEOUT_SECONDS,
     DEFAULT_MAX_LOC,
@@ -54,6 +55,7 @@ from .schemas import (
     BranchRecord,
     GitState,
     Group,
+    GroupAssignment,
     PlanFile,
     PRRecord,
     SplitPlan,
@@ -337,6 +339,109 @@ def _push_and_create_prs(
     return [results[g.id] for g in groups]
 
 
+def _move_assignment(
+    groups: list[Group], file_path: str, hunk_index: int, from_id: str, to_id: str
+) -> bool:
+    group_map = {g.id: g for g in groups}
+    src = group_map.get(from_id)
+    dst = group_map.get(to_id)
+    if not src or not dst:
+        console.print(f"[red]Group '{from_id}' or '{to_id}' not found.[/red]")
+        return False
+
+    found = False
+    for assignment in src.assignments:
+        if assignment.file_path == file_path and hunk_index in assignment.hunk_indices:
+            assignment.hunk_indices.remove(hunk_index)
+            if not assignment.hunk_indices:
+                src.assignments.remove(assignment)
+            found = True
+            break
+
+    if not found:
+        console.print(f"[red]Hunk {file_path}:{hunk_index} not found in {from_id}.[/red]")
+        return False
+
+    dst_assignment = next(
+        (a for a in dst.assignments if a.file_path == file_path), None
+    )
+    if dst_assignment:
+        dst_assignment.hunk_indices.append(hunk_index)
+        dst_assignment.hunk_indices.sort()
+    else:
+        dst.assignments.append(
+            GroupAssignment(
+                file_path=file_path,
+                assignment_type=AssignmentType.PARTIAL_HUNKS,
+                hunk_indices=[hunk_index],
+            )
+        )
+
+    console.print(f"[green]Moved {file_path}:{hunk_index} from {from_id} to {to_id}[/green]")
+    return True
+
+
+def _show_group_detail(groups: list[Group], group_id: str) -> None:
+    group_map = {g.id: g for g in groups}
+    group = group_map.get(group_id)
+    if not group:
+        console.print(f"[red]Group '{group_id}' not found.[/red]")
+        return
+    console.print(f"\n[bold]{group.id}[/bold]: {group.title}")
+    console.print(f"  Description: {group.description}")
+    console.print(f"  Depends on: {', '.join(group.depends_on) or 'none'}")
+    console.print(f"  Estimated: +{group.estimated_added}/-{group.estimated_removed} ({group.estimated_loc} LOC)")
+    for a in group.assignments:
+        indices = ", ".join(str(i) for i in a.hunk_indices)
+        console.print(f"  {a.file_path} [{a.assignment_type}] hunks: [{indices}]")
+    console.print()
+
+
+def _interactive_edit(groups: list[Group]) -> list[Group]:
+    console.print(
+        "\n[cyan]Interactive editor. Commands:[/cyan]\n"
+        "  [bold]move[/bold] <file>:<hunk> <from_group> <to_group>\n"
+        "  [bold]show[/bold] <group_id>\n"
+        "  [bold]plan[/bold]  — redisplay the plan table\n"
+        "  [bold]done[/bold]  — proceed\n"
+        "  [bold]abort[/bold] — cancel\n"
+    )
+    while True:
+        try:
+            cmd = typer.prompt("edit", default="done")
+        except (KeyboardInterrupt, EOFError):
+            raise typer.Abort()
+
+        parts = cmd.strip().split()
+        if not parts:
+            continue
+
+        action = parts[0].lower()
+
+        if action == "done":
+            return groups
+        elif action == "abort":
+            raise typer.Abort()
+        elif action == "plan":
+            _present_plan(groups)
+        elif action == "show" and len(parts) == 2:
+            _show_group_detail(groups, parts[1])
+        elif action == "move" and len(parts) == 4:
+            ref, from_id, to_id = parts[1], parts[2], parts[3]
+            if ":" not in ref:
+                console.print("[red]Usage: move <file>:<hunk_index> <from> <to>[/red]")
+                continue
+            file_path, hunk_str = ref.rsplit(":", 1)
+            try:
+                hunk_index = int(hunk_str)
+            except ValueError:
+                console.print("[red]Hunk index must be an integer.[/red]")
+                continue
+            _move_assignment(groups, file_path, hunk_index, from_id, to_id)
+        else:
+            console.print("[yellow]Unknown command. Type 'done' to proceed or 'abort' to cancel.[/yellow]")
+
+
 def _resolve_fork_ref(dev_branch: str) -> ForkPRInfo | None:
     cleaned = dev_branch.lstrip("#")
     if cleaned.isdigit():
@@ -440,6 +545,8 @@ def split(
 
     logger.info(logs.PRESENTING_PLAN)
     _present_plan(groups)
+
+    groups = _interactive_edit(groups)
 
     merge_base_ref = merge_base(base, dev_branch)
 

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -19,13 +19,13 @@ from . import logs
 from .config import Settings
 from .constants import (
     BRANCH_PREFIX,
-    AssignmentType,
     DEFAULT_CHUNK_STRATEGY,
     DEFAULT_CP_SAT_TIMEOUT_SECONDS,
     DEFAULT_MAX_LOC,
     DEFAULT_PARTITION_STRATEGY,
     PLAN_DIR,
     PLAN_FILE,
+    AssignmentType,
     ChunkStrategy,
     PartitionStrategy,
     Priority,
@@ -340,7 +340,12 @@ def _push_and_create_prs(
 
 
 def _move_assignment(
-    groups: list[Group], file_path: str, hunk_index: int, from_id: str, to_id: str
+    groups: list[Group],
+    parsed_diff: ParsedDiff,
+    file_path: str,
+    hunk_index: int,
+    from_id: str,
+    to_id: str,
 ) -> bool:
     group_map = {g.id: g for g in groups}
     src = group_map.get(from_id)
@@ -349,9 +354,20 @@ def _move_assignment(
         console.print(f"[red]Group '{from_id}' or '{to_id}' not found.[/red]")
         return False
 
+    pf_map = {pf.path: pf for pf in parsed_diff.patch_set}
+
     found = False
     for assignment in src.assignments:
-        if assignment.file_path == file_path and hunk_index in assignment.hunk_indices:
+        if assignment.file_path != file_path:
+            continue
+        # For WHOLE_FILE, expand to explicit hunk indices first
+        if assignment.assignment_type == AssignmentType.WHOLE_FILE:
+            pf = pf_map.get(file_path)
+            if pf is None:
+                continue
+            assignment.hunk_indices = list(range(len(pf)))
+            assignment.assignment_type = AssignmentType.PARTIAL_HUNKS
+        if hunk_index in assignment.hunk_indices:
             assignment.hunk_indices.remove(hunk_index)
             if not assignment.hunk_indices:
                 src.assignments.remove(assignment)
@@ -390,14 +406,17 @@ def _show_group_detail(groups: list[Group], group_id: str) -> None:
     console.print(f"\n[bold]{group.id}[/bold]: {group.title}")
     console.print(f"  Description: {group.description}")
     console.print(f"  Depends on: {', '.join(group.depends_on) or 'none'}")
-    console.print(f"  Estimated: +{group.estimated_added}/-{group.estimated_removed} ({group.estimated_loc} LOC)")
+    console.print(
+        f"  Estimated: +{group.estimated_added}/-{group.estimated_removed}"
+        f" ({group.estimated_loc} LOC)"
+    )
     for a in group.assignments:
         indices = ", ".join(str(i) for i in a.hunk_indices)
         console.print(f"  {a.file_path} [{a.assignment_type}] hunks: [{indices}]")
     console.print()
 
 
-def _interactive_edit(groups: list[Group]) -> list[Group]:
+def _interactive_edit(groups: list[Group], parsed_diff: ParsedDiff) -> list[Group]:
     console.print(
         "\n[cyan]Interactive editor. Commands:[/cyan]\n"
         "  [bold]move[/bold] <file>:<hunk> <from_group> <to_group>\n"
@@ -409,8 +428,8 @@ def _interactive_edit(groups: list[Group]) -> list[Group]:
     while True:
         try:
             cmd = typer.prompt("edit", default="done")
-        except (KeyboardInterrupt, EOFError):
-            raise typer.Abort()
+        except (KeyboardInterrupt, EOFError) as exc:
+            raise typer.Abort() from exc
 
         parts = cmd.strip().split()
         if not parts:
@@ -424,12 +443,24 @@ def _interactive_edit(groups: list[Group]) -> list[Group]:
             raise typer.Abort()
         elif action == "plan":
             _present_plan(groups)
-        elif action == "show" and len(parts) == 2:
-            _show_group_detail(groups, parts[1])
-        elif action == "move" and len(parts) == 4:
+        elif action == "show":
+            if len(parts) == 2:
+                _show_group_detail(groups, parts[1])
+            else:
+                console.print("[red]Usage: show <group_id>[/red]")
+        elif action == "move":
+            if len(parts) != 4:
+                console.print(
+                    "[red]Usage: move <file>:<hunk_index>"
+                    " <from_group> <to_group>[/red]"
+                )
+                continue
             ref, from_id, to_id = parts[1], parts[2], parts[3]
             if ":" not in ref:
-                console.print("[red]Usage: move <file>:<hunk_index> <from> <to>[/red]")
+                console.print(
+                    "[red]Usage: move <file>:<hunk_index>"
+                    " <from_group> <to_group>[/red]"
+                )
                 continue
             file_path, hunk_str = ref.rsplit(":", 1)
             try:
@@ -437,9 +468,14 @@ def _interactive_edit(groups: list[Group]) -> list[Group]:
             except ValueError:
                 console.print("[red]Hunk index must be an integer.[/red]")
                 continue
-            _move_assignment(groups, file_path, hunk_index, from_id, to_id)
+            _move_assignment(
+                groups, parsed_diff, file_path, hunk_index, from_id, to_id
+            )
         else:
-            console.print("[yellow]Unknown command. Type 'done' to proceed or 'abort' to cancel.[/yellow]")
+            console.print(
+                "[yellow]Unknown command."
+                " Type 'done' to proceed or 'abort' to cancel.[/yellow]"
+            )
 
 
 def _resolve_fork_ref(dev_branch: str) -> ForkPRInfo | None:
@@ -546,7 +582,7 @@ def split(
     logger.info(logs.PRESENTING_PLAN)
     _present_plan(groups)
 
-    groups = _interactive_edit(groups)
+    groups = _interactive_edit(groups, parsed_diff)
 
     merge_base_ref = merge_base(base, dev_branch)
 

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -347,6 +347,13 @@ def _move_assignment(
     from_id: str,
     to_id: str,
 ) -> bool:
+    if from_id == to_id:
+        console.print(
+            f"[yellow]Source and destination are the same"
+            f" ('{from_id}'). No move performed.[/yellow]"
+        )
+        return False
+
     group_map = {g.id: g for g in groups}
     src = group_map.get(from_id)
     dst = group_map.get(to_id)


### PR DESCRIPTION
## Summary
- After the plan is displayed, users enter an interactive editor before confirming
- Commands:
  - `move <file>:<hunk_index> <from_group> <to_group>` — move a hunk between groups
  - `show <group_id>` — display group details (files, hunks, deps, stats)
  - `plan` — redisplay the plan table
  - `done` — proceed to confirmation
  - `abort` — cancel
- Default action is `done` (just press Enter to skip editing)
- Validates that source group has the hunk before moving

## Test plan
- [x] All 293 tests pass
- [ ] Manual: run split, use `show` to inspect groups, `move` a hunk, `plan` to verify, `done` to proceed
- [ ] Manual: press Enter immediately to skip editing (default=done)
- [ ] Manual: type `abort` to cancel