### PR TITLE
feat: add shared LOC bounds configuration and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ pr-split split feature-branch --base main --dry-run
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--base` | `main` | Base branch for the diff |
-| `--max-loc` | `400` | Soft limit on diff lines per sub-PR |
+| `--min-loc` | unset | Optional minimum diff lines per sub-PR |
+| `--max-loc` | `400` | Maximum target diff lines per sub-PR |
+| `--strict-loc-bounds` | `false` | Exit instead of proceeding when the final plan violates configured LOC bounds |
 | `--priority` | `orthogonal` | Grouping priority (`orthogonal` or `logical`) |
 | `--chunk-strategy` | `dynamic_programming` | Large-diff chunking strategy (`dynamic_programming` or `greedy`) |
 | `--partition-strategy` | `llm` | Hunk-to-PR partition backend (`llm`, `graph`, or `cp_sat`) |
@@ -167,7 +169,9 @@ Settings can be set via environment variables with the `PR_SPLIT_` prefix:
 | `ANTHROPIC_API_KEY` | (required for Anthropic) | Anthropic API key |
 | `OPENAI_API_KEY` | (required for OpenAI) | OpenAI API key |
 | `PR_SPLIT_MODEL` | auto per provider | Model name (defaults to best available model for the chosen provider) |
-| `PR_SPLIT_MAX_LOC` | `400` | Default soft limit on diff lines |
+| `PR_SPLIT_MIN_LOC` | unset | Optional minimum target diff lines |
+| `PR_SPLIT_MAX_LOC` | `400` | Default maximum target diff lines |
+| `PR_SPLIT_STRICT_LOC_BOUNDS` | `false` | Fail if the final plan violates configured LOC bounds |
 | `PR_SPLIT_PRIORITY` | `orthogonal` | Default grouping priority |
 | `PR_SPLIT_CHUNK_STRATEGY` | `dynamic_programming` | Large-diff chunking strategy |
 | `PR_SPLIT_PARTITION_STRATEGY` | `llm` | Hunk-to-PR partition backend |

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -12,6 +12,7 @@ from typing import Annotated
 
 import typer
 from loguru import logger
+from pydantic import ValidationError
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -132,14 +133,14 @@ def _validate_inputs(dev_branch: str, base: str, *, dry_run: bool = False) -> No
 
 
 def _handle_loc_bound_warnings(warnings: list[str], *, strict_loc_bounds: bool) -> None:
-    for warning in warnings:
-        logger.warning(warning)
-
     if strict_loc_bounds and warnings:
         console.print(f"[red]{ErrorMsg.LOC_BOUNDS_STRICT_FAILED()}[/red]")
         for warning in warnings:
             console.print(f"[red]- {warning}[/red]")
         raise typer.Exit(1)
+
+    for warning in warnings:
+        logger.warning(warning)
 
 
 def _present_plan(groups: list[Group]) -> None:
@@ -565,7 +566,12 @@ def split(
         ),
     ] = DEFAULT_MIN_LOC,
     max_loc: Annotated[
-        int, typer.Option(help="Soft limit on diff lines per sub-PR")
+        int,
+        typer.Option(
+            "--max-loc",
+            envvar="PR_SPLIT_MAX_LOC",
+            help="Maximum target diff lines per sub-PR",
+        ),
     ] = DEFAULT_MAX_LOC,
     strict_loc_bounds: Annotated[
         bool,
@@ -653,7 +659,7 @@ def split(
             chunk_strategy=chunk_strategy,
             partition_strategy=partition_strategy,
         )
-    except ValueError as exc:
+    except (ValidationError, ValueError) as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(1) from exc
     groups = plan_split(parsed_diff, settings)
@@ -679,9 +685,14 @@ def split(
         raise typer.Exit(1)
     try:
         dag = PlanDAG(groups)
-        warnings = validate_plan(groups, parsed_diff, dag, max_loc)
-        for warning in warnings:
-            logger.warning(warning)
+        warnings = validate_plan(
+            groups,
+            parsed_diff,
+            dag,
+            settings.max_loc,
+            min_loc=settings.min_loc,
+        )
+        _handle_loc_bound_warnings(warnings, strict_loc_bounds=settings.strict_loc_bounds)
         logger.success("Edited plan validation passed")
     except PRSplitError as exc:
         console.print(f"[red]Edited plan is invalid: {exc}[/red]")

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -24,7 +24,9 @@ from .constants import (
     DEFAULT_CHUNK_STRATEGY,
     DEFAULT_CP_SAT_TIMEOUT_SECONDS,
     DEFAULT_MAX_LOC,
+    DEFAULT_MIN_LOC,
     DEFAULT_PARTITION_STRATEGY,
+    DEFAULT_STRICT_LOC_BOUNDS,
     PLAN_DIR,
     PLAN_FILE,
     AssignmentType,
@@ -126,6 +128,17 @@ def _validate_inputs(dev_branch: str, base: str, *, dry_run: bool = False) -> No
         raise typer.Exit(1)
     if not dry_run and not check_gh_auth():
         console.print(f"[red]{ErrorMsg.GH_AUTH_FAILED()}[/red]")
+        raise typer.Exit(1)
+
+
+def _handle_loc_bound_warnings(warnings: list[str], *, strict_loc_bounds: bool) -> None:
+    for warning in warnings:
+        logger.warning(warning)
+
+    if strict_loc_bounds and warnings:
+        console.print(f"[red]{ErrorMsg.LOC_BOUNDS_STRICT_FAILED()}[/red]")
+        for warning in warnings:
+            console.print(f"[red]- {warning}[/red]")
         raise typer.Exit(1)
 
 
@@ -543,9 +556,25 @@ def _resolve_fork_ref(dev_branch: str) -> ForkPRInfo | None:
 def split(
     dev_branch: Annotated[str, typer.Argument(help="Branch name, PR number, or user:branch")],
     base: Annotated[str, typer.Option(help="Base branch")] = "main",
+    min_loc: Annotated[
+        int | None,
+        typer.Option(
+            "--min-loc",
+            envvar="PR_SPLIT_MIN_LOC",
+            help="Minimum target diff lines per sub-PR",
+        ),
+    ] = DEFAULT_MIN_LOC,
     max_loc: Annotated[
         int, typer.Option(help="Soft limit on diff lines per sub-PR")
     ] = DEFAULT_MAX_LOC,
+    strict_loc_bounds: Annotated[
+        bool,
+        typer.Option(
+            "--strict-loc-bounds",
+            envvar="PR_SPLIT_STRICT_LOC_BOUNDS",
+            help="Fail if the final plan violates configured LOC bounds",
+        ),
+    ] = DEFAULT_STRICT_LOC_BOUNDS,
     priority: Annotated[Priority, typer.Option(help="Grouping priority")] = Priority.ORTHOGONAL,
     chunk_strategy: Annotated[
         ChunkStrategy, typer.Option(help="Chunking strategy for large diffs")
@@ -614,20 +643,25 @@ def split(
         )
     )
 
-    settings = Settings(
-        max_loc=max_loc,
-        cp_sat_timeout=cp_sat_timeout,
-        priority=priority,
-        chunk_strategy=chunk_strategy,
-        partition_strategy=partition_strategy,
-    )
+    try:
+        settings = Settings(
+            min_loc=min_loc,
+            max_loc=max_loc,
+            strict_loc_bounds=strict_loc_bounds,
+            cp_sat_timeout=cp_sat_timeout,
+            priority=priority,
+            chunk_strategy=chunk_strategy,
+            partition_strategy=partition_strategy,
+        )
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
     groups = plan_split(parsed_diff, settings)
 
     logger.info(logs.VALIDATING_PLAN)
     dag = PlanDAG(groups)
-    warnings = validate_plan(groups, parsed_diff, dag, max_loc)
-    for warning in warnings:
-        logger.warning(warning)
+    warnings = validate_plan(groups, parsed_diff, dag, settings.max_loc, min_loc=settings.min_loc)
+    _handle_loc_bound_warnings(warnings, strict_loc_bounds=settings.strict_loc_bounds)
     logger.success(logs.VALIDATION_PASSED)
 
     logger.info(logs.PRESENTING_PLAN)
@@ -658,7 +692,9 @@ def split(
     split_plan = SplitPlan(
         dev_branch=dev_branch,
         base_branch=base,
-        max_loc=max_loc,
+        min_loc=settings.min_loc,
+        max_loc=settings.max_loc,
+        strict_loc_bounds=settings.strict_loc_bounds,
         priority=priority,
         groups=groups,
         author=author,

--- a/pr_split/config.py
+++ b/pr_split/config.py
@@ -6,8 +6,10 @@ from .constants import (
     DEFAULT_CHUNK_STRATEGY,
     DEFAULT_CP_SAT_TIMEOUT_SECONDS,
     DEFAULT_MAX_LOC,
+    DEFAULT_MIN_LOC,
     DEFAULT_MODEL,
     DEFAULT_PARTITION_STRATEGY,
+    DEFAULT_STRICT_LOC_BOUNDS,
     OPENAI_MAX_CONTEXT_TOKENS,
     OPENAI_MODEL,
     ChunkStrategy,
@@ -15,6 +17,7 @@ from .constants import (
     Priority,
     Provider,
 )
+from .exceptions import ErrorMsg
 
 
 class Settings(BaseSettings):
@@ -30,7 +33,9 @@ class Settings(BaseSettings):
     )
     provider: Provider = Provider.ANTHROPIC
     model: str = ""
-    max_loc: int = DEFAULT_MAX_LOC
+    min_loc: int | None = Field(default=DEFAULT_MIN_LOC, ge=1)
+    max_loc: int = Field(default=DEFAULT_MAX_LOC, gt=0)
+    strict_loc_bounds: bool = DEFAULT_STRICT_LOC_BOUNDS
     cp_sat_timeout: float = DEFAULT_CP_SAT_TIMEOUT_SECONDS
     priority: Priority = Priority.ORTHOGONAL
     chunk_strategy: ChunkStrategy = DEFAULT_CHUNK_STRATEGY
@@ -46,6 +51,14 @@ class Settings(BaseSettings):
                     self.model = OPENAI_MODEL
                 case _:
                     raise NotImplementedError(f"No default model for provider '{self.provider}'")
+        return self
+
+    @model_validator(mode="after")
+    def validate_loc_bounds(self):
+        if self.min_loc is not None and self.min_loc >= self.max_loc:
+            raise ValueError(
+                ErrorMsg.MIN_LOC_GE_MAX_LOC(min_loc=self.min_loc, max_loc=self.max_loc)
+            )
         return self
 
     @model_validator(mode="after")

--- a/pr_split/constants.py
+++ b/pr_split/constants.py
@@ -22,6 +22,11 @@ class PartitionStrategy(StrEnum):
     CP_SAT = "cp_sat"
 
 
+class LocViolationType(StrEnum):
+    BELOW_MIN = "below_min"
+    ABOVE_MAX = "above_max"
+
+
 class PRState(StrEnum):
     OPEN = "open"
     CLOSED = "closed"
@@ -36,7 +41,9 @@ class Provider(StrEnum):
 BRANCH_PREFIX = "pr-split/"
 PLAN_DIR = ".pr-split"
 PLAN_FILE = ".pr-split/plan.json"
+DEFAULT_MIN_LOC: int | None = None
 DEFAULT_MAX_LOC = 400
+DEFAULT_STRICT_LOC_BOUNDS = False
 DEFAULT_CP_SAT_TIMEOUT_SECONDS = 15.0
 DEFAULT_CHUNK_STRATEGY = ChunkStrategy.DYNAMIC_PROGRAMMING
 DEFAULT_PARTITION_STRATEGY = PartitionStrategy.LLM

--- a/pr_split/exceptions.py
+++ b/pr_split/exceptions.py
@@ -19,6 +19,8 @@ class ErrorMsg(StrEnum):
     PR_FETCH_FAILED = "Failed to fetch fork branch for PR #{number}: {detail}"
     FORK_FETCH_FAILED = "Failed to fetch {user}:{branch}: {detail}"
     HUNK_TOO_LARGE = "Hunk {file}[{index}] has ~{tokens} estimated tokens, exceeds budget {budget}"
+    MIN_LOC_GE_MAX_LOC = "min_loc {min_loc} must be less than max_loc {max_loc}"
+    LOC_BOUNDS_STRICT_FAILED = "Plan violates configured LOC bounds"
 
     def __call__(self, **kwargs: object) -> str:
         return self.value.format(**kwargs) if kwargs else self.value

--- a/pr_split/logs.py
+++ b/pr_split/logs.py
@@ -4,7 +4,12 @@ SENDING_TO_LLM = "Sending diff to LLM for analysis ({model})"
 LLM_RESPONSE_RECEIVED = "Received split plan with {count} groups"
 VALIDATING_PLAN = "Validating split plan"
 VALIDATION_PASSED = "Plan validation passed"
-LOC_SOFT_WARN = "Group '{group}' has +{added}/-{removed} diff lines (soft limit: {limit})"
+LOC_MIN_WARN = (
+    "Group '{group}' has {loc} diff lines (+{added}/-{removed}) below minimum: {limit}"
+)
+LOC_MAX_WARN = (
+    "Group '{group}' has {loc} diff lines (+{added}/-{removed}) above maximum: {limit}"
+)
 PRESENTING_PLAN = "Split plan ready for review"
 CREATING_BRANCH = "Creating branch {branch} from {base}"
 CREATING_MERGE_BASE = "Creating merge base {branch} from parents: {parents}"
@@ -46,6 +51,6 @@ INVALID_HUNK_INDEX = (
 HUNK_AUTO_ASSIGNED = "Auto-assigned uncovered hunk {file}[{index}] to group '{group}'"
 UNCOVERED_HUNKS_FIXED = "Auto-assigned {count} uncovered hunk(s) to existing groups"
 PLAN_METRICS = (
-    "Plan metrics: groups={groups}, max_group_loc={max_loc}, overflow={overflow}, "
-    "width={width}, depth={depth}, scatter={scatter}, objective={objective}"
+    "Plan metrics: groups={groups}, max_group_loc={max_loc}, underflow={underflow}, "
+    "overflow={overflow}, width={width}, depth={depth}, scatter={scatter}, objective={objective}"
 )

--- a/pr_split/planner/client.py
+++ b/pr_split/planner/client.py
@@ -362,11 +362,12 @@ def plan_split(
                 f"Unsupported partition strategy '{settings.partition_strategy}'"
             )
 
-    metrics = score_plan(groups, settings.max_loc)
+    metrics = score_plan(groups, settings.max_loc, settings.min_loc)
     logger.info(
         logs.PLAN_METRICS.format(
             groups=metrics.total_groups,
             max_loc=metrics.max_group_loc,
+            underflow=metrics.loc_underflow,
             overflow=metrics.loc_overflow,
             width=metrics.dag_width,
             depth=metrics.dag_depth,

--- a/pr_split/planner/scoring.py
+++ b/pr_split/planner/scoring.py
@@ -50,6 +50,7 @@ def score_plan(groups: list[Group], max_loc: int, min_loc: int | None = None) ->
     file_scatter = sum(max(0, len(group_ids) - 1) for group_ids in file_groups.values())
 
     undersized_groups = (
+        # Includes empty groups (estimated_loc == 0), unlike tiny_groups below.
         sum(1 for group in groups if group.estimated_loc < min_loc)
         if min_loc is not None
         else 0

--- a/pr_split/planner/scoring.py
+++ b/pr_split/planner/scoring.py
@@ -10,11 +10,13 @@ from ..schemas import Group
 class PlanMetrics:
     total_groups: int
     max_group_loc: int
+    loc_underflow: int
     loc_overflow: int
     dependency_edges: int
     dag_depth: int
     dag_width: int
     file_scatter: int
+    undersized_groups: int
     tiny_groups: int
     objective: int
 
@@ -27,10 +29,15 @@ def _dag_depth(dag: PlanDAG) -> int:
     return max(depths.values(), default=0)
 
 
-def score_plan(groups: list[Group], max_loc: int) -> PlanMetrics:
+def score_plan(groups: list[Group], max_loc: int, min_loc: int | None = None) -> PlanMetrics:
     dag = PlanDAG(groups)
 
     max_group_loc = max((group.estimated_loc for group in groups), default=0)
+    loc_underflow = (
+        sum(max(0, min_loc - group.estimated_loc) for group in groups)
+        if min_loc is not None
+        else 0
+    )
     loc_overflow = sum(max(0, group.estimated_loc - max_loc) for group in groups)
     dependency_edges = sum(len(group.depends_on) for group in groups)
     dag_width = max((len(batch) for batch in dag.iter_ready()), default=0)
@@ -42,11 +49,18 @@ def score_plan(groups: list[Group], max_loc: int) -> PlanMetrics:
             file_groups.setdefault(assignment.file_path, set()).add(group.id)
     file_scatter = sum(max(0, len(group_ids) - 1) for group_ids in file_groups.values())
 
+    undersized_groups = (
+        sum(1 for group in groups if group.estimated_loc < min_loc)
+        if min_loc is not None
+        else 0
+    )
     tiny_threshold = max(1, max_loc // 4)
     tiny_groups = sum(1 for group in groups if 0 < group.estimated_loc < tiny_threshold)
 
     objective = (
-        loc_overflow * 1000
+        loc_underflow * 1000
+        + undersized_groups * 100
+        + loc_overflow * 1000
         + dependency_edges * 20
         + file_scatter * 50
         + tiny_groups * 10
@@ -58,11 +72,13 @@ def score_plan(groups: list[Group], max_loc: int) -> PlanMetrics:
     return PlanMetrics(
         total_groups=len(groups),
         max_group_loc=max_group_loc,
+        loc_underflow=loc_underflow,
         loc_overflow=loc_overflow,
         dependency_edges=dependency_edges,
         dag_depth=dag_depth,
         dag_width=dag_width,
         file_scatter=file_scatter,
+        undersized_groups=undersized_groups,
         tiny_groups=tiny_groups,
         objective=objective,
     )

--- a/pr_split/planner/validator.py
+++ b/pr_split/planner/validator.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from loguru import logger
-
 from .. import logs
+from ..constants import LocViolationType
 from ..diff_ops import ParsedDiff
 from ..exceptions import ErrorMsg, PlanValidationError
 from ..graph import PlanDAG
 from ..schemas import Group
+from ..types_defs import LocBoundViolation
 
 
 def validate_coverage(groups: list[Group], parsed_diff: ParsedDiff) -> None:
@@ -65,19 +65,62 @@ def validate_no_conflicts(groups: list[Group], dag: PlanDAG) -> None:
                     )
 
 
-def validate_loc_bounds(groups: list[Group], max_loc: int) -> list[str]:
-    warnings: list[str] = []
+def detect_loc_bound_violations(
+    groups: list[Group],
+    max_loc: int,
+    min_loc: int | None = None,
+) -> list[LocBoundViolation]:
+    violations: list[LocBoundViolation] = []
     for group in groups:
-        if group.estimated_loc > max_loc:
-            msg = logs.LOC_SOFT_WARN.format(
-                group=group.id,
-                added=group.estimated_added,
-                removed=group.estimated_removed,
-                limit=max_loc,
+        if min_loc is not None and group.estimated_loc < min_loc:
+            violations.append(
+                LocBoundViolation(
+                    group_id=group.id,
+                    violation_type=LocViolationType.BELOW_MIN,
+                    limit=min_loc,
+                    estimated_loc=group.estimated_loc,
+                    estimated_added=group.estimated_added,
+                    estimated_removed=group.estimated_removed,
+                )
             )
-            logger.warning(msg)
-            warnings.append(msg)
-    return warnings
+        if group.estimated_loc > max_loc:
+            violations.append(
+                LocBoundViolation(
+                    group_id=group.id,
+                    violation_type=LocViolationType.ABOVE_MAX,
+                    limit=max_loc,
+                    estimated_loc=group.estimated_loc,
+                    estimated_added=group.estimated_added,
+                    estimated_removed=group.estimated_removed,
+                )
+            )
+    return violations
+
+
+def _format_loc_bound_violation(violation: LocBoundViolation) -> str:
+    template = (
+        logs.LOC_MIN_WARN
+        if violation.violation_type == LocViolationType.BELOW_MIN
+        else logs.LOC_MAX_WARN
+    )
+    return template.format(
+        group=violation.group_id,
+        loc=violation.estimated_loc,
+        added=violation.estimated_added,
+        removed=violation.estimated_removed,
+        limit=violation.limit,
+    )
+
+
+def validate_loc_bounds(
+    groups: list[Group],
+    max_loc: int,
+    min_loc: int | None = None,
+) -> list[str]:
+    return [
+        _format_loc_bound_violation(violation)
+        for violation in detect_loc_bound_violations(groups, max_loc, min_loc)
+    ]
 
 
 def validate_plan(
@@ -85,9 +128,10 @@ def validate_plan(
     parsed_diff: ParsedDiff,
     dag: PlanDAG,
     max_loc: int,
+    min_loc: int | None = None,
 ) -> list[str]:
     dag.validate_acyclic()
     validate_coverage(groups, parsed_diff)
     validate_loc(groups, parsed_diff)
     validate_no_conflicts(groups, dag)
-    return validate_loc_bounds(groups, max_loc)
+    return validate_loc_bounds(groups, max_loc, min_loc)

--- a/pr_split/schemas.py
+++ b/pr_split/schemas.py
@@ -38,7 +38,9 @@ class Group(BaseModel):
 class SplitPlan(BaseModel):
     dev_branch: str
     base_branch: str
+    min_loc: int | None = None
     max_loc: int
+    strict_loc_bounds: bool = False
     priority: Priority
     groups: list[Group] = Field(default_factory=list)
     author: str | None = None

--- a/pr_split/types_defs.py
+++ b/pr_split/types_defs.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import NamedTuple, TypedDict
 
+from .constants import LocViolationType
+
 
 class HunkInfo(NamedTuple):
     index: int
@@ -35,6 +37,15 @@ class HunkRef(NamedTuple):
     file_path: str
     hunk_index: int
     token_estimate: int
+
+
+class LocBoundViolation(NamedTuple):
+    group_id: str
+    violation_type: LocViolationType
+    limit: int
+    estimated_loc: int
+    estimated_added: int
+    estimated_removed: int
 
 
 class DiffStats(TypedDict):

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -5,8 +5,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import typer
+from typer.testing import CliRunner
 
-from pr_split.cli import _build_pr_body, _cleanup_git_state, _handle_loc_bound_warnings
+from pr_split.cli import (
+    _build_pr_body,
+    _cleanup_git_state,
+    _handle_loc_bound_warnings,
+    app,
+)
 from pr_split.constants import AssignmentType
 from pr_split.exceptions import GitOperationError, PRSplitError
 from pr_split.git_ops.prs import get_pr_state, merge_pr
@@ -17,6 +23,8 @@ from pr_split.schemas import (
     GroupAssignment,
     PRRecord,
 )
+
+runner = CliRunner()
 
 
 def _group(
@@ -226,4 +234,107 @@ class TestHandleLocBoundWarnings:
     ) -> None:
         with pytest.raises(typer.Exit):
             _handle_loc_bound_warnings(["warning 1"], strict_loc_bounds=True)
-        assert mock_warning.call_count == 1
+        mock_warning.assert_not_called()
+
+
+class TestSplitCliEnvVars:
+    @patch("pr_split.cli.save_plan")
+    @patch("pr_split.cli.merge_base", return_value="abc123")
+    @patch("pr_split.cli._interactive_edit")
+    @patch("pr_split.cli._present_plan")
+    @patch("pr_split.cli.validate_plan", return_value=[])
+    @patch("pr_split.cli.plan_split")
+    @patch("pr_split.cli.parse_diff")
+    @patch("pr_split.cli.extract_diff", return_value="diff --git a/a.py b/a.py\n")
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_split_uses_max_loc_envvar(
+        self,
+        mock_branch_exists: MagicMock,
+        mock_validate_inputs: MagicMock,
+        mock_extract_diff: MagicMock,
+        mock_parse_diff: MagicMock,
+        mock_plan_split: MagicMock,
+        mock_validate_plan: MagicMock,
+        mock_present_plan: MagicMock,
+        mock_interactive_edit: MagicMock,
+        mock_merge_base: MagicMock,
+        mock_save_plan: MagicMock,
+    ) -> None:
+        parsed_diff = MagicMock()
+        parsed_diff.stats = {
+            "total_files": 1,
+            "total_added": 1,
+            "total_removed": 0,
+            "total_loc": 1,
+        }
+        group = _group("pr-1", "t", files=["a.py"])
+        mock_parse_diff.return_value = parsed_diff
+        mock_plan_split.return_value = [group]
+        mock_interactive_edit.return_value = [group]
+
+        result = runner.invoke(
+            app,
+            ["split", "feature-branch", "--dry-run"],
+            env={
+                "ANTHROPIC_API_KEY": "sk-test",
+                "PR_SPLIT_MAX_LOC": "123",
+            },
+        )
+
+        assert result.exit_code == 0
+        settings = mock_plan_split.call_args[0][1]
+        assert settings.max_loc == 123
+
+    @patch("pr_split.cli.save_plan")
+    @patch("pr_split.cli.merge_base", return_value="abc123")
+    @patch("pr_split.cli._interactive_edit")
+    @patch("pr_split.cli._present_plan")
+    @patch("pr_split.cli.validate_plan", side_effect=[[], ["warning 1"]])
+    @patch("pr_split.cli.plan_split")
+    @patch("pr_split.cli.parse_diff")
+    @patch("pr_split.cli.extract_diff", return_value="diff --git a/a.py b/a.py\n")
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_split_revalidates_min_loc_after_interactive_edit(
+        self,
+        mock_branch_exists: MagicMock,
+        mock_validate_inputs: MagicMock,
+        mock_extract_diff: MagicMock,
+        mock_parse_diff: MagicMock,
+        mock_plan_split: MagicMock,
+        mock_validate_plan: MagicMock,
+        mock_present_plan: MagicMock,
+        mock_interactive_edit: MagicMock,
+        mock_merge_base: MagicMock,
+        mock_save_plan: MagicMock,
+    ) -> None:
+        parsed_diff = MagicMock()
+        parsed_diff.stats = {
+            "total_files": 1,
+            "total_added": 1,
+            "total_removed": 0,
+            "total_loc": 1,
+        }
+        mock_parse_diff.return_value = parsed_diff
+        group = _group("pr-1", "t", files=["a.py"])
+        mock_plan_split.return_value = [group]
+        mock_interactive_edit.return_value = [group]
+
+        result = runner.invoke(
+            app,
+            [
+                "split",
+                "feature-branch",
+                "--dry-run",
+                "--min-loc",
+                "50",
+                "--strict-loc-bounds",
+            ],
+            env={"ANTHROPIC_API_KEY": "sk-test"},
+        )
+
+        assert result.exit_code == 1
+        assert mock_validate_plan.call_args_list[0].kwargs["min_loc"] == 50
+        assert mock_validate_plan.call_args_list[1].kwargs["min_loc"] == 50
+        mock_save_plan.assert_not_called()

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -4,8 +4,9 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import typer
 
-from pr_split.cli import _build_pr_body, _cleanup_git_state
+from pr_split.cli import _build_pr_body, _cleanup_git_state, _handle_loc_bound_warnings
 from pr_split.constants import AssignmentType
 from pr_split.exceptions import GitOperationError, PRSplitError
 from pr_split.git_ops.prs import get_pr_state, merge_pr
@@ -210,3 +211,19 @@ class TestMergePr:
         assert "--auto" in args
         assert "--merge" in args
         assert "--delete-branch" in args
+
+
+class TestHandleLocBoundWarnings:
+    @patch("pr_split.cli.logger.warning")
+    def test_non_strict_only_logs(self, mock_warning: MagicMock) -> None:
+        _handle_loc_bound_warnings(["warning 1"], strict_loc_bounds=False)
+        mock_warning.assert_called_once_with("warning 1")
+
+    @patch("pr_split.cli.console.print")
+    @patch("pr_split.cli.logger.warning")
+    def test_strict_raises_exit(
+        self, mock_warning: MagicMock, mock_print: MagicMock
+    ) -> None:
+        with pytest.raises(typer.Exit):
+            _handle_loc_bound_warnings(["warning 1"], strict_loc_bounds=True)
+        assert mock_warning.call_count == 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -240,6 +240,7 @@ new file mode 100644
             {
                 "total_groups": 1,
                 "max_group_loc": 1,
+                "loc_underflow": 0,
                 "loc_overflow": 0,
                 "dag_width": 1,
                 "dag_depth": 1,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from pr_split.config import Settings
 from pr_split.constants import (
@@ -47,13 +48,13 @@ class TestSettingsApiKeyValidation:
     def test_anthropic_missing_key_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        with pytest.raises(ValueError, match="ANTHROPIC_API_KEY"):
+        with pytest.raises(ValidationError, match="ANTHROPIC_API_KEY"):
             Settings(provider=Provider.ANTHROPIC)
 
     def test_openai_missing_key_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        with pytest.raises(ValueError, match="OPENAI_API_KEY"):
+        with pytest.raises(ValidationError, match="OPENAI_API_KEY"):
             Settings(provider=Provider.OPENAI)
 
     def test_anthropic_key_present_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -94,7 +95,7 @@ class TestSettingsLocBoundsValidation:
     def test_min_loc_equal_to_max_loc_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        with pytest.raises(ValueError, match="min_loc 100 must be less than max_loc 100"):
+        with pytest.raises(ValidationError, match="min_loc 100 must be less than max_loc 100"):
             Settings(partition_strategy=PartitionStrategy.GRAPH, min_loc=100, max_loc=100)
 
     def test_min_loc_greater_than_max_loc_raises(
@@ -102,7 +103,7 @@ class TestSettingsLocBoundsValidation:
     ) -> None:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        with pytest.raises(ValueError, match="min_loc 101 must be less than max_loc 100"):
+        with pytest.raises(ValidationError, match="min_loc 101 must be less than max_loc 100"):
             Settings(partition_strategy=PartitionStrategy.GRAPH, min_loc=101, max_loc=100)
 
     def test_min_loc_loaded_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -128,10 +129,10 @@ class TestSettingsMaxContextTokens:
 class TestSettingsEmptyKeyValidation:
     def test_empty_string_key_raises_anthropic(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "")
-        with pytest.raises(ValueError, match="ANTHROPIC_API_KEY"):
+        with pytest.raises(ValidationError, match="ANTHROPIC_API_KEY"):
             Settings(provider=Provider.ANTHROPIC)
 
     def test_empty_string_key_raises_openai(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("OPENAI_API_KEY", "")
-        with pytest.raises(ValueError, match="OPENAI_API_KEY"):
+        with pytest.raises(ValidationError, match="OPENAI_API_KEY"):
             Settings(provider=Provider.OPENAI)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ from pr_split.constants import (
     DEFAULT_CP_SAT_TIMEOUT_SECONDS,
     DEFAULT_MODEL,
     DEFAULT_PARTITION_STRATEGY,
+    DEFAULT_STRICT_LOC_BOUNDS,
     OPENAI_MAX_CONTEXT_TOKENS,
     OPENAI_MODEL,
     PartitionStrategy,
@@ -38,6 +39,8 @@ class TestSettingsDefaults:
         assert s.chunk_strategy == DEFAULT_CHUNK_STRATEGY
         assert s.partition_strategy == DEFAULT_PARTITION_STRATEGY
         assert s.cp_sat_timeout == DEFAULT_CP_SAT_TIMEOUT_SECONDS
+        assert s.min_loc is None
+        assert s.strict_loc_bounds == DEFAULT_STRICT_LOC_BOUNDS
 
 
 class TestSettingsApiKeyValidation:
@@ -78,6 +81,36 @@ class TestSettingsApiKeyValidation:
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         s = Settings(partition_strategy=PartitionStrategy.CP_SAT)
         assert s.partition_strategy == PartitionStrategy.CP_SAT
+
+
+class TestSettingsLocBoundsValidation:
+    def test_min_loc_less_than_max_loc_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        s = Settings(partition_strategy=PartitionStrategy.GRAPH, min_loc=50, max_loc=100)
+        assert s.min_loc == 50
+        assert s.max_loc == 100
+
+    def test_min_loc_equal_to_max_loc_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="min_loc 100 must be less than max_loc 100"):
+            Settings(partition_strategy=PartitionStrategy.GRAPH, min_loc=100, max_loc=100)
+
+    def test_min_loc_greater_than_max_loc_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="min_loc 101 must be less than max_loc 100"):
+            Settings(partition_strategy=PartitionStrategy.GRAPH, min_loc=101, max_loc=100)
+
+    def test_min_loc_loaded_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("PR_SPLIT_MIN_LOC", "75")
+        s = Settings(partition_strategy=PartitionStrategy.GRAPH)
+        assert s.min_loc == 75
 
 
 class TestSettingsMaxContextTokens:

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -6,7 +6,9 @@ from pr_split.constants import (
     CHUNK_TARGET_RATIO,
     DEFAULT_CHUNK_STRATEGY,
     DEFAULT_MAX_LOC,
+    DEFAULT_MIN_LOC,
     DEFAULT_PARTITION_STRATEGY,
+    DEFAULT_STRICT_LOC_BOUNDS,
     FORK_REF_PREFIX,
     MAX_OUTPUT_TOKENS,
     PLAN_DIR,
@@ -14,6 +16,7 @@ from pr_split.constants import (
     PR_REF_PREFIX,
     AssignmentType,
     ChunkStrategy,
+    LocViolationType,
     PartitionStrategy,
     Priority,
     Provider,
@@ -49,6 +52,12 @@ class TestPartitionStrategy:
         assert PartitionStrategy.CP_SAT == "cp_sat"
 
 
+class TestLocViolationType:
+    def test_values(self) -> None:
+        assert LocViolationType.BELOW_MIN == "below_min"
+        assert LocViolationType.ABOVE_MAX == "above_max"
+
+
 class TestPRState:
     def test_values(self) -> None:
         assert PRState.OPEN == "open"
@@ -72,6 +81,12 @@ class TestConstants:
 
     def test_default_max_loc(self) -> None:
         assert DEFAULT_MAX_LOC == 400
+
+    def test_default_min_loc(self) -> None:
+        assert DEFAULT_MIN_LOC is None
+
+    def test_default_strict_loc_bounds(self) -> None:
+        assert DEFAULT_STRICT_LOC_BOUNDS is False
 
     def test_default_strategies(self) -> None:
         assert DEFAULT_CHUNK_STRATEGY == ChunkStrategy.DYNAMIC_PROGRAMMING

--- a/tests/test_plan_store.py
+++ b/tests/test_plan_store.py
@@ -22,7 +22,9 @@ def _make_plan_file() -> PlanFile:
         plan=SplitPlan(
             dev_branch="feat/big",
             base_branch="main",
+            min_loc=50,
             max_loc=400,
+            strict_loc_bounds=True,
             priority=Priority.ORTHOGONAL,
             groups=[
                 Group(
@@ -56,6 +58,8 @@ class TestPlanStore:
         assert loaded.plan.dev_branch == "feat/big"
         assert len(loaded.plan.groups) == 1
         assert loaded.plan.groups[0].id == "pr-1"
+        assert loaded.plan.min_loc == 50
+        assert loaded.plan.strict_loc_bounds is True
 
     def test_plan_exists_false(self, tmp_path: object, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.chdir(tmp_path)
@@ -89,7 +93,9 @@ class TestPlanStoreJson:
             plan=SplitPlan(
                 dev_branch="dev",
                 base_branch="main",
+                min_loc=25,
                 max_loc=400,
+                strict_loc_bounds=True,
                 priority=Priority.LOGICAL,
                 groups=[],
             ),
@@ -98,3 +104,5 @@ class TestPlanStoreJson:
         raw = json.loads((tmp_path / ".pr-split" / "plan.json").read_text())
         assert "plan" in raw
         assert raw["plan"]["priority"] == "logical"
+        assert raw["plan"]["min_loc"] == 25
+        assert raw["plan"]["strict_loc_bounds"] is True

--- a/tests/test_schemas_extended.py
+++ b/tests/test_schemas_extended.py
@@ -22,6 +22,8 @@ class TestSplitPlan:
         )
         assert plan.groups == []
         assert plan.author is None
+        assert plan.min_loc is None
+        assert plan.strict_loc_bounds is False
 
     def test_with_author(self) -> None:
         plan = SplitPlan(
@@ -30,6 +32,18 @@ class TestSplitPlan:
             author="Jane <jane@x.com>",
         )
         assert plan.author == "Jane <jane@x.com>"
+
+    def test_with_loc_bounds(self) -> None:
+        plan = SplitPlan(
+            dev_branch="feat/x",
+            base_branch="main",
+            min_loc=50,
+            max_loc=400,
+            strict_loc_bounds=True,
+            priority=Priority.LOGICAL,
+        )
+        assert plan.min_loc == 50
+        assert plan.strict_loc_bounds is True
 
 
 class TestBranchRecord:

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -37,6 +37,7 @@ class TestScorePlan:
         metrics = score_plan(groups, 100)
         assert metrics.total_groups == 2
         assert metrics.max_group_loc == 120
+        assert metrics.loc_underflow == 0
         assert metrics.loc_overflow == 20
         assert metrics.dependency_edges == 1
         assert metrics.dag_depth == 2
@@ -56,3 +57,12 @@ class TestScorePlan:
         ]
         metrics = score_plan(groups, 100)
         assert metrics.tiny_groups == 1
+
+    def test_underflow_and_undersized_groups_are_counted(self) -> None:
+        groups = [
+            _group("g1", "a.py", [0], 20),
+            _group("g2", "b.py", [0], 90),
+        ]
+        metrics = score_plan(groups, 100, min_loc=50)
+        assert metrics.loc_underflow == 30
+        assert metrics.undersized_groups == 1

--- a/tests/test_types_defs.py
+++ b/tests/test_types_defs.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
-from pr_split.types_defs import DiffStats, FileSummary, ForkPRInfo, HunkInfo, HunkRef
+from pr_split.constants import LocViolationType
+from pr_split.types_defs import (
+    DiffStats,
+    FileSummary,
+    ForkPRInfo,
+    HunkInfo,
+    HunkRef,
+    LocBoundViolation,
+)
 
 
 class TestHunkInfo:
@@ -79,3 +87,18 @@ class TestHunkRefExtended:
         r1 = HunkRef(file_path="a.py", hunk_index=0, token_estimate=50)
         r2 = HunkRef(file_path="a.py", hunk_index=0, token_estimate=50)
         assert r1 == r2
+
+
+class TestLocBoundViolation:
+    def test_fields(self) -> None:
+        violation = LocBoundViolation(
+            group_id="pr-1",
+            violation_type=LocViolationType.BELOW_MIN,
+            limit=50,
+            estimated_loc=20,
+            estimated_added=15,
+            estimated_removed=5,
+        )
+        assert violation.group_id == "pr-1"
+        assert violation.violation_type == LocViolationType.BELOW_MIN
+        assert violation.limit == 50

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import pytest
 
-from pr_split.constants import AssignmentType
+from pr_split.constants import AssignmentType, LocViolationType
 from pr_split.diff_ops.parser import parse_diff
 from pr_split.exceptions import PlanValidationError
 from pr_split.graph import PlanDAG
 from pr_split.planner.validator import (
+    detect_loc_bound_violations,
     validate_coverage,
     validate_loc,
     validate_loc_bounds,
@@ -155,3 +156,19 @@ class TestValidateLocBounds:
         warnings = validate_loc_bounds(groups, 400)
         assert len(warnings) == 1
         assert "g1" in warnings[0]
+        assert "above maximum" in warnings[0]
+
+    def test_below_minimum_returns_warnings(self) -> None:
+        groups = [_make_group("g1", [], 25)]
+        warnings = validate_loc_bounds(groups, 400, min_loc=50)
+        assert len(warnings) == 1
+        assert "g1" in warnings[0]
+        assert "below minimum" in warnings[0]
+
+    def test_detect_loc_bound_violations_returns_structured_result(self) -> None:
+        groups = [_make_group("g1", [], 25)]
+        violations = detect_loc_bound_violations(groups, 400, min_loc=50)
+        assert len(violations) == 1
+        assert violations[0].group_id == "g1"
+        assert violations[0].violation_type == LocViolationType.BELOW_MIN
+        assert violations[0].limit == 50

--- a/tests/test_validator_extended.py
+++ b/tests/test_validator_extended.py
@@ -63,3 +63,14 @@ class TestValidatePlanIntegration:
         dag = PlanDAG(groups)
         warnings = validate_plan(groups, parsed, dag, 2)
         assert len(warnings) == 2
+
+    def test_valid_plan_with_min_loc_warning(self) -> None:
+        parsed = parse_diff(SAMPLE_DIFF)
+        groups = [
+            _make_group("g1", [_ga("a.py", WHOLE, [0])], 3),
+            _make_group("g2", [_ga("b.py", WHOLE, [0])], 4),
+        ]
+        dag = PlanDAG(groups)
+        warnings = validate_plan(groups, parsed, dag, 10, min_loc=5)
+        assert len(warnings) == 2
+        assert all("below minimum" in warning for warning in warnings)


### PR DESCRIPTION
## Summary
- add shared min/max LOC bounds configuration and persisted plan metadata
- add structured LOC bound violation detection plus strict split-time enforcement
- expose underflow metrics and document the new CLI/env options

Part of #6.

## Testing
- uv run ruff check pr_split tests
- uv run pytest -q