### PR TITLE
test: improve coverage for cli.py and git_ops/prs.py

### DIFF
--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -1,0 +1,529 @@
+"""Tests to improve coverage for pr_split/cli.py.
+
+Covers: _validate_inputs, _handle_loc_bound_warnings, _resolve_fork_ref,
+_present_plan, _build_pr_body (template error paths), _send_webhook,
+_show_group_detail, _move_assignment, and split command argument validation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from pr_split.cli import (
+    _build_pr_body,
+    _handle_loc_bound_warnings,
+    _move_assignment,
+    _present_plan,
+    _resolve_fork_ref,
+    _send_webhook,
+    _show_group_detail,
+    _validate_inputs,
+    app,
+)
+from pr_split.constants import AssignmentType
+from pr_split.exceptions import PRSplitError
+from pr_split.schemas import Group, GroupAssignment
+from pr_split.types_defs import ForkPRInfo
+
+runner = CliRunner()
+
+
+def _group(
+    gid: str,
+    title: str,
+    depends_on: list[str] | None = None,
+    files: list[str] | None = None,
+    added: int = 10,
+    removed: int = 5,
+) -> Group:
+    assignments = [
+        GroupAssignment(
+            file_path=f, assignment_type=AssignmentType.WHOLE_FILE, hunk_indices=[]
+        )
+        for f in (files or [])
+    ]
+    return Group(
+        id=gid,
+        title=title,
+        description=f"desc for {gid}",
+        depends_on=depends_on or [],
+        assignments=assignments,
+        estimated_loc=added + removed,
+        estimated_added=added,
+        estimated_removed=removed,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _validate_inputs
+# ---------------------------------------------------------------------------
+class TestValidateInputs:
+    @patch("pr_split.cli.is_worktree_clean", return_value=True)
+    @patch("pr_split.cli.check_gh_auth", return_value=True)
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_all_ok_no_exit(
+        self, mock_be: MagicMock, mock_auth: MagicMock, mock_clean: MagicMock
+    ) -> None:
+        _validate_inputs("feature", "main")
+
+    @patch("pr_split.cli.branch_exists", side_effect=[False])
+    def test_dev_branch_missing(self, mock_be: MagicMock) -> None:
+        with pytest.raises(typer.Exit):
+            _validate_inputs("no-such-branch", "main")
+
+    @patch("pr_split.cli.branch_exists", side_effect=[True, False])
+    def test_base_branch_missing(self, mock_be: MagicMock) -> None:
+        with pytest.raises(typer.Exit):
+            _validate_inputs("feature", "no-such-base")
+
+    @patch("pr_split.cli.is_worktree_clean", return_value=False)
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_dirty_worktree(self, mock_be: MagicMock, mock_clean: MagicMock) -> None:
+        with pytest.raises(typer.Exit):
+            _validate_inputs("feature", "main")
+
+    @patch("pr_split.cli.check_gh_auth", return_value=False)
+    @patch("pr_split.cli.is_worktree_clean", return_value=True)
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_gh_auth_failed(
+        self, mock_be: MagicMock, mock_clean: MagicMock, mock_auth: MagicMock
+    ) -> None:
+        with pytest.raises(typer.Exit):
+            _validate_inputs("feature", "main")
+
+    @patch("pr_split.cli.is_worktree_clean", return_value=True)
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_dry_run_skips_gh_auth(
+        self, mock_be: MagicMock, mock_clean: MagicMock
+    ) -> None:
+        # dry_run=True should not check gh auth
+        _validate_inputs("feature", "main", dry_run=True)
+
+
+# ---------------------------------------------------------------------------
+# _handle_loc_bound_warnings
+# ---------------------------------------------------------------------------
+class TestHandleLocBoundWarningsExtended:
+    def test_no_warnings_no_effect(self) -> None:
+        # Should not raise even with strict=True when there are no warnings
+        _handle_loc_bound_warnings([], strict_loc_bounds=True)
+
+    @patch("pr_split.cli.logger.warning")
+    def test_non_strict_logs_multiple(self, mock_warn: MagicMock) -> None:
+        _handle_loc_bound_warnings(["w1", "w2"], strict_loc_bounds=False)
+        assert mock_warn.call_count == 2
+
+    def test_strict_with_warnings_exits(self) -> None:
+        with pytest.raises(typer.Exit):
+            _handle_loc_bound_warnings(["too big"], strict_loc_bounds=True)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_fork_ref
+# ---------------------------------------------------------------------------
+class TestResolveForkRefCoverage:
+    def test_plain_branch_returns_none(self) -> None:
+        assert _resolve_fork_ref("my-feature") is None
+
+    @patch("pr_split.cli.fetch_fork_pr")
+    def test_hash_pr_number(self, mock_fetch: MagicMock) -> None:
+        info: ForkPRInfo = {
+            "pr_number": 42,
+            "local_ref": "refs/pr-split/pr-42",
+            "base_branch": "main",
+            "author": "Author <a@b.c>",
+            "fork_full_name": "user/repo",
+        }
+        mock_fetch.return_value = info
+        result = _resolve_fork_ref("#42")
+        mock_fetch.assert_called_once_with(42)
+        assert result is not None
+        assert result["pr_number"] == 42
+
+    @patch("pr_split.cli.fetch_fork_branch")
+    def test_user_colon_branch(self, mock_fetch: MagicMock) -> None:
+        info: ForkPRInfo = {
+            "pr_number": None,
+            "local_ref": "refs/pr-split/fork-user-feat",
+            "base_branch": "main",
+            "author": "Author <a@b.c>",
+            "fork_full_name": "user/repo",
+        }
+        mock_fetch.return_value = info
+        result = _resolve_fork_ref("user:feat")
+        mock_fetch.assert_called_once_with("user", "feat")
+        assert result is not None
+
+    @patch("pr_split.cli.fetch_fork_pr")
+    def test_bare_number_treated_as_pr(self, mock_fetch: MagicMock) -> None:
+        info: ForkPRInfo = {
+            "pr_number": 7,
+            "local_ref": "refs/pr-split/pr-7",
+            "base_branch": "main",
+            "author": "Author <a@b.c>",
+            "fork_full_name": "user/repo",
+        }
+        mock_fetch.return_value = info
+        result = _resolve_fork_ref("7")
+        mock_fetch.assert_called_once_with(7)
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# _present_plan
+# ---------------------------------------------------------------------------
+class TestPresentPlan:
+    def test_renders_without_error(self) -> None:
+        groups = [
+            _group("pr-1", "base", files=["a.py"]),
+            _group("pr-2", "child", depends_on=["pr-1"], files=["b.py"]),
+        ]
+        # Should not raise
+        _present_plan(groups)
+
+    def test_handles_no_deps(self) -> None:
+        groups = [_group("pr-1", "solo", files=["a.py"])]
+        _present_plan(groups)
+
+
+# ---------------------------------------------------------------------------
+# _build_pr_body template OSError path
+# ---------------------------------------------------------------------------
+class TestBuildPrBodyOsError:
+    def test_template_os_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        template_file = tmp_path / "template.md"
+        template_file.write_text("{description}")
+
+        # Create a mock Path that exists but raises OSError on read_text
+        mock_path = MagicMock()
+        mock_path.exists.return_value = True
+        mock_path.read_text.side_effect = OSError("Permission denied")
+        monkeypatch.setattr("pr_split.cli._PR_TEMPLATE_PATH", mock_path)
+
+        group = _group("pr-1", "t", files=["a.py"])
+        with pytest.raises(PRSplitError, match="Could not read PR template"):
+            _build_pr_body(group, [group])
+
+
+# ---------------------------------------------------------------------------
+# _send_webhook
+# ---------------------------------------------------------------------------
+class TestSendWebhook:
+    @patch("pr_split.cli.urllib.request.urlopen")
+    def test_successful_webhook(self, mock_urlopen: MagicMock) -> None:
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b""
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        _send_webhook("https://example.com/hook", {"event": "test"})
+        mock_urlopen.assert_called_once()
+
+    @patch("pr_split.cli.urllib.request.urlopen", side_effect=Exception("timeout"))
+    def test_failed_webhook_logs_warning(self, mock_urlopen: MagicMock) -> None:
+        # Should not raise
+        _send_webhook("https://example.com/hook", {"event": "test"})
+
+
+# ---------------------------------------------------------------------------
+# _show_group_detail
+# ---------------------------------------------------------------------------
+class TestShowGroupDetail:
+    def test_unknown_group(self) -> None:
+        groups = [_group("pr-1", "root")]
+        # Should print error but not raise
+        _show_group_detail(groups, "nonexistent")
+
+    def test_known_group_renders(self) -> None:
+        g = _group("pr-1", "root", files=["a.py"], depends_on=["pr-0"])
+        _show_group_detail([g], "pr-1")
+
+    def test_partial_hunks_rendering(self) -> None:
+        g = Group(
+            id="pr-1",
+            title="partial",
+            description="d",
+            depends_on=[],
+            assignments=[
+                GroupAssignment(
+                    file_path="x.py",
+                    assignment_type=AssignmentType.PARTIAL_HUNKS,
+                    hunk_indices=[0, 2, 4],
+                )
+            ],
+        )
+        _show_group_detail([g], "pr-1")
+
+
+# ---------------------------------------------------------------------------
+# _move_assignment
+# ---------------------------------------------------------------------------
+class TestMoveAssignment:
+    def _parsed_diff_with_file(self, path: str, num_hunks: int) -> MagicMock:
+        pf = MagicMock()
+        pf.path = path
+        pf.__len__ = MagicMock(return_value=num_hunks)
+        parsed = MagicMock()
+        parsed.patch_set = [pf]
+        return parsed
+
+    def test_same_src_dst_returns_false(self) -> None:
+        g = _group("pr-1", "t", files=["a.py"])
+        pd = self._parsed_diff_with_file("a.py", 3)
+        result = _move_assignment([g], pd, "a.py", 0, "pr-1", "pr-1")
+        assert result is False
+
+    def test_unknown_group_returns_false(self) -> None:
+        g = _group("pr-1", "t", files=["a.py"])
+        pd = self._parsed_diff_with_file("a.py", 3)
+        result = _move_assignment([g], pd, "a.py", 0, "pr-1", "nonexistent")
+        assert result is False
+
+    def test_hunk_not_found_returns_false(self) -> None:
+        g1 = _group("pr-1", "t", files=["a.py"])
+        g2 = _group("pr-2", "t2")
+        pd = self._parsed_diff_with_file("a.py", 3)
+        # The group has WHOLE_FILE assignment, hunk 99 is out of range
+        result = _move_assignment([g1, g2], pd, "a.py", 99, "pr-1", "pr-2")
+        assert result is False
+
+    def test_successful_move_whole_file(self) -> None:
+        g1 = _group("pr-1", "src", files=["a.py"])
+        g2 = _group("pr-2", "dst")
+        pd = self._parsed_diff_with_file("a.py", 3)
+        result = _move_assignment([g1, g2], pd, "a.py", 1, "pr-1", "pr-2")
+        assert result is True
+        # Hunk 1 should now be in pr-2
+        dst_assignments = [a for a in g2.assignments if a.file_path == "a.py"]
+        assert len(dst_assignments) == 1
+        assert 1 in dst_assignments[0].hunk_indices
+
+    def test_move_to_existing_partial_assignment(self) -> None:
+        g1 = Group(
+            id="pr-1",
+            title="src",
+            description="d",
+            depends_on=[],
+            assignments=[
+                GroupAssignment(
+                    file_path="a.py",
+                    assignment_type=AssignmentType.PARTIAL_HUNKS,
+                    hunk_indices=[0, 1, 2],
+                )
+            ],
+        )
+        g2 = Group(
+            id="pr-2",
+            title="dst",
+            description="d",
+            depends_on=[],
+            assignments=[
+                GroupAssignment(
+                    file_path="a.py",
+                    assignment_type=AssignmentType.PARTIAL_HUNKS,
+                    hunk_indices=[3],
+                )
+            ],
+        )
+        pd = self._parsed_diff_with_file("a.py", 5)
+        result = _move_assignment([g1, g2], pd, "a.py", 1, "pr-1", "pr-2")
+        assert result is True
+        # Hunk 1 removed from pr-1
+        src_a = [a for a in g1.assignments if a.file_path == "a.py"]
+        assert 1 not in src_a[0].hunk_indices
+        # Hunk 1 added to pr-2
+        dst_a = [a for a in g2.assignments if a.file_path == "a.py"]
+        assert 1 in dst_a[0].hunk_indices
+
+    def test_move_last_hunk_removes_assignment(self) -> None:
+        g1 = Group(
+            id="pr-1",
+            title="src",
+            description="d",
+            depends_on=[],
+            assignments=[
+                GroupAssignment(
+                    file_path="a.py",
+                    assignment_type=AssignmentType.PARTIAL_HUNKS,
+                    hunk_indices=[0],
+                )
+            ],
+        )
+        g2 = _group("pr-2", "dst")
+        pd = self._parsed_diff_with_file("a.py", 3)
+        result = _move_assignment([g1, g2], pd, "a.py", 0, "pr-1", "pr-2")
+        assert result is True
+        # pr-1 should have no assignments for a.py
+        src_a = [a for a in g1.assignments if a.file_path == "a.py"]
+        assert len(src_a) == 0
+
+
+# ---------------------------------------------------------------------------
+# split command argument validation
+# ---------------------------------------------------------------------------
+class TestSplitCommandValidation:
+    def test_split_min_loc_ge_max_loc_error(self) -> None:
+        """min_loc >= max_loc should cause a validation error."""
+        result = runner.invoke(
+            app,
+            ["split", "feature", "--dry-run", "--min-loc", "500", "--max-loc", "400"],
+            env={"ANTHROPIC_API_KEY": "sk-test"},
+        )
+        assert result.exit_code != 0
+
+    @patch("pr_split.cli.save_plan")
+    @patch("pr_split.cli.merge_base", return_value="abc123")
+    @patch("pr_split.cli._interactive_edit")
+    @patch("pr_split.cli._present_plan")
+    @patch("pr_split.cli.validate_plan", return_value=[])
+    @patch("pr_split.cli.plan_split")
+    @patch("pr_split.cli.parse_diff")
+    @patch("pr_split.cli.extract_diff", return_value="diff --git a/a.py b/a.py\n")
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    @patch("pr_split.cli.plan_exists", return_value=False)
+    def test_split_dry_run_saves_plan(
+        self,
+        mock_plan_exists: MagicMock,
+        mock_branch_exists: MagicMock,
+        mock_validate_inputs: MagicMock,
+        mock_extract_diff: MagicMock,
+        mock_parse_diff: MagicMock,
+        mock_plan_split: MagicMock,
+        mock_validate_plan: MagicMock,
+        mock_present_plan: MagicMock,
+        mock_interactive_edit: MagicMock,
+        mock_merge_base: MagicMock,
+        mock_save_plan: MagicMock,
+    ) -> None:
+        parsed_diff = MagicMock()
+        parsed_diff.stats = {
+            "total_files": 1,
+            "total_added": 10,
+            "total_removed": 5,
+            "total_loc": 15,
+        }
+        mock_parse_diff.return_value = parsed_diff
+        group = _group("pr-1", "feat: auth", files=["a.py"])
+        mock_plan_split.return_value = [group]
+        mock_interactive_edit.return_value = [group]
+
+        result = runner.invoke(
+            app,
+            ["split", "feature-branch", "--dry-run"],
+            env={"ANTHROPIC_API_KEY": "sk-test"},
+        )
+        assert result.exit_code == 0
+        mock_save_plan.assert_called_once()
+
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.check_gh_auth", return_value=False)
+    @patch("pr_split.cli.branch_exists", return_value=False)
+    def test_split_fork_ref_no_auth(
+        self,
+        mock_be: MagicMock,
+        mock_auth: MagicMock,
+        mock_vi: MagicMock,
+    ) -> None:
+        result = runner.invoke(app, ["split", "#42", "--dry-run"])
+        assert result.exit_code != 0
+
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.is_worktree_clean", return_value=False)
+    @patch("pr_split.cli.check_gh_auth", return_value=True)
+    @patch("pr_split.cli.branch_exists", return_value=False)
+    def test_split_fork_ref_dirty_worktree(
+        self,
+        mock_be: MagicMock,
+        mock_auth: MagicMock,
+        mock_clean: MagicMock,
+        mock_vi: MagicMock,
+    ) -> None:
+        result = runner.invoke(app, ["split", "#42", "--dry-run"])
+        assert result.exit_code != 0
+
+    @patch("pr_split.cli._resolve_fork_ref", return_value=None)
+    @patch("pr_split.cli.is_worktree_clean", return_value=True)
+    @patch("pr_split.cli.check_gh_auth", return_value=True)
+    @patch("pr_split.cli.branch_exists", return_value=False)
+    def test_split_fork_ref_not_found(
+        self,
+        mock_be: MagicMock,
+        mock_auth: MagicMock,
+        mock_clean: MagicMock,
+        mock_resolve: MagicMock,
+    ) -> None:
+        result = runner.invoke(app, ["split", "unknown-ref", "--dry-run"])
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# execute command
+# ---------------------------------------------------------------------------
+class TestExecuteCommand:
+    @patch("pr_split.cli.plan_exists", return_value=False)
+    def test_execute_no_plan(self, mock_pe: MagicMock) -> None:
+        result = runner.invoke(app, ["execute"])
+        assert result.exit_code != 0
+
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_execute_already_has_git_state(
+        self, mock_pe: MagicMock, mock_load: MagicMock
+    ) -> None:
+        mock_plan_file = MagicMock()
+        mock_plan_file.git_state.branches = [MagicMock()]
+        mock_plan_file.git_state.prs = []
+        mock_load.return_value = mock_plan_file
+        result = runner.invoke(app, ["execute"])
+        assert result.exit_code != 0
+
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_execute_missing_raw_diff(
+        self, mock_pe: MagicMock, mock_load: MagicMock
+    ) -> None:
+        mock_plan_file = MagicMock()
+        mock_plan_file.git_state.branches = []
+        mock_plan_file.git_state.prs = []
+        mock_plan_file.plan.raw_diff = ""
+        mock_load.return_value = mock_plan_file
+        result = runner.invoke(app, ["execute"])
+        assert result.exit_code != 0
+
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_execute_missing_merge_base_sha(
+        self, mock_pe: MagicMock, mock_load: MagicMock
+    ) -> None:
+        mock_plan_file = MagicMock()
+        mock_plan_file.git_state.branches = []
+        mock_plan_file.git_state.prs = []
+        mock_plan_file.plan.raw_diff = "some diff"
+        mock_plan_file.plan.merge_base_sha = ""
+        mock_load.return_value = mock_plan_file
+        result = runner.invoke(app, ["execute"])
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# status command
+# ---------------------------------------------------------------------------
+class TestStatusCommand:
+    @patch("pr_split.cli.plan_exists", return_value=False)
+    def test_status_no_plan(self, mock_pe: MagicMock) -> None:
+        result = runner.invoke(app, ["status"])
+        assert result.exit_code == 0
+
+    @patch("pr_split.cli.plan_exists", return_value=False)
+    def test_clean_no_plan(self, mock_pe: MagicMock) -> None:
+        result = runner.invoke(app, ["clean"])
+        assert result.exit_code == 0

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -96,13 +96,15 @@ class TestValidateInputs:
         with pytest.raises(typer.Exit):
             _validate_inputs("feature", "main")
 
+    @patch("pr_split.cli.check_gh_auth")
     @patch("pr_split.cli.is_worktree_clean", return_value=True)
     @patch("pr_split.cli.branch_exists", return_value=True)
     def test_dry_run_skips_gh_auth(
-        self, mock_be: MagicMock, mock_clean: MagicMock
+        self, mock_be: MagicMock, mock_clean: MagicMock, mock_auth: MagicMock
     ) -> None:
         # dry_run=True should not check gh auth
         _validate_inputs("feature", "main", dry_run=True)
+        mock_auth.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -370,8 +372,28 @@ class TestMoveAssignment:
 # split command argument validation
 # ---------------------------------------------------------------------------
 class TestSplitCommandValidation:
-    def test_split_min_loc_ge_max_loc_error(self) -> None:
+    @patch("pr_split.cli.parse_diff")
+    @patch("pr_split.cli.extract_diff", return_value="diff --git a/a.py b/a.py\n")
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    @patch("pr_split.cli.plan_exists", return_value=False)
+    def test_split_min_loc_ge_max_loc_error(
+        self,
+        mock_pe: MagicMock,
+        mock_be: MagicMock,
+        mock_vi: MagicMock,
+        mock_extract: MagicMock,
+        mock_parse: MagicMock,
+    ) -> None:
         """min_loc >= max_loc should cause a validation error."""
+        parsed_diff = MagicMock()
+        parsed_diff.stats = {
+            "total_files": 1,
+            "total_added": 10,
+            "total_removed": 5,
+            "total_loc": 15,
+        }
+        mock_parse.return_value = parsed_diff
         result = runner.invoke(
             app,
             ["split", "feature", "--dry-run", "--min-loc", "500", "--max-loc", "400"],
@@ -424,19 +446,16 @@ class TestSplitCommandValidation:
         assert result.exit_code == 0
         mock_save_plan.assert_called_once()
 
-    @patch("pr_split.cli._validate_inputs")
     @patch("pr_split.cli.check_gh_auth", return_value=False)
     @patch("pr_split.cli.branch_exists", return_value=False)
     def test_split_fork_ref_no_auth(
         self,
         mock_be: MagicMock,
         mock_auth: MagicMock,
-        mock_vi: MagicMock,
     ) -> None:
         result = runner.invoke(app, ["split", "#42", "--dry-run"])
         assert result.exit_code != 0
 
-    @patch("pr_split.cli._validate_inputs")
     @patch("pr_split.cli.is_worktree_clean", return_value=False)
     @patch("pr_split.cli.check_gh_auth", return_value=True)
     @patch("pr_split.cli.branch_exists", return_value=False)
@@ -445,7 +464,6 @@ class TestSplitCommandValidation:
         mock_be: MagicMock,
         mock_auth: MagicMock,
         mock_clean: MagicMock,
-        mock_vi: MagicMock,
     ) -> None:
         result = runner.invoke(app, ["split", "#42", "--dry-run"])
         assert result.exit_code != 0

--- a/tests/test_git_prs_coverage.py
+++ b/tests/test_git_prs_coverage.py
@@ -1,0 +1,162 @@
+"""Tests to improve coverage for pr_split/git_ops/prs.py.
+
+Covers: get_pr_state (JSON decode error), merge_pr, fetch_fork_pr (happy path),
+fetch_fork_branch (happy path and error paths).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pr_split.exceptions import GitOperationError
+from pr_split.git_ops.prs import (
+    fetch_fork_branch,
+    fetch_fork_pr,
+    get_pr_state,
+    merge_pr,
+)
+
+
+class TestGetPrStateJsonError:
+    @patch("pr_split.git_ops.prs._run_gh")
+    def test_returns_empty_on_json_decode_error(self, mock_gh: MagicMock) -> None:
+        mock_gh.return_value = "not valid json"
+        result = get_pr_state(42)
+        assert result == {}
+
+
+class TestMergePrExtended:
+    @patch("pr_split.git_ops.prs._run_gh")
+    def test_merge_passes_pr_number_as_string(self, mock_gh: MagicMock) -> None:
+        mock_gh.return_value = ""
+        merge_pr(99)
+        args = mock_gh.call_args[0]
+        assert "99" in args
+        assert "pr" in args
+        assert "merge" in args
+
+    @patch("pr_split.git_ops.prs._run_gh")
+    def test_merge_raises_on_failure(self, mock_gh: MagicMock) -> None:
+        mock_gh.side_effect = GitOperationError("conflict")
+        with pytest.raises(GitOperationError, match="conflict"):
+            merge_pr(42)
+
+
+class TestFetchForkPrHappyPath:
+    @patch("pr_split.git_ops.branches.run_git")
+    @patch("pr_split.git_ops.prs._run_gh")
+    def test_successful_fetch(self, mock_gh: MagicMock, mock_git: MagicMock) -> None:
+        pr_data = {
+            "head": {
+                "ref": "feature-branch",
+                "repo": {
+                    "fork": True,
+                    "clone_url": "https://github.com/user/repo.git",
+                    "full_name": "user/repo",
+                },
+            },
+            "base": {"ref": "main"},
+        }
+        mock_gh.return_value = json.dumps(pr_data)
+        mock_git.side_effect = [
+            "",  # fetch
+            "Author Name <author@example.com>",  # log
+        ]
+
+        result = fetch_fork_pr(42)
+
+        assert result["pr_number"] == 42
+        assert result["base_branch"] == "main"
+        assert result["author"] == "Author Name <author@example.com>"
+        assert result["fork_full_name"] == "user/repo"
+        assert "pr-split/pr-42" in result["local_ref"]
+
+    @patch("pr_split.git_ops.branches.run_git")
+    @patch("pr_split.git_ops.prs._run_gh")
+    def test_fetch_git_failure(self, mock_gh: MagicMock, mock_git: MagicMock) -> None:
+        pr_data = {
+            "head": {
+                "ref": "feature-branch",
+                "repo": {
+                    "fork": True,
+                    "clone_url": "https://github.com/user/repo.git",
+                    "full_name": "user/repo",
+                },
+            },
+            "base": {"ref": "main"},
+        }
+        mock_gh.return_value = json.dumps(pr_data)
+        mock_git.side_effect = GitOperationError("fetch failed")
+
+        with pytest.raises(GitOperationError, match="Failed to fetch"):
+            fetch_fork_pr(42)
+
+    @patch("pr_split.git_ops.prs._run_gh")
+    def test_head_repo_none_raises(self, mock_gh: MagicMock) -> None:
+        """When head.repo is None (deleted fork), should raise."""
+        pr_data = {
+            "head": {
+                "ref": "feature",
+                "repo": None,
+            },
+            "base": {"ref": "main"},
+        }
+        mock_gh.return_value = json.dumps(pr_data)
+        with pytest.raises(GitOperationError):
+            fetch_fork_pr(42)
+
+
+class TestFetchForkBranch:
+    @patch("pr_split.git_ops.branches.run_git")
+    @patch("pr_split.git_ops.prs._run_gh")
+    def test_successful_fetch(self, mock_gh: MagicMock, mock_git: MagicMock) -> None:
+        # _run_gh is called 3 times:
+        # 1. get repo name
+        # 2. get fork repo data
+        # 3. get default branch
+        mock_gh.side_effect = [
+            "my-repo",  # repo name
+            json.dumps({
+                "clone_url": "https://github.com/user/my-repo.git",
+                "full_name": "user/my-repo",
+            }),
+            "main",  # default branch
+        ]
+        mock_git.side_effect = [
+            "",  # fetch
+            "Author <a@b.c>",  # log
+        ]
+
+        result = fetch_fork_branch("user", "feature")
+        assert result["pr_number"] is None
+        assert result["base_branch"] == "main"
+        assert result["author"] == "Author <a@b.c>"
+        assert result["fork_full_name"] == "user/my-repo"
+        assert "fork-user-feature" in result["local_ref"]
+
+    @patch("pr_split.git_ops.prs._run_gh")
+    def test_fork_repo_not_found(self, mock_gh: MagicMock) -> None:
+        mock_gh.side_effect = [
+            "my-repo",  # repo name ok
+            GitOperationError("Not Found"),  # fork repo fails
+        ]
+        with pytest.raises(GitOperationError, match="Failed to fetch"):
+            fetch_fork_branch("nonexistent-user", "branch")
+
+    @patch("pr_split.git_ops.branches.run_git")
+    @patch("pr_split.git_ops.prs._run_gh")
+    def test_git_fetch_failure(self, mock_gh: MagicMock, mock_git: MagicMock) -> None:
+        mock_gh.side_effect = [
+            "my-repo",
+            json.dumps({
+                "clone_url": "https://github.com/user/my-repo.git",
+                "full_name": "user/my-repo",
+            }),
+        ]
+        mock_git.side_effect = GitOperationError("fetch failed")
+
+        with pytest.raises(GitOperationError, match="Failed to fetch"):
+            fetch_fork_branch("user", "branch")


### PR DESCRIPTION
## Summary

- Add 28 tests in `tests/test_cli_coverage.py` covering `_validate_inputs`, `_handle_loc_bound_warnings`, `_resolve_fork_ref`, `_present_plan`, `_build_pr_body` (OSError path), `_send_webhook`, `_show_group_detail`, `_move_assignment`, split command argument validation, execute command error paths, and status/clean no-plan paths
- Add 9 tests in `tests/test_git_prs_coverage.py` covering `get_pr_state` JSON decode error, `merge_pr` extended cases, `fetch_fork_pr` happy path and git failure, and `fetch_fork_branch` happy path and error paths

## Test plan

- [x] All 406 tests pass (`pytest -x -v`)
- [x] Lint passes (`ruff check pr_split/ tests/`)