### PR TITLE
feat: add webhook notification on merge completion

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -808,12 +808,22 @@ def merge_all(
     if failed:
         console.print(f"[red]Failed ({len(failed)}): {', '.join(failed)}[/red]")
     if notify:
+        exit_reason = (
+            "merge_error" if stopped
+            else "incomplete_batch" if exited_early
+            else "success"
+        )
+        skipped_structured = [
+            {"id": s.split(" (")[0], "reason": s}
+            for s in skipped
+        ]
         _send_webhook(notify, {
             "event": "merge_complete",
             "merged": merged,
-            "skipped": skipped,
+            "skipped": skipped_structured,
             "failed": failed,
             "success": not (failed or stopped or exited_early),
+            "exit_reason": exit_reason,
         })
 
     if failed or stopped or exited_early:

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import json as json_mod
 import shutil
 import tempfile
 import time
+import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from threading import Lock, Semaphore
@@ -666,6 +668,19 @@ def _poll_for_merged(
     return actually_merged
 
 
+def _send_webhook(url: str, payload: dict[str, object]) -> None:
+    try:
+        data = json_mod.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            url, data=data, headers={"Content-Type": "application/json"}
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            resp.read()
+        logger.info(f"Webhook notification sent to {url}")
+    except Exception as exc:
+        logger.warning(f"Failed to send webhook notification: {exc}")
+
+
 @app.command(
     name="merge",
     help="Merge all split PRs in dependency order. Skips already-merged PRs.",
@@ -674,6 +689,14 @@ def merge_all(
     auto: Annotated[
         bool, typer.Option("--auto", help="Queue merges to run after CI checks pass")
     ] = False,
+    notify: Annotated[
+        str | None,
+        typer.Option(
+            "--notify",
+            help="Webhook URL to POST merge results to",
+            envvar="PR_SPLIT_WEBHOOK_URL",
+        ),
+    ] = None,
 ) -> None:
     if not plan_exists():
         console.print(ErrorMsg.NO_PLAN())
@@ -784,6 +807,15 @@ def merge_all(
         console.print(f"[yellow]Skipped ({len(skipped)}): {', '.join(skipped)}[/yellow]")
     if failed:
         console.print(f"[red]Failed ({len(failed)}): {', '.join(failed)}[/red]")
+    if notify:
+        _send_webhook(notify, {
+            "event": "merge_complete",
+            "merged": merged,
+            "skipped": skipped,
+            "failed": failed,
+            "success": not (failed or stopped or exited_early),
+        })
+
     if failed or stopped or exited_early:
         raise typer.Exit(1)
     logger.success(f"Merge complete: {len(merged)} PRs merged")


### PR DESCRIPTION
## Summary
- Add `--notify <url>` flag to the `merge` command (also reads `PR_SPLIT_WEBHOOK_URL` env var)
- POSTs a JSON payload to the webhook URL after merge completes (success or failure)
- Payload includes: event type, merged/skipped/failed lists, success boolean
- Webhook failures are logged as warnings, never block the merge flow
- Uses stdlib `urllib.request` — no new dependencies

Example payload:
```json
{
  "event": "merge_complete",
  "merged": ["pr-1", "pr-2"],
  "skipped": ["pr-3 (draft)"],
  "failed": [],
  "success": true
}
```

## Test plan
- [x] All 293 tests pass
- [ ] Manual: run `merge --notify https://httpbin.org/post` and verify payload
- [ ] Manual: run merge without --notify — no webhook sent