### PR TITLE
chore: apply ruff format and enforce it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,8 @@ jobs:
       - name: Run linter
         run: uv run ruff check pr_split/ tests/
 
+      - name: Check formatting
+        run: uv run ruff format --check pr_split/ tests/ scripts/
+
       - name: Run tests
         run: uv run pytest tests/ -q --tb=short

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -243,9 +243,7 @@ def _stacked_batch_args(
             group = groups_by_id[gid]
             parents = dag.parents(gid)
             if len(parents) == 1:
-                merged = merge_chain_assignments(
-                    group, [effective[parents[0]]], hunk_counts
-                )
+                merged = merge_chain_assignments(group, [effective[parents[0]]], hunk_counts)
                 start_point = branch_names[parents[0]]
                 group_base = branch_names[parents[0]]
             elif len(parents) > 1:
@@ -365,9 +363,7 @@ def _build_pr_body(group: Group, all_groups: list[Group]) -> str:
             template = _PR_TEMPLATE_PATH.read_text(encoding="utf-8")
             return template.format(**template_vars)
         except (KeyError, ValueError, IndexError) as exc:
-            available = ", ".join(
-                f"{{{k}}}" for k in sorted(template_vars)
-            )
+            available = ", ".join(f"{{{k}}}" for k in sorted(template_vars))
             raise PRSplitError(
                 f"Invalid PR template at {_PR_TEMPLATE_PATH}: {exc}. "
                 f"Available placeholders: {available}. "
@@ -548,9 +544,7 @@ def _move_assignment(
         console.print(f"[red]Hunk {file_path}:{hunk_index} not found in {from_id}.[/red]")
         return False
 
-    dst_assignment = next(
-        (a for a in dst.assignments if a.file_path == file_path), None
-    )
+    dst_assignment = next((a for a in dst.assignments if a.file_path == file_path), None)
     if dst_assignment:
         if dst_assignment.assignment_type == AssignmentType.WHOLE_FILE:
             pf = pf_map.get(file_path)
@@ -629,17 +623,11 @@ def _interactive_edit(groups: list[Group], parsed_diff: ParsedDiff) -> list[Grou
                 console.print("[red]Usage: show <group_id>[/red]")
         elif action == "move":
             if len(parts) != 4:
-                console.print(
-                    "[red]Usage: move <file>:<hunk_index>"
-                    " <from_group> <to_group>[/red]"
-                )
+                console.print("[red]Usage: move <file>:<hunk_index> <from_group> <to_group>[/red]")
                 continue
             ref, from_id, to_id = parts[1], parts[2], parts[3]
             if ":" not in ref:
-                console.print(
-                    "[red]Usage: move <file>:<hunk_index>"
-                    " <from_group> <to_group>[/red]"
-                )
+                console.print("[red]Usage: move <file>:<hunk_index> <from_group> <to_group>[/red]")
                 continue
             file_path, hunk_str = ref.rsplit(":", 1)
             try:
@@ -650,13 +638,10 @@ def _interactive_edit(groups: list[Group], parsed_diff: ParsedDiff) -> list[Grou
             if hunk_index < 0:
                 console.print("[red]Hunk index must be non-negative.[/red]")
                 continue
-            _move_assignment(
-                groups, parsed_diff, file_path, hunk_index, from_id, to_id
-            )
+            _move_assignment(groups, parsed_diff, file_path, hunk_index, from_id, to_id)
         else:
             console.print(
-                "[yellow]Unknown command."
-                " Type 'done' to proceed or 'abort' to cancel.[/yellow]"
+                "[yellow]Unknown command. Type 'done' to proceed or 'abort' to cancel.[/yellow]"
             )
 
 
@@ -761,9 +746,7 @@ def split(
         existing = load_plan()
         has_git_state = existing.git_state.branches or existing.git_state.prs
         if has_git_state:
-            console.print(
-                "[yellow]An existing split plan with branches/PRs was found.[/yellow]"
-            )
+            console.print("[yellow]An existing split plan with branches/PRs was found.[/yellow]")
             console.print(
                 "[red]Warning: this will permanently close PRs and delete remote branches.[/red]"
             )
@@ -821,9 +804,7 @@ def split(
     empty_groups = [g for g in groups if not g.assignments]
     if empty_groups:
         empty_ids = [g.id for g in empty_groups]
-        console.print(
-            f"[red]Groups {empty_ids} are empty after editing.[/red]"
-        )
+        console.print(f"[red]Groups {empty_ids} are empty after editing.[/red]")
         raise typer.Exit(1)
     try:
         dag = PlanDAG(groups)
@@ -872,18 +853,22 @@ def split(
     try:
         pr_records = _push_and_create_prs(groups, branch_records, draft=draft)
     except PRCreationError as exc:
-        save_plan(PlanFile(
-            plan=split_plan,
-            git_state=GitState(branches=branch_records, prs=exc.pr_records),
-        ))
+        save_plan(
+            PlanFile(
+                plan=split_plan,
+                git_state=GitState(branches=branch_records, prs=exc.pr_records),
+            )
+        )
         raise
     if stack:
         _link_stacks(dag, pr_records)
 
-    save_plan(PlanFile(
-        plan=split_plan,
-        git_state=GitState(branches=branch_records, prs=pr_records),
-    ))
+    save_plan(
+        PlanFile(
+            plan=split_plan,
+            git_state=GitState(branches=branch_records, prs=pr_records),
+        )
+    )
     logger.success(f"Split complete: {len(groups)} PRs created")
 
 
@@ -1008,10 +993,7 @@ def execute(
         plan = plan.model_copy(update={"draft": True})
 
     if plan_file.git_state.branches or plan_file.git_state.prs:
-        console.print(
-            "[red]This plan already has branches/PRs."
-            " Use 'pr-split clean' first.[/red]"
-        )
+        console.print("[red]This plan already has branches/PRs. Use 'pr-split clean' first.[/red]")
         raise typer.Exit(1)
 
     if not plan.raw_diff:
@@ -1029,9 +1011,7 @@ def execute(
         raise typer.Exit(1)
 
     if not branch_exists(plan.base_branch):
-        console.print(
-            f"[red]{ErrorMsg.BRANCH_NOT_FOUND(branch=plan.base_branch)}[/red]"
-        )
+        console.print(f"[red]{ErrorMsg.BRANCH_NOT_FOUND(branch=plan.base_branch)}[/red]")
         raise typer.Exit(1)
     if not is_worktree_clean():
         console.print(f"[red]{ErrorMsg.DIRTY_WORKTREE()}[/red]")
@@ -1051,9 +1031,7 @@ def execute(
     _present_plan(plan.groups)
     typer.confirm("Proceed with creating branches and PRs?", abort=True)
 
-    namespace = derive_split_namespace(
-        plan.dev_branch_arg or plan.dev_branch
-    )
+    namespace = derive_split_namespace(plan.dev_branch_arg or plan.dev_branch)
     branch_records = _create_branches_and_commits(
         plan.groups,
         parsed_diff,
@@ -1066,30 +1044,30 @@ def execute(
     try:
         pr_records = _push_and_create_prs(plan.groups, branch_records, draft=plan.draft)
     except PRCreationError as exc:
-        save_plan(PlanFile(
-            plan=plan,
-            git_state=GitState(branches=branch_records, prs=exc.pr_records),
-        ))
+        save_plan(
+            PlanFile(
+                plan=plan,
+                git_state=GitState(branches=branch_records, prs=exc.pr_records),
+            )
+        )
         raise
     if plan.stacked:
         _link_stacks(PlanDAG(plan.groups), pr_records)
 
-    save_plan(PlanFile(
-        plan=plan,
-        git_state=GitState(branches=branch_records, prs=pr_records),
-    ))
-    logger.success(
-        f"Execute complete: {len(plan.groups)} PRs created from saved plan"
+    save_plan(
+        PlanFile(
+            plan=plan,
+            git_state=GitState(branches=branch_records, prs=pr_records),
+        )
     )
+    logger.success(f"Execute complete: {len(plan.groups)} PRs created from saved plan")
 
 
 _AUTO_MERGE_POLL_INTERVAL = 10
 _AUTO_MERGE_POLL_TIMEOUT = 600
 
 
-def _poll_for_merged(
-    group_ids: list[str], pr_map: dict[str, PRRecord]
-) -> set[str]:
+def _poll_for_merged(group_ids: list[str], pr_map: dict[str, PRRecord]) -> set[str]:
     pending = set(group_ids)
     actually_merged: set[str] = set()
     deadline = time.monotonic() + _AUTO_MERGE_POLL_TIMEOUT
@@ -1118,9 +1096,7 @@ def _poll_for_merged(
 def _send_webhook(url: str, payload: dict[str, object]) -> None:
     try:
         data = json_mod.dumps(payload).encode("utf-8")
-        req = urllib.request.Request(
-            url, data=data, headers={"Content-Type": "application/json"}
-        )
+        req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
         with urllib.request.urlopen(req, timeout=10) as resp:
             resp.read()
         logger.info(f"Webhook notification sent to {url}")
@@ -1224,10 +1200,7 @@ def merge_all(
                 break
 
         if auto and not stopped:
-            queued = [
-                gid for gid in batch
-                if gid not in merged and gid not in skipped_ids
-            ]
+            queued = [gid for gid in batch if gid not in merged and gid not in skipped_ids]
             if queued:
                 logger.info(f"Waiting for auto-merge to complete: {', '.join(queued)}")
                 actually_merged = _poll_for_merged(queued, pr_map)
@@ -1256,22 +1229,20 @@ def merge_all(
         console.print(f"[red]Failed ({len(failed)}): {', '.join(failed)}[/red]")
     if notify:
         exit_reason = (
-            "merge_error" if stopped
-            else "incomplete_batch" if exited_early
-            else "success"
+            "merge_error" if stopped else "incomplete_batch" if exited_early else "success"
         )
-        skipped_structured = [
-            {"id": s.split(" (")[0], "reason": s}
-            for s in skipped
-        ]
-        _send_webhook(notify, {
-            "event": "merge_complete",
-            "merged": merged,
-            "skipped": skipped_structured,
-            "failed": failed,
-            "success": not (failed or stopped or exited_early),
-            "exit_reason": exit_reason,
-        })
+        skipped_structured = [{"id": s.split(" (")[0], "reason": s} for s in skipped]
+        _send_webhook(
+            notify,
+            {
+                "event": "merge_complete",
+                "merged": merged,
+                "skipped": skipped_structured,
+                "failed": failed,
+                "success": not (failed or stopped or exited_early),
+                "exit_reason": exit_reason,
+            },
+        )
 
     if failed or stopped or exited_early:
         raise typer.Exit(1)

--- a/pr_split/git_ops/prs.py
+++ b/pr_split/git_ops/prs.py
@@ -59,9 +59,7 @@ def create_pr(
 
 def get_pr_state(pr_number: int) -> dict[str, str | bool | None]:
     try:
-        raw = _run_gh(
-            "pr", "view", str(pr_number), "--json", "state,reviewDecision,isDraft"
-        )
+        raw = _run_gh("pr", "view", str(pr_number), "--json", "state,reviewDecision,isDraft")
         return json.loads(raw)
     except (GitOperationError, json.JSONDecodeError) as exc:
         logger.debug(f"Failed to fetch live state for PR #{pr_number}: {exc}")

--- a/pr_split/logs.py
+++ b/pr_split/logs.py
@@ -4,12 +4,8 @@ SENDING_TO_LLM = "Sending diff to LLM for analysis ({model})"
 LLM_RESPONSE_RECEIVED = "Received split plan with {count} groups"
 VALIDATING_PLAN = "Validating split plan"
 VALIDATION_PASSED = "Plan validation passed"
-LOC_MIN_WARN = (
-    "Group '{group}' has {loc} diff lines (+{added}/-{removed}) below minimum: {limit}"
-)
-LOC_MAX_WARN = (
-    "Group '{group}' has {loc} diff lines (+{added}/-{removed}) above maximum: {limit}"
-)
+LOC_MIN_WARN = "Group '{group}' has {loc} diff lines (+{added}/-{removed}) below minimum: {limit}"
+LOC_MAX_WARN = "Group '{group}' has {loc} diff lines (+{added}/-{removed}) above maximum: {limit}"
 PRESENTING_PLAN = "Split plan ready for review"
 CREATING_BRANCH = "Creating branch {branch} from {base}"
 CREATING_MERGE_BASE = "Creating merge base {branch} from parents: {parents}"

--- a/pr_split/planner/client.py
+++ b/pr_split/planner/client.py
@@ -162,9 +162,7 @@ def _call_openai(system: str, user: str, *, settings: Settings) -> RawToolOutput
                 parsed = json.loads(item.arguments)
             except json.JSONDecodeError as exc:
                 raise LLMError(
-                    ErrorMsg.LLM_PARSE_ERROR(
-                        detail=f"failed to parse tool arguments: {exc}"
-                    )
+                    ErrorMsg.LLM_PARSE_ERROR(detail=f"failed to parse tool arguments: {exc}")
                 ) from exc
             return RawToolOutput(groups=_extract_raw_output(parsed))
     raise LLMError(ErrorMsg.LLM_PARSE_ERROR(detail="no function_call in response output"))
@@ -354,18 +352,12 @@ def _refine_plan_with_llm(
         return groups
 
     for iteration in range(1, settings.max_refinement_iterations + 1):
-        violations = detect_loc_bound_violations(
-            groups, settings.max_loc, settings.min_loc
-        )
+        violations = detect_loc_bound_violations(groups, settings.max_loc, settings.min_loc)
         if not violations:
-            logger.info(
-                logs.REFINEMENT_RESOLVED.format(iterations=iteration - 1)
-            )
+            logger.info(logs.REFINEMENT_RESOLVED.format(iterations=iteration - 1))
             return groups
 
-        logger.info(
-            logs.REFINEMENT_START.format(count=len(violations), iteration=iteration)
-        )
+        logger.info(logs.REFINEMENT_START.format(count=len(violations), iteration=iteration))
 
         user = build_refinement_prompt(
             violations=violations,
@@ -380,19 +372,13 @@ def _refine_plan_with_llm(
             groups = refined
         except LLMError:
             logger.warning(
-                logs.REFINEMENT_EXHAUSTED.format(
-                    iterations=iteration, remaining=len(violations)
-                )
+                logs.REFINEMENT_EXHAUSTED.format(iterations=iteration, remaining=len(violations))
             )
             return groups
 
     remaining = detect_loc_bound_violations(groups, settings.max_loc, settings.min_loc)
     if not remaining:
-        logger.info(
-            logs.REFINEMENT_RESOLVED.format(
-                iterations=settings.max_refinement_iterations
-            )
-        )
+        logger.info(logs.REFINEMENT_RESOLVED.format(iterations=settings.max_refinement_iterations))
     else:
         logger.warning(
             logs.REFINEMENT_EXHAUSTED.format(
@@ -442,9 +428,7 @@ def plan_split(
         case PartitionStrategy.GRAPH | PartitionStrategy.CP_SAT:
             groups = partition_diff(parsed_diff, settings)
         case _:
-            raise PRSplitError(
-                f"Unsupported partition strategy '{settings.partition_strategy}'"
-            )
+            raise PRSplitError(f"Unsupported partition strategy '{settings.partition_strategy}'")
 
     metrics = score_plan(groups, settings.max_loc, settings.min_loc)
     logger.info(

--- a/pr_split/planner/partitioning.py
+++ b/pr_split/planner/partitioning.py
@@ -359,8 +359,7 @@ def _group_units_cp_sat(
 
     for group_idx in range(group_slots):
         load = sum(
-            units[unit_idx].loc * x[(unit_idx, group_idx)]
-            for unit_idx in range(len(units))
+            units[unit_idx].loc * x[(unit_idx, group_idx)] for unit_idx in range(len(units))
         )
         model.Add(load <= max_total_loc * y[group_idx])
         model.Add(load - settings.max_loc <= overflow[group_idx])

--- a/pr_split/planner/scoring.py
+++ b/pr_split/planner/scoring.py
@@ -51,9 +51,7 @@ def score_plan(groups: list[Group], max_loc: int, min_loc: int | None = None) ->
 
     undersized_groups = (
         # Includes empty groups (estimated_loc == 0), unlike tiny_groups below.
-        sum(1 for group in groups if group.estimated_loc < min_loc)
-        if min_loc is not None
-        else 0
+        sum(1 for group in groups if group.estimated_loc < min_loc) if min_loc is not None else 0
     )
     tiny_threshold = max(1, max_loc // 4)
     tiny_groups = sum(1 for group in groups if 0 < group.estimated_loc < tiny_threshold)

--- a/scripts/score_pr.py
+++ b/scripts/score_pr.py
@@ -92,11 +92,17 @@ def main() -> None:
 
     # Run pr-split in dry-run mode
     cmd = [
-        "pr-split", "split", head_branch,
-        "--base", base_branch,
-        "--partition-strategy", strategy,
-        "--priority", priority,
-        "--max-loc", str(max_loc),
+        "pr-split",
+        "split",
+        head_branch,
+        "--base",
+        base_branch,
+        "--partition-strategy",
+        strategy,
+        "--priority",
+        priority,
+        "--max-loc",
+        str(max_loc),
         "--dry-run",
     ]
     if min_loc_raw:
@@ -163,14 +169,9 @@ def main() -> None:
         lines.append("| Group | Title | Diff | Depends On | Files |")
         lines.append("|-------|-------|------|------------|-------|")
         for g in groups:
-            files = ", ".join(
-                f"`{_md_escape(a['file_path'])}`"
-                for a in g.get("assignments", [])
-            )
+            files = ", ".join(f"`{_md_escape(a['file_path'])}`" for a in g.get("assignments", []))
             deps = ", ".join(g.get("depends_on", [])) or "—"
-            diff_str = (
-                f"+{g.get('estimated_added', 0)}/-{g.get('estimated_removed', 0)}"
-            )
+            diff_str = f"+{g.get('estimated_added', 0)}/-{g.get('estimated_removed', 0)}"
             title = _md_escape(g["title"])
             gid = _md_escape(g["id"])
             lines.append(f"| {gid} | {title} | {diff_str} | {deps} | {files} |")

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -286,19 +286,13 @@ class TestFormatGroupCatalog:
 
 class TestChunkHunksExtended:
     def test_single_hunk_per_chunk_when_tight(self) -> None:
-        refs = [
-            HunkRef(file_path=f"f{i}.py", hunk_index=0, token_estimate=90)
-            for i in range(3)
-        ]
+        refs = [HunkRef(file_path=f"f{i}.py", hunk_index=0, token_estimate=90) for i in range(3)]
         result = chunk_hunks(refs, 100)
         assert len(result) == 3
         assert all(len(c) == 1 for c in result)
 
     def test_many_small_hunks_pack_efficiently(self) -> None:
-        refs = [
-            HunkRef(file_path=f"f{i}.py", hunk_index=0, token_estimate=10)
-            for i in range(10)
-        ]
+        refs = [HunkRef(file_path=f"f{i}.py", hunk_index=0, token_estimate=10) for i in range(10)]
         result = chunk_hunks(refs, 100)
         assert len(result) == 1
         assert len(result[0]) == 10

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -42,9 +42,7 @@ def _group(
     removed: int = 5,
 ) -> Group:
     assignments = [
-        GroupAssignment(
-            file_path=f, assignment_type=AssignmentType.WHOLE_FILE, hunk_indices=[]
-        )
+        GroupAssignment(file_path=f, assignment_type=AssignmentType.WHOLE_FILE, hunk_indices=[])
         for f in (files or [])
     ]
     return Group(
@@ -197,9 +195,7 @@ class TestPresentPlan:
 # _build_pr_body template OSError path
 # ---------------------------------------------------------------------------
 class TestBuildPrBodyOsError:
-    def test_template_os_error(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_template_os_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         template_file = tmp_path / "template.md"
         template_file.write_text("{description}")
 
@@ -494,9 +490,7 @@ class TestExecuteCommand:
 
     @patch("pr_split.cli.load_plan")
     @patch("pr_split.cli.plan_exists", return_value=True)
-    def test_execute_already_has_git_state(
-        self, mock_pe: MagicMock, mock_load: MagicMock
-    ) -> None:
+    def test_execute_already_has_git_state(self, mock_pe: MagicMock, mock_load: MagicMock) -> None:
         mock_plan_file = MagicMock()
         mock_plan_file.git_state.branches = [MagicMock()]
         mock_plan_file.git_state.prs = []
@@ -506,9 +500,7 @@ class TestExecuteCommand:
 
     @patch("pr_split.cli.load_plan")
     @patch("pr_split.cli.plan_exists", return_value=True)
-    def test_execute_missing_raw_diff(
-        self, mock_pe: MagicMock, mock_load: MagicMock
-    ) -> None:
+    def test_execute_missing_raw_diff(self, mock_pe: MagicMock, mock_load: MagicMock) -> None:
         mock_plan_file = MagicMock()
         mock_plan_file.git_state.branches = []
         mock_plan_file.git_state.prs = []

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -180,9 +180,7 @@ class TestPushAndCreatePrs:
 
     @patch("pr_split.cli.create_pr", return_value=(1, "https://github.com/pr/1"))
     @patch("pr_split.cli.push_branch")
-    def test_pushes_all_branches(
-        self, mock_push: MagicMock, mock_create: MagicMock
-    ) -> None:
+    def test_pushes_all_branches(self, mock_push: MagicMock, mock_create: MagicMock) -> None:
         groups = [_group("pr-1", "feat: a"), _group("pr-2", "feat: b")]
         records = [
             _branch_record("pr-1", "pr-split/ns/pr-1"),
@@ -194,9 +192,7 @@ class TestPushAndCreatePrs:
 
     @patch("pr_split.cli.create_pr", return_value=(5, "https://github.com/pr/5"))
     @patch("pr_split.cli.push_branch")
-    def test_preserves_group_order(
-        self, mock_push: MagicMock, mock_create: MagicMock
-    ) -> None:
+    def test_preserves_group_order(self, mock_push: MagicMock, mock_create: MagicMock) -> None:
         groups = [
             _group("pr-3", "c"),
             _group("pr-1", "a"),
@@ -212,9 +208,7 @@ class TestPushAndCreatePrs:
 
     @patch("pr_split.cli.create_pr")
     @patch("pr_split.cli.push_branch")
-    def test_concurrent_execution(
-        self, mock_push: MagicMock, mock_create: MagicMock
-    ) -> None:
+    def test_concurrent_execution(self, mock_push: MagicMock, mock_create: MagicMock) -> None:
         """Verify that multiple groups are processed concurrently."""
         barrier = threading.Barrier(3, timeout=5)
         lock = threading.Lock()
@@ -337,9 +331,7 @@ class TestCreateBranchesAndCommitsStacked:
         _create_branches_and_commits(
             [parent, child], MagicMock(), "main", "base_sha", "ns", stacked=True
         )
-        child_calls = [
-            call for call in mock_mat.call_args_list if call.args[1].id == "pr-3"
-        ]
+        child_calls = [call for call in mock_mat.call_args_list if call.args[1].id == "pr-3"]
         assert child_calls[0].args[1].assignments[0].hunk_indices == [0, 1]
         assert child_calls[0].args[2] == "base_sha"
 
@@ -543,9 +535,7 @@ class TestStackedTransitiveChain:
         _create_branches_and_commits(
             [grandparent, parent, child], MagicMock(), "main", "base_sha", "ns", stacked=True
         )
-        child_calls = [
-            call for call in mock_mat.call_args_list if call.args[1].id == "pr-3"
-        ]
+        child_calls = [call for call in mock_mat.call_args_list if call.args[1].id == "pr-3"]
         assert child_calls[0].args[1].assignments[0].hunk_indices == [0, 1, 2]
 
 

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -36,9 +36,7 @@ def _group(
     removed: int = 5,
 ) -> Group:
     assignments = [
-        GroupAssignment(
-            file_path=f, assignment_type=AssignmentType.WHOLE_FILE, hunk_indices=[]
-        )
+        GroupAssignment(file_path=f, assignment_type=AssignmentType.WHOLE_FILE, hunk_indices=[])
         for f in (files or [])
     ]
     return Group(
@@ -96,9 +94,7 @@ class TestBuildPrBody:
         body = _build_pr_body(group, [group])
         assert "## Files changed" not in body
 
-    def test_custom_template(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_custom_template(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         template_dir = tmp_path / ".pr-split"
         template_dir.mkdir()
         template_file = template_dir / "template.md"
@@ -229,9 +225,7 @@ class TestHandleLocBoundWarnings:
 
     @patch("pr_split.cli.console.print")
     @patch("pr_split.cli.logger.warning")
-    def test_strict_raises_exit(
-        self, mock_warning: MagicMock, mock_print: MagicMock
-    ) -> None:
+    def test_strict_raises_exit(self, mock_warning: MagicMock, mock_print: MagicMock) -> None:
         with pytest.raises(typer.Exit):
             _handle_loc_bound_warnings(["warning 1"], strict_loc_bounds=True)
         mock_warning.assert_not_called()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -270,9 +270,7 @@ new file mode 100644
         assert len(groups) == 1
         mock_partition.assert_called_once()
 
-    def test_unsupported_partition_strategy_raises(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_unsupported_partition_strategy_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         parsed = parse_diff(
             """\
@@ -374,9 +372,7 @@ def _merged_group() -> list[Group]:
 
 
 class TestRefinePlanWithLlm:
-    def test_no_refinement_when_zero_iterations(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_no_refinement_when_zero_iterations(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         parsed = parse_diff(_TWO_FILE_DIFF)
@@ -434,9 +430,7 @@ class TestRefinePlanWithLlm:
         assert result[0].estimated_loc == 7
         mock_call_llm.assert_called_once()
 
-    def test_no_refinement_when_no_violations(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_no_refinement_when_no_violations(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         parsed = parse_diff(_TWO_FILE_DIFF)
@@ -470,9 +464,7 @@ class TestRefinePlanWithLlm:
         assert len(result) == 2
         mock_call_llm.assert_called_once()
 
-    def test_no_refinement_when_min_loc_is_none(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_no_refinement_when_min_loc_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         parsed = parse_diff(_TWO_FILE_DIFF)
@@ -549,9 +541,7 @@ class TestCountTokensAnthropic:
     @patch("pr_split.planner.client.anthropic.Anthropic")
     def test_returns_input_tokens(self, mock_cls: MagicMock) -> None:
         mock_client = mock_cls.return_value
-        mock_client.messages.count_tokens.return_value = SimpleNamespace(
-            input_tokens=42
-        )
+        mock_client.messages.count_tokens.return_value = SimpleNamespace(input_tokens=42)
         settings = _make_settings(Provider.ANTHROPIC)
         result = _count_tokens_anthropic("sys", "usr", settings=settings)
         assert result == 42
@@ -575,9 +565,7 @@ class TestCountTokensOpenai:
         "pr_split.planner.client.tiktoken.encoding_for_model",
         side_effect=KeyError("unknown"),
     )
-    def test_unknown_model_falls_back(
-        self, _mock_enc: MagicMock, mock_get: MagicMock
-    ) -> None:
+    def test_unknown_model_falls_back(self, _mock_enc: MagicMock, mock_get: MagicMock) -> None:
         fake_enc = MagicMock()
         fake_enc.encode.return_value = [1, 2, 3]
         mock_get.return_value = fake_enc
@@ -632,12 +620,10 @@ class TestCallAnthropic:
     def test_api_error_raises_llm_error(self, mock_cls: MagicMock) -> None:
         import anthropic as _anthropic
 
-        mock_cls.return_value.beta.messages.create.side_effect = (
-            _anthropic.APIError(
-                message="server error",
-                request=MagicMock(),
-                body=None,
-            )
+        mock_cls.return_value.beta.messages.create.side_effect = _anthropic.APIError(
+            message="server error",
+            request=MagicMock(),
+            body=None,
         )
         settings = _make_settings(Provider.ANTHROPIC)
         with pytest.raises(LLMError):
@@ -655,9 +641,7 @@ class TestCallAnthropic:
             _call_anthropic("sys", "usr", settings=settings)
 
     @patch("pr_split.planner.client.anthropic.Anthropic")
-    def test_stop_reason_not_tool_use_still_succeeds(
-        self, mock_cls: MagicMock
-    ) -> None:
+    def test_stop_reason_not_tool_use_still_succeeds(self, mock_cls: MagicMock) -> None:
         from anthropic.types.beta import BetaToolUseBlock
 
         tool_block = BetaToolUseBlock(
@@ -779,9 +763,7 @@ class TestCallChunkWithRetry:
         mock_llm.side_effect = LLMError("persistent failure")
         settings = _make_settings(Provider.ANTHROPIC)
         with pytest.raises(LLMError, match="persistent failure"):
-            _call_chunk_with_retry(
-                "sys", "usr", settings=settings, chunk_index=1, total_chunks=1
-            )
+            _call_chunk_with_retry("sys", "usr", settings=settings, chunk_index=1, total_chunks=1)
 
 
 # ---------------------------------------------------------------------------
@@ -978,9 +960,7 @@ class TestPlanSplitWithLlm:
         mock_refine: MagicMock,
     ) -> None:
         parsed = parse_diff(_TWO_FILE_DIFF)
-        settings = _make_settings(
-            Provider.ANTHROPIC, partition_strategy=PartitionStrategy.LLM
-        )
+        settings = _make_settings(Provider.ANTHROPIC, partition_strategy=PartitionStrategy.LLM)
         mock_llm.return_value = RawToolOutput(groups=_SAMPLE_RAW_GROUPS)
         mock_refine.side_effect = lambda groups, *a, **kw: groups
 
@@ -998,9 +978,7 @@ class TestPlanSplitWithLlm:
         mock_refine: MagicMock,
     ) -> None:
         parsed = parse_diff(_TWO_FILE_DIFF)
-        settings = _make_settings(
-            Provider.ANTHROPIC, partition_strategy=PartitionStrategy.LLM
-        )
+        settings = _make_settings(Provider.ANTHROPIC, partition_strategy=PartitionStrategy.LLM)
         group = Group(id="pr-1", title="t", description="d", estimated_loc=7)
         mock_chunked.return_value = [group]
         mock_refine.side_effect = lambda groups, *a, **kw: groups

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -99,9 +99,7 @@ class TestSettingsLocBoundsValidation:
         with pytest.raises(ValidationError, match="min_loc 100 must be less than max_loc 100"):
             Settings(partition_strategy=PartitionStrategy.GRAPH, min_loc=100, max_loc=100)
 
-    def test_min_loc_greater_than_max_loc_raises(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_min_loc_greater_than_max_loc_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         with pytest.raises(ValidationError, match="min_loc 101 must be less than max_loc 100"):
@@ -140,9 +138,7 @@ class TestSettingsAutoDerivMinLoc:
         )
         assert s.min_loc is None
 
-    def test_explicit_min_loc_not_overridden(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_explicit_min_loc_not_overridden(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         s = Settings(
@@ -153,9 +149,7 @@ class TestSettingsAutoDerivMinLoc:
         )
         assert s.min_loc == 50
 
-    def test_derived_min_loc_uses_integer_division(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_derived_min_loc_uses_integer_division(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         s = Settings(

--- a/tests/test_git_branches.py
+++ b/tests/test_git_branches.py
@@ -275,9 +275,7 @@ class TestAddWorktree:
 
     @patch("pr_split.git_ops.branches.run_git")
     @patch("pr_split.git_ops.branches.branch_exists", return_value=True)
-    def test_restores_branch_on_failure(
-        self, mock_exists: MagicMock, mock_git: MagicMock
-    ) -> None:
+    def test_restores_branch_on_failure(self, mock_exists: MagicMock, mock_git: MagicMock) -> None:
         mock_git.side_effect = [
             "oldsha",
             "",
@@ -316,4 +314,3 @@ class TestCommitFilesInDir:
     def test_empty_file_paths_raises(self) -> None:
         with pytest.raises(GitOperationError, match="no file paths"):
             commit_files_in_dir("/tmp/wt", [], "msg")
-

--- a/tests/test_git_prs.py
+++ b/tests/test_git_prs.py
@@ -87,9 +87,7 @@ class TestCreatePrUrlParsingExtended:
 
     @patch("pr_split.git_ops.prs._run_gh")
     def test_multiline_output_uses_last_line(self, mock_gh: MagicMock) -> None:
-        mock_gh.return_value = (
-            "Creating PR...\nhttps://github.com/org/repo/pull/55"
-        )
+        mock_gh.return_value = "Creating PR...\nhttps://github.com/org/repo/pull/55"
         number, url = create_pr("head", "base", "Title", "Body")
         assert number == 55
         assert url == "https://github.com/org/repo/pull/55"

--- a/tests/test_git_prs_coverage.py
+++ b/tests/test_git_prs_coverage.py
@@ -119,10 +119,12 @@ class TestFetchForkBranch:
         # 3. get default branch
         mock_gh.side_effect = [
             "my-repo",  # repo name
-            json.dumps({
-                "clone_url": "https://github.com/user/my-repo.git",
-                "full_name": "user/my-repo",
-            }),
+            json.dumps(
+                {
+                    "clone_url": "https://github.com/user/my-repo.git",
+                    "full_name": "user/my-repo",
+                }
+            ),
             "main",  # default branch
         ]
         mock_git.side_effect = [
@@ -151,10 +153,12 @@ class TestFetchForkBranch:
     def test_git_fetch_failure(self, mock_gh: MagicMock, mock_git: MagicMock) -> None:
         mock_gh.side_effect = [
             "my-repo",
-            json.dumps({
-                "clone_url": "https://github.com/user/my-repo.git",
-                "full_name": "user/my-repo",
-            }),
+            json.dumps(
+                {
+                    "clone_url": "https://github.com/user/my-repo.git",
+                    "full_name": "user/my-repo",
+                }
+            ),
         ]
         mock_git.side_effect = GitOperationError("fetch failed")
 

--- a/tests/test_partitioning_extensive.py
+++ b/tests/test_partitioning_extensive.py
@@ -146,9 +146,7 @@ class TestPartitionDiffGraphExtensive:
         assert all(len(group.assignments) == 1 for group in groups)
         _assert_valid_plan(groups, UNRELATED_DIFF, 10)
 
-    def test_logical_groups_related_files_together(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_logical_groups_related_files_together(self, monkeypatch: pytest.MonkeyPatch) -> None:
         settings = _settings(
             monkeypatch,
             max_loc=10,
@@ -237,9 +235,7 @@ class TestPartitionDiffCpSatExtensive:
         assert all(len(group.assignments) == 1 for group in groups)
         _assert_valid_plan(groups, UNRELATED_DIFF, 10)
 
-    def test_logical_groups_related_files_together(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_logical_groups_related_files_together(self, monkeypatch: pytest.MonkeyPatch) -> None:
         pytest.importorskip("ortools.sat.python.cp_model")
         settings = _settings(
             monkeypatch,

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -120,9 +120,7 @@ class TestBuildChunkFirstPrompt:
 class TestBuildChunkContinuationPrompt:
     def test_contains_chunk_index_and_catalog(self) -> None:
         stats = _make_diff_stats()
-        result = build_chunk_continuation_prompt(
-            stats, "chunk diff", 3, 5, "group catalog text"
-        )
+        result = build_chunk_continuation_prompt(stats, "chunk diff", 3, 5, "group catalog text")
         assert "chunk 3 of 5" in result
         assert "group catalog text" in result
         assert "chunk diff" in result

--- a/tests/test_reconstructor.py
+++ b/tests/test_reconstructor.py
@@ -129,7 +129,9 @@ class TestMaterializeGroupFilesNewFile:
     def test_whole_file_new(self) -> None:
         parsed = parse_diff(NEW_FILE_DIFF)
         group = Group(
-            id="g1", title="t", description="d",
+            id="g1",
+            title="t",
+            description="d",
             assignments=[
                 GroupAssignment(
                     file_path="new_file.py",
@@ -145,7 +147,9 @@ class TestMaterializeGroupFilesNewFile:
     def test_partial_hunks_new(self) -> None:
         parsed = parse_diff(NEW_FILE_DIFF)
         group = Group(
-            id="g1", title="t", description="d",
+            id="g1",
+            title="t",
+            description="d",
             assignments=[
                 GroupAssignment(
                     file_path="new_file.py",
@@ -160,7 +164,9 @@ class TestMaterializeGroupFilesNewFile:
     def test_file_not_in_diff_skipped(self) -> None:
         parsed = parse_diff(NEW_FILE_DIFF)
         group = Group(
-            id="g1", title="t", description="d",
+            id="g1",
+            title="t",
+            description="d",
             assignments=[
                 GroupAssignment(
                     file_path="not_in_diff.py",
@@ -187,7 +193,9 @@ class TestMaterializeGroupFilesExisting:
         mock_base.return_value = "line1\nline2\nline3\n"
         parsed = parse_diff(MODIFY_DIFF)
         group = Group(
-            id="g1", title="t", description="d",
+            id="g1",
+            title="t",
+            description="d",
             assignments=[
                 GroupAssignment(
                     file_path="existing.py",
@@ -205,7 +213,9 @@ class TestMaterializeGroupFilesExisting:
         mock_base.return_value = "line1\nline2\nline3\n"
         parsed = parse_diff(MODIFY_DIFF)
         group = Group(
-            id="g1", title="t", description="d",
+            id="g1",
+            title="t",
+            description="d",
             assignments=[
                 GroupAssignment(
                     file_path="existing.py",

--- a/tests/test_schemas_extended.py
+++ b/tests/test_schemas_extended.py
@@ -17,8 +17,10 @@ from pr_split.schemas import (
 class TestSplitPlan:
     def test_defaults(self) -> None:
         plan = SplitPlan(
-            dev_branch="feat/x", base_branch="main",
-            max_loc=400, priority=Priority.ORTHOGONAL,
+            dev_branch="feat/x",
+            base_branch="main",
+            max_loc=400,
+            priority=Priority.ORTHOGONAL,
         )
         assert plan.groups == []
         assert plan.author is None
@@ -27,8 +29,10 @@ class TestSplitPlan:
 
     def test_with_author(self) -> None:
         plan = SplitPlan(
-            dev_branch="feat/x", base_branch="main",
-            max_loc=400, priority=Priority.LOGICAL,
+            dev_branch="feat/x",
+            base_branch="main",
+            max_loc=400,
+            priority=Priority.LOGICAL,
             author="Jane <jane@x.com>",
         )
         assert plan.author == "Jane <jane@x.com>"
@@ -49,14 +53,18 @@ class TestSplitPlan:
 class TestBranchRecord:
     def test_defaults(self) -> None:
         record = BranchRecord(
-            group_id="pr-1", branch_name="pr-split/pr-1", base_branch="main",
+            group_id="pr-1",
+            branch_name="pr-split/pr-1",
+            base_branch="main",
         )
         assert record.commit_sha == ""
 
     def test_full_record(self) -> None:
         record = BranchRecord(
-            group_id="pr-2", branch_name="pr-split/pr-2",
-            base_branch="main", commit_sha="abc123",
+            group_id="pr-2",
+            branch_name="pr-split/pr-2",
+            base_branch="main",
+            commit_sha="abc123",
         )
         assert record.commit_sha == "abc123"
         assert record.group_id == "pr-2"
@@ -65,14 +73,16 @@ class TestBranchRecord:
 class TestPRRecord:
     def test_default_state_is_open(self) -> None:
         record = PRRecord(
-            group_id="pr-1", pr_number=42,
+            group_id="pr-1",
+            pr_number=42,
             pr_url="https://github.com/org/repo/pull/42",
         )
         assert record.state == PRState.OPEN
 
     def test_explicit_state(self) -> None:
         record = PRRecord(
-            group_id="pr-1", pr_number=42,
+            group_id="pr-1",
+            pr_number=42,
             pr_url="https://github.com/org/repo/pull/42",
             state=PRState.MERGED,
         )
@@ -90,17 +100,27 @@ class TestPlanFile:
     def test_roundtrip_json(self) -> None:
         plan_file = PlanFile(
             plan=SplitPlan(
-                dev_branch="feat/big", base_branch="main",
-                max_loc=400, priority=Priority.ORTHOGONAL,
+                dev_branch="feat/big",
+                base_branch="main",
+                max_loc=400,
+                priority=Priority.ORTHOGONAL,
                 groups=[Group(id="pr-1", title="t", description="d")],
             ),
             git_state=GitState(
-                branches=[BranchRecord(
-                    group_id="pr-1", branch_name="pr-split/pr-1", base_branch="main",
-                )],
-                prs=[PRRecord(
-                    group_id="pr-1", pr_number=1, pr_url="https://example.com/1",
-                )],
+                branches=[
+                    BranchRecord(
+                        group_id="pr-1",
+                        branch_name="pr-split/pr-1",
+                        base_branch="main",
+                    )
+                ],
+                prs=[
+                    PRRecord(
+                        group_id="pr-1",
+                        pr_number=1,
+                        pr_url="https://example.com/1",
+                    )
+                ],
             ),
         )
         json_str = plan_file.model_dump_json()
@@ -112,8 +132,10 @@ class TestPlanFile:
     def test_default_git_state(self) -> None:
         plan_file = PlanFile(
             plan=SplitPlan(
-                dev_branch="feat/x", base_branch="main",
-                max_loc=200, priority=Priority.LOGICAL,
+                dev_branch="feat/x",
+                base_branch="main",
+                max_loc=200,
+                priority=Priority.LOGICAL,
             )
         )
         assert plan_file.git_state.branches == []
@@ -123,8 +145,11 @@ class TestPlanFile:
 class TestGroupPatchHashEdge:
     def test_explicit_hash_not_overwritten(self) -> None:
         g = Group(
-            id="pr-1", title="t", description="d",
-            expected_patch="content", expected_patch_sha256="custom_hash",
+            id="pr-1",
+            title="t",
+            description="d",
+            expected_patch="content",
+            expected_patch_sha256="custom_hash",
         )
         assert g.expected_patch_sha256 == "custom_hash"
 

--- a/tests/test_types_defs.py
+++ b/tests/test_types_defs.py
@@ -13,8 +13,15 @@ from pr_split.types_defs import (
 
 class TestHunkInfo:
     def test_fields(self) -> None:
-        h = HunkInfo(index=0, source_start=1, source_length=5,
-                     target_start=1, target_length=7, added_lines=3, removed_lines=1)
+        h = HunkInfo(
+            index=0,
+            source_start=1,
+            source_length=5,
+            target_start=1,
+            target_length=7,
+            added_lines=3,
+            removed_lines=1,
+        )
         assert h.index == 0
         assert h.source_start == 1
         assert h.added_lines == 3
@@ -41,8 +48,13 @@ class TestHunkRef:
 class TestFileSummary:
     def test_dict_access(self) -> None:
         fs: FileSummary = {
-            "path": "test.py", "added": 10, "removed": 5,
-            "is_new": True, "is_deleted": False, "is_renamed": False, "hunk_count": 2,
+            "path": "test.py",
+            "added": 10,
+            "removed": 5,
+            "is_new": True,
+            "is_deleted": False,
+            "is_renamed": False,
+            "hunk_count": 2,
         }
         assert fs["path"] == "test.py"
         assert fs["added"] == 10
@@ -51,8 +63,11 @@ class TestFileSummary:
 class TestDiffStats:
     def test_dict_access(self) -> None:
         ds: DiffStats = {
-            "total_files": 3, "total_added": 20, "total_removed": 5,
-            "total_loc": 25, "file_summaries": [],
+            "total_files": 3,
+            "total_added": 20,
+            "total_removed": 5,
+            "total_loc": 25,
+            "file_summaries": [],
         }
         assert ds["total_files"] == 3
         assert ds["total_loc"] == 25
@@ -61,16 +76,20 @@ class TestDiffStats:
 class TestForkPRInfo:
     def test_dict_access(self) -> None:
         info: ForkPRInfo = {
-            "pr_number": 42, "local_ref": "refs/pr-split/pr-42",
-            "base_branch": "main", "author": "Jane <jane@x.com>",
+            "pr_number": 42,
+            "local_ref": "refs/pr-split/pr-42",
+            "base_branch": "main",
+            "author": "Jane <jane@x.com>",
             "fork_full_name": "jane/repo",
         }
         assert info["pr_number"] == 42
 
     def test_pr_number_none(self) -> None:
         info: ForkPRInfo = {
-            "pr_number": None, "local_ref": "refs/pr-split/fork-user-branch",
-            "base_branch": "main", "author": "User <u@x.com>",
+            "pr_number": None,
+            "local_ref": "refs/pr-split/fork-user-branch",
+            "base_branch": "main",
+            "author": "User <u@x.com>",
             "fork_full_name": "user/repo",
         }
         assert info["pr_number"] is None

--- a/tests/test_validator_extended.py
+++ b/tests/test_validator_extended.py
@@ -34,12 +34,18 @@ def _ga(path: str, atype: AssignmentType, indices: list[int]) -> GroupAssignment
 
 
 def _make_group(
-    gid: str, assignments: list[GroupAssignment], loc: int,
+    gid: str,
+    assignments: list[GroupAssignment],
+    loc: int,
     depends_on: list[str] | None = None,
 ) -> Group:
     return Group(
-        id=gid, title=gid, description=gid,
-        depends_on=depends_on or [], assignments=assignments, estimated_loc=loc,
+        id=gid,
+        title=gid,
+        description=gid,
+        depends_on=depends_on or [],
+        assignments=assignments,
+        estimated_loc=loc,
     )
 
 


### PR DESCRIPTION
## Summary
- Reformat the 22 files that failed `ruff format --check` (no logic changes; 444 tests pass)
- Add a `ruff format --check` step to `.github/workflows/ci.yml` so formatting drift is caught on every PR

## Test plan
- [x] `uv run ruff check` clean
- [x] `uv run ruff format --check` clean
- [x] `uv run pytest -q` — 444 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized code formatting across application, scripts, and tests.
  - Added automated formatting verification to continuous integration.

- **Tests**
  - Updated test formatting for consistency without changing coverage, assertions, or behavior.

- **Refactor**
  - Improved readability and consistency of error messages, logging, command invocations, and data construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->