### PR TITLE
feat(cp_sat): add soft lower-bound penalty for min_loc

### DIFF
--- a/pr_split/planner/partitioning.py
+++ b/pr_split/planner/partitioning.py
@@ -25,6 +25,7 @@ _AFFINITY_ORTHOGONAL_PENALTY = 20
 _AFFINITY_LOGICAL_SHARED_DIR_BONUS = 10
 _GRAPH_ORTHOGONAL_FILE_PENALTY = 25.0
 _CP_SAT_OVERFLOW_WEIGHT = 1_000
+_CP_SAT_UNDERFLOW_WEIGHT = 1_000
 _CP_SAT_GROUP_WEIGHT_LOGICAL = 200
 _CP_SAT_GROUP_WEIGHT_ORTHOGONAL = 250
 _CP_SAT_CROSS_FILE_PENALTY_LOGICAL = 0
@@ -344,6 +345,14 @@ def _group_units_cp_sat(
         model.NewIntVar(0, max_total_loc, f"overflow_{group_idx}")
         for group_idx in range(group_slots)
     ]
+    underflow = (
+        [
+            model.NewIntVar(0, max_total_loc, f"underflow_{group_idx}")
+            for group_idx in range(group_slots)
+        ]
+        if settings.min_loc is not None
+        else []
+    )
 
     for unit_idx in range(len(units)):
         model.Add(sum(x[(unit_idx, group_idx)] for group_idx in range(group_slots)) == 1)
@@ -355,6 +364,10 @@ def _group_units_cp_sat(
         )
         model.Add(load <= max_total_loc * y[group_idx])
         model.Add(load - settings.max_loc <= overflow[group_idx])
+        if underflow:
+            # Underflow only applies to active groups: inactive groups (y==0)
+            # have zero load and should not be penalised for being undersized.
+            model.Add(settings.min_loc * y[group_idx] - load <= underflow[group_idx])
         for unit_idx in range(len(units)):
             model.Add(x[(unit_idx, group_idx)] <= y[group_idx])
 
@@ -394,9 +407,11 @@ def _group_units_cp_sat(
         else _CP_SAT_AFFINITY_DIVISOR_ORTHOGONAL
     )
 
+    underflow_cost = _CP_SAT_UNDERFLOW_WEIGHT * sum(underflow) if underflow else 0
     model.Minimize(
         group_weight * sum(y)
         + overflow_weight * sum(overflow)
+        + underflow_cost
         + cross_file_penalty
         * sum(same_group for _, is_cross_file, same_group in pair_terms if is_cross_file)
         - sum(

--- a/tests/test_partitioning_extensive.py
+++ b/tests/test_partitioning_extensive.py
@@ -267,6 +267,34 @@ class TestPartitionDiffCpSatExtensive:
         assert groups[1].depends_on == ["pr-1"]
         _assert_valid_plan(groups, TWO_HUNK_DIFF, 1)
 
+    def test_min_loc_merges_undersized_groups(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pytest.importorskip("ortools.sat.python.cp_model")
+        settings = _settings(
+            monkeypatch,
+            max_loc=10,
+            min_loc=5,
+            partition_strategy=PartitionStrategy.CP_SAT,
+            priority=Priority.ORTHOGONAL,
+        )
+        groups = partition_diff(parse_diff(UNRELATED_DIFF), settings)
+        assert len(groups) == 1
+        _assert_valid_plan(groups, UNRELATED_DIFF, 10, min_loc=5)
+
+    def test_min_loc_no_effect_when_groups_already_large(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pytest.importorskip("ortools.sat.python.cp_model")
+        settings = _settings(
+            monkeypatch,
+            max_loc=10,
+            min_loc=1,
+            partition_strategy=PartitionStrategy.CP_SAT,
+            priority=Priority.ORTHOGONAL,
+        )
+        groups = partition_diff(parse_diff(UNRELATED_DIFF), settings)
+        assert len(groups) == 2
+        _assert_valid_plan(groups, UNRELATED_DIFF, 10, min_loc=1)
+
     def test_is_deterministic_across_runs(self, monkeypatch: pytest.MonkeyPatch) -> None:
         pytest.importorskip("ortools.sat.python.cp_model")
         settings = _settings(


### PR DESCRIPTION
## Summary

- Add underflow variables and soft penalty to the CP-SAT optimizer so it prefers groupings that respect `min_loc` lower bounds
- Inactive group slots (y=0) are excluded from underflow penalties to avoid penalising empty slots
- Weight matches the existing overflow penalty (1000) for symmetric treatment of upper/lower bounds

Closes phase 3 (cp_sat) of #6.

## Test plan

- [x] New test: `test_min_loc_merges_undersized_groups` — with min_loc=5, two small groups (3+4 LOC) merge into one
- [x] New test: `test_min_loc_no_effect_when_groups_already_large` — min_loc=1 leaves groups unchanged
- [x] Full suite: 329 tests pass