### PR TITLE
fix: reject unknown hunks and dependencies during plan validation

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -1064,6 +1064,10 @@ def execute(
     parsed_diff = parse_diff(plan.raw_diff)
 
     try:
+        # Building the DAG rejects unknown dependency ids; do it here so a
+        # malformed saved plan fails before any branch is created.
+        dag = PlanDAG(plan.groups)
+        dag.validate_acyclic()
         validate_coverage(plan.groups, parsed_diff)
     except PlanValidationError as exc:
         console.print(f"[red]{exc}[/red]")

--- a/pr_split/exceptions.py
+++ b/pr_split/exceptions.py
@@ -14,6 +14,8 @@ class ErrorMsg(StrEnum):
     CYCLE_DETECTED = "Dependency cycle detected in split plan"
     COVERAGE_GAP = "Hunk {file}[{index}] not assigned to any group"
     COVERAGE_OVERLAP = "Hunk {file}[{index}] assigned to multiple groups: {groups}"
+    UNKNOWN_HUNK = "Hunk {file}[{index}] assigned to group '{group}' does not exist in the diff"
+    UNKNOWN_DEPENDENCY = "Group '{group}' depends on unknown group '{dep}'"
     LOC_MISMATCH = "Total LOC {actual} does not match diff LOC {expected}"
     MERGE_CONFLICT = "Groups '{a}' and '{b}' modify overlapping regions in '{file}'"
     NO_PLAN = "No split plan found; run 'pr-split split' first"

--- a/pr_split/exceptions.py
+++ b/pr_split/exceptions.py
@@ -15,6 +15,7 @@ class ErrorMsg(StrEnum):
     COVERAGE_GAP = "Hunk {file}[{index}] not assigned to any group"
     COVERAGE_OVERLAP = "Hunk {file}[{index}] assigned to multiple groups: {groups}"
     UNKNOWN_HUNK = "Hunk {file}[{index}] assigned to group '{group}' does not exist in the diff"
+    UNKNOWN_FILE = "File '{file}' assigned to group '{group}' does not exist in the diff"
     UNKNOWN_DEPENDENCY = "Group '{group}' depends on unknown group '{dep}'"
     LOC_MISMATCH = "Total LOC {actual} does not match diff LOC {expected}"
     MERGE_CONFLICT = "Groups '{a}' and '{b}' modify overlapping regions in '{file}'"

--- a/pr_split/graph.py
+++ b/pr_split/graph.py
@@ -15,6 +15,8 @@ class PlanDAG:
         self._parents: dict[str, list[str]] = {g.id: list(g.depends_on) for g in groups}
         for g in groups:
             for dep in g.depends_on:
+                if dep not in self._groups:
+                    raise PlanValidationError(ErrorMsg.UNKNOWN_DEPENDENCY(group=g.id, dep=dep))
                 self._children[dep].append(g.id)
 
     def _build_sorter(self) -> TopologicalSorter[str]:

--- a/pr_split/planner/validator.py
+++ b/pr_split/planner/validator.py
@@ -14,6 +14,10 @@ def validate_coverage(groups: list[Group], parsed_diff: ParsedDiff) -> None:
     assigned: dict[tuple[str, int], list[str]] = {}
     for group in groups:
         for assignment in group.assignments:
+            if assignment.file_path not in hunk_counts:
+                raise PlanValidationError(
+                    ErrorMsg.UNKNOWN_FILE(file=assignment.file_path, group=group.id)
+                )
             # A WHOLE_FILE assignment claims every hunk of the file even when
             # its hunk_indices list was left empty.
             if assignment.assignment_type is AssignmentType.WHOLE_FILE:

--- a/pr_split/planner/validator.py
+++ b/pr_split/planner/validator.py
@@ -26,6 +26,12 @@ def validate_coverage(groups: list[Group], parsed_diff: ParsedDiff) -> None:
 
     all_hunks = {(pf.path, i) for pf in parsed_diff.patch_set for i in range(len(pf))}
 
+    for key, group_ids in assigned.items():
+        if key not in all_hunks:
+            raise PlanValidationError(
+                ErrorMsg.UNKNOWN_HUNK(file=key[0], index=key[1], group=group_ids[0])
+            )
+
     for key in all_hunks:
         if key not in assigned:
             raise PlanValidationError(ErrorMsg.COVERAGE_GAP(file=key[0], index=key[1]))

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -583,6 +583,36 @@ class TestExecuteCommand:
         result = runner.invoke(app, ["execute"])
         assert result.exit_code != 0
 
+    @patch("pr_split.cli._create_branches_and_commits")
+    @patch("pr_split.cli.check_gh_auth", return_value=True)
+    @patch("pr_split.cli.is_worktree_clean", return_value=True)
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_execute_rejects_unknown_dependency_before_branch_creation(
+        self,
+        mock_pe: MagicMock,
+        mock_load: MagicMock,
+        mock_be: MagicMock,
+        mock_clean: MagicMock,
+        mock_auth: MagicMock,
+        mock_create: MagicMock,
+    ) -> None:
+        mock_plan_file = MagicMock()
+        mock_plan_file.git_state.branches = []
+        mock_plan_file.git_state.prs = []
+        plan = mock_plan_file.plan
+        plan.raw_diff = "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n@@ -1 +1 @@\n-x\n+y\n"
+        plan.merge_base_sha = "abc123"
+        plan.base_branch = "main"
+        plan.stacked = False
+        plan.groups = [_group("pr-1", "a", files=["a.py"]), _group("pr-2", "b", ["ghost"])]
+        mock_load.return_value = mock_plan_file
+        result = runner.invoke(app, ["execute"])
+        assert result.exit_code == 1
+        assert "depends on unknown group 'ghost'" in result.output
+        mock_create.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # status command

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -38,6 +38,10 @@ class TestPlanDAG:
         with pytest.raises(PlanValidationError):
             dag.validate_acyclic()
 
+    def test_unknown_dependency_raises(self) -> None:
+        with pytest.raises(PlanValidationError, match="'b' depends on unknown group 'zzz'"):
+            PlanDAG([_group("a"), _group("b", ["zzz"])])
+
     def test_acyclic_passes(self) -> None:
         groups = [_group("a"), _group("b", ["a"])]
         dag = PlanDAG(groups)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -95,7 +95,18 @@ class TestValidateCoverage:
             _make_group("g1", [_ga("a.py", WHOLE, [0]), _ga("ghost.py", PARTIAL, [0])], 3),
             _make_group("g2", [_ga("b.py", WHOLE, [0])], 4),
         ]
-        with pytest.raises(PlanValidationError, match=r"ghost\.py\[0\]"):
+        with pytest.raises(PlanValidationError, match=r"File 'ghost\.py' assigned to group 'g1'"):
+            validate_coverage(groups, parsed)
+
+    def test_unknown_whole_file_path_raises(self) -> None:
+        # A WHOLE_FILE assignment for a path outside the diff expands to zero
+        # hunks, so it must be rejected before expansion.
+        parsed = parse_diff(SAMPLE_DIFF)
+        groups = [
+            _make_group("g1", [_ga("a.py", WHOLE, []), _ga("ghost.py", WHOLE, [])], 3),
+            _make_group("g2", [_ga("b.py", WHOLE, [])], 4),
+        ]
+        with pytest.raises(PlanValidationError, match=r"File 'ghost\.py' assigned to group 'g1'"):
             validate_coverage(groups, parsed)
 
     def test_duplicate_assignment_raises(self) -> None:

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -80,6 +80,24 @@ class TestValidateCoverage:
         with pytest.raises(PlanValidationError, match="not assigned"):
             validate_coverage(groups, parsed)
 
+    def test_out_of_range_hunk_index_raises(self) -> None:
+        parsed = parse_diff(SAMPLE_DIFF)
+        groups = [
+            _make_group("g1", [_ga("a.py", PARTIAL, [0, 7])], 3),
+            _make_group("g2", [_ga("b.py", WHOLE, [0])], 4),
+        ]
+        with pytest.raises(PlanValidationError, match=r"a\.py\[7\] assigned to group 'g1'"):
+            validate_coverage(groups, parsed)
+
+    def test_unknown_file_raises(self) -> None:
+        parsed = parse_diff(SAMPLE_DIFF)
+        groups = [
+            _make_group("g1", [_ga("a.py", WHOLE, [0]), _ga("ghost.py", PARTIAL, [0])], 3),
+            _make_group("g2", [_ga("b.py", WHOLE, [0])], 4),
+        ]
+        with pytest.raises(PlanValidationError, match=r"ghost\.py\[0\]"):
+            validate_coverage(groups, parsed)
+
     def test_duplicate_assignment_raises(self) -> None:
         parsed = parse_diff(SAMPLE_DIFF)
         groups = [


### PR DESCRIPTION
## Summary
Two ways a malformed plan (e.g. from the LLM backend) escaped validation and crashed later:

- **Out-of-range hunk index** — `validate_coverage` only checked that every real hunk was assigned exactly once; an assignment like `hunk_indices: [0, 7]` on a 1-hunk file passed, then `apply_hunks` raised a bare `IndexError` in a worker thread during branch creation. Now raises `PlanValidationError` (`UNKNOWN_HUNK`), also covering files not in the diff.
- **Unknown `depends_on` id** — `PlanDAG.__init__` raised a raw `KeyError`. Now raises `PlanValidationError` (`UNKNOWN_DEPENDENCY`).

Both fire before any git state is touched.

## Test plan
- [x] New tests: out-of-range index, unknown file, unknown dependency
- [x] `uv run ruff check` clean
- [x] `uv run pytest -q` — 447 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation for unknown files, hunks, and dependencies in saved plans.
  - Detects dependency cycles and invalid references before creating branches.
  - Provides clearer error messages for plan-validation failures.
- **Tests**
  - Added coverage for invalid dependencies, files, and hunk references.
  - Verified invalid plans are rejected before any branches or commits are created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->