### PR TITLE
chore: clean up .gitignore entries left by tampered merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,5 @@ build/
 .mypy_cache/
 .ruff_cache/
 .pytest_cache/
-branch_structure.json
-temp_auto_push.bat
-temp_interactive_push.bat
-.gitignore
+.vscode/
+.idea/


### PR DESCRIPTION
## Summary
- The rewritten merge commit `b187f10` appended four lines to `.gitignore` that exist in neither parent: a self-ignore rule (`.gitignore`), two Windows push scripts, and `branch_structure.json`. Remove them.
- Ignore `.vscode/` and `.idea/` so editor configs (the vector used for the injected auto-run task) can't be committed by accident.

## Test plan
- [x] `git check-ignore .vscode/tasks.json` matches; nothing currently tracked is affected