### PR TITLE
fix: preserve missing trailing newline when reconstructing files

### DIFF
--- a/pr_split/diff_ops/reconstructor.py
+++ b/pr_split/diff_ops/reconstructor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import subprocess
 
 from loguru import logger
-from unidiff import PatchedFile
+from unidiff import Hunk, PatchedFile
 
 from .. import logs
 from ..constants import AssignmentType
@@ -70,6 +70,33 @@ def _get_base_file_content(file_path: str, ref: str) -> str:
     return result.stdout
 
 
+NO_NEWLINE_MARKER = "\\"
+
+
+def _hunk_target_lines(hunk: Hunk) -> list[str]:
+    """Return the post-image lines of a hunk with their exact line endings.
+
+    unidiff always attaches a newline to a line's value, and reports a
+    missing trailing newline as a separate ``\\ No newline at end of file``
+    marker following that line. Honour the marker so a file that ends
+    without a newline is reconstructed byte-for-byte.
+    """
+    target: list[str] = []
+    last_was_target = False
+    for line in hunk:
+        if line.is_added or line.is_context:
+            value = line.value
+            target.append(value if value.endswith("\n") else value + "\n")
+            last_was_target = True
+        elif line.line_type == NO_NEWLINE_MARKER:
+            if last_was_target:
+                target[-1] = target[-1].rstrip("\n")
+            last_was_target = False
+        else:
+            last_was_target = False
+    return target
+
+
 def apply_hunks(base_content: str, patch_file: PatchedFile, assigned_indices: list[int]) -> str:
     lines = base_content.splitlines(keepends=True)
     sorted_indices = sorted(assigned_indices, reverse=True)
@@ -77,9 +104,7 @@ def apply_hunks(base_content: str, patch_file: PatchedFile, assigned_indices: li
         hunk = patch_file[idx]
         start = hunk.source_start - 1
         end = start + hunk.source_length
-        target_lines = [str(line)[1:] for line in hunk if line.is_added or line.is_context]
-        target_with_endings = [ln if ln.endswith("\n") else ln + "\n" for ln in target_lines]
-        lines[start:end] = target_with_endings
+        lines[start:end] = _hunk_target_lines(hunk)
     return "".join(lines)
 
 
@@ -103,16 +128,8 @@ def materialize_group_files(
                     indices = all_indices
                 case AssignmentType.PARTIAL_HUNKS:
                     indices = assignment.hunk_indices
-            target_lines = []
-            for idx in indices:
-                hunk = patch_file[idx]
-                for line in hunk:
-                    if line.is_added or line.is_context:
-                        target_lines.append(str(line)[1:])
-            # Lines from unidiff keep their trailing newline, so they are
-            # concatenated as-is; joining on "\n" double-spaces the file.
             result[assignment.file_path] = "".join(
-                ln if ln.endswith("\n") else ln + "\n" for ln in target_lines
+                "".join(_hunk_target_lines(patch_file[idx])) for idx in indices
             )
             continue
         base_content = _get_base_file_content(assignment.file_path, ref)

--- a/tests/test_reconstructor.py
+++ b/tests/test_reconstructor.py
@@ -379,3 +379,74 @@ class TestAddedFileLineEndings:
         )
         result = materialize_group_files(parsed, group, "abc123")
         assert result["new_file.py"] == 'def hello():\n    return "world"\n\n'
+
+
+class TestMissingTrailingNewline:
+    NO_EOL_PATCH = """\
+--- a/f.txt
++++ b/f.txt
+@@ -1,2 +1,2 @@
+ a
+-b
+\\ No newline at end of file
++c
+\\ No newline at end of file
+"""
+
+    def test_existing_file_keeps_missing_trailing_newline(self) -> None:
+        patch_file = PatchSet(self.NO_EOL_PATCH)[0]
+        assert apply_hunks("a\nb", patch_file, [0]) == "a\nc"
+
+    def test_newline_added_when_dev_branch_adds_one(self) -> None:
+        patch = """\
+--- a/f.txt
++++ b/f.txt
+@@ -1,2 +1,2 @@
+ a
+-b
+\\ No newline at end of file
++b
+"""
+        patch_file = PatchSet(patch)[0]
+        assert apply_hunks("a\nb", patch_file, [0]) == "a\nb\n"
+
+    def test_marker_after_removed_line_does_not_strip_target(self) -> None:
+        patch = """\
+--- a/f.txt
++++ b/f.txt
+@@ -1,2 +1,2 @@
+ a
++c
+-b
+\\ No newline at end of file
+"""
+        patch_file = PatchSet(patch)[0]
+        assert apply_hunks("a\nb", patch_file, [0]) == "a\nc\n"
+
+    def test_new_file_without_trailing_newline(self) -> None:
+        diff = """\
+diff --git a/n.txt b/n.txt
+new file mode 100644
+--- /dev/null
++++ b/n.txt
+@@ -0,0 +1,2 @@
++x
++y
+\\ No newline at end of file
+"""
+        parsed = parse_diff(diff)
+        group = Group(
+            id="g",
+            title="g",
+            description="g",
+            depends_on=[],
+            assignments=[
+                GroupAssignment(
+                    file_path="n.txt",
+                    assignment_type=AssignmentType.WHOLE_FILE,
+                    hunk_indices=[0],
+                )
+            ],
+            estimated_loc=2,
+        )
+        assert materialize_group_files(parsed, group, "base")["n.txt"] == "x\ny"


### PR DESCRIPTION
## Summary
`apply_hunks` and the added-file path in `materialize_group_files` forced `\n` onto every line and dropped `\ No newline at end of file` markers. A file ending `b` (no EOL) changed to `c` (no EOL) was reconstructed as `a\nc\n`, so the sub-PR commit differed from the dev branch and the final merged tree was not the original change.

Both paths now go through `_hunk_target_lines`, which honours the marker (`line_type == '\\'`) and strips the newline from the preceding post-image line only.

## Test plan
- [x] New tests: existing file keeps missing EOL; EOL added when the dev branch adds one; marker after a removed line does not affect the target; new file without trailing EOL
- [x] `uv run ruff check` / `ruff format --check` clean
- [x] `uv run pytest -q` — 448 passed