### PR TITLE
ci: pin split-score workflow to published v1.0.0 action

### DIFF
--- a/.github/workflows/split-score.yml
+++ b/.github/workflows/split-score.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:
@@ -15,7 +16,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ./
+      - name: pr-split score
+        uses: vitali87/pr-split@v1.0.0
         with:
           max-loc: "400"
           partition-strategy: "graph"


### PR DESCRIPTION
## Summary

- Reference the published `vitali87/pr-split@v1.0.0` action instead of local `./`
- Add `contents: read` permission required by checkout

## Test plan

- [ ] Verify the action runs on this PR