### PR TITLE
fix: pin git diff output format so user config cannot break parsing

### DIFF
--- a/pr_split/diff_ops/parser.py
+++ b/pr_split/diff_ops/parser.py
@@ -11,11 +11,28 @@ from .. import logs
 from ..exceptions import DiffParseError, GitOperationError
 from ..types_defs import DiffStats, FileSummary, HunkInfo
 
+# Flags that pin the diff to the exact unified format the parser and
+# reconstructor expect, regardless of the user's git config:
+#   --no-color / --no-ext-diff  plain unified output, never an external tool
+#   --no-renames                renames become delete + add; the reconstructor
+#                               resolves base content by path, so a rename
+#                               reported under its new name would fail
+#   -U3 and fixed prefixes      override diff.context and diff.mnemonicPrefix,
+#                               which would shift hunk positions and paths
+DIFF_ARGS: tuple[str, ...] = (
+    "--no-color",
+    "--no-ext-diff",
+    "--no-renames",
+    "-U3",
+    "--src-prefix=a/",
+    "--dst-prefix=b/",
+)
+
 
 def extract_diff(dev_branch: str, base_branch: str) -> str:
     logger.info(logs.EXTRACTING_DIFF.format(base=base_branch, dev=dev_branch))
     result = subprocess.run(
-        ["git", "diff", f"{base_branch}...{dev_branch}"],
+        ["git", "diff", *DIFF_ARGS, f"{base_branch}...{dev_branch}"],
         capture_output=True,
         text=True,
     )

--- a/pr_split/diff_ops/parser.py
+++ b/pr_split/diff_ops/parser.py
@@ -14,6 +14,8 @@ from ..types_defs import DiffStats, FileSummary, HunkInfo
 # Flags that pin the diff to the exact unified format the parser and
 # reconstructor expect, regardless of the user's git config:
 #   --no-color / --no-ext-diff  plain unified output, never an external tool
+#   --no-textconv               hunks must be raw blob content, since the
+#                               reconstructor applies them to git show output
 #   --no-renames                renames become delete + add; the reconstructor
 #                               resolves base content by path, so a rename
 #                               reported under its new name would fail
@@ -22,6 +24,7 @@ from ..types_defs import DiffStats, FileSummary, HunkInfo
 DIFF_ARGS: tuple[str, ...] = (
     "--no-color",
     "--no-ext-diff",
+    "--no-textconv",
     "--no-renames",
     "-U3",
     "--src-prefix=a/",

--- a/tests/test_diff_parser_extended.py
+++ b/tests/test_diff_parser_extended.py
@@ -107,6 +107,7 @@ class TestExtractDiffSubprocess:
                 "diff",
                 "--no-color",
                 "--no-ext-diff",
+                "--no-textconv",
                 "--no-renames",
                 "-U3",
                 "--src-prefix=a/",

--- a/tests/test_diff_parser_extended.py
+++ b/tests/test_diff_parser_extended.py
@@ -102,7 +102,17 @@ class TestExtractDiffSubprocess:
         result = extract_diff("feature", "main")
         assert result == EXTRACT_DIFF_SAMPLE
         mock_run.assert_called_once_with(
-            ["git", "diff", "main...feature"],
+            [
+                "git",
+                "diff",
+                "--no-color",
+                "--no-ext-diff",
+                "--no-renames",
+                "-U3",
+                "--src-prefix=a/",
+                "--dst-prefix=b/",
+                "main...feature",
+            ],
             capture_output=True,
             text=True,
         )


### PR DESCRIPTION
## Summary
`extract_diff` ran a bare `git diff base...dev`, inheriting the user's git config. Confirmed failures:

- **Renames** — git reports a rename under its new path; `_get_base_file_content` then runs `git show <merge-base>:<new-name>` and fails with `GitOperationError`, aborting the split after the LLM call. Pure renames also passed coverage vacuously and never deleted the old file. With `--no-renames` a rename becomes delete + add, which the reconstructor already handles.
- **`diff.mnemonicPrefix=true`** — paths come out as `i/foo.py`, so assignments never match `git show` paths.
- **`diff.context=0`** — zero-length source hunks are mis-placed by `apply_hunks`.
- **`diff.external` / `color.ui=always`** — output is not a parseable unified diff.

Now pinned: `--no-color --no-ext-diff --no-renames -U3 --src-prefix=a/ --dst-prefix=b/`.

Verified in a scratch repo with all of the above set: the diff parses, and a renamed+edited file appears as `old.py` (removed) + `new.py` (added).

## Test plan
- [x] Updated `test_extract_diff_success` for the new argv
- [x] `uv run ruff check` clean
- [x] `uv run pytest -q` — 444 passed