### PR TITLE
chore: remove dead checkout-based branch helpers

### DIFF
--- a/pr_split/git_ops/__init__.py
+++ b/pr_split/git_ops/__init__.py
@@ -5,16 +5,7 @@ from .branches import (
     branch_exists as branch_exists,
 )
 from .branches import (
-    checkout_branch as checkout_branch,
-)
-from .branches import (
-    commit_files as commit_files,
-)
-from .branches import (
     commit_files_in_dir as commit_files_in_dir,
-)
-from .branches import (
-    create_group_branch as create_group_branch,
 )
 from .branches import (
     delete_branch as delete_branch,

--- a/pr_split/git_ops/branches.py
+++ b/pr_split/git_ops/branches.py
@@ -6,7 +6,6 @@ import subprocess
 from loguru import logger
 
 from .. import logs
-from ..constants import BRANCH_PREFIX
 from ..exceptions import GitOperationError
 
 
@@ -46,25 +45,6 @@ def is_worktree_clean() -> bool:
     return all(line.startswith("??") for line in output.splitlines())
 
 
-def checkout_new_branch(name: str, start_point: str) -> None:
-    run_git("checkout", "-b", name, start_point)
-
-
-def checkout_branch(name: str) -> None:
-    run_git("checkout", name)
-
-
-def commit_files(file_paths: list[str], message: str, *, author: str | None = None) -> str:
-    run_git("add", "--", *file_paths)
-    author_args = ("--author", author) if author else ()
-    try:
-        run_git("commit", "-m", message, *author_args)
-    except GitOperationError:
-        run_git("add", "-u")
-        run_git("commit", "-m", message, *author_args)
-    return run_git("rev-parse", "HEAD")
-
-
 def push_branch(branch: str) -> None:
     logger.info(logs.PUSHING_BRANCH.format(branch=branch))
     run_git("push", "--force-with-lease", "-u", "origin", branch)
@@ -85,16 +65,6 @@ def derive_split_namespace(dev_branch_arg: str) -> str:
     raw = dev_branch_arg.split(":", 1)[1] if ":" in dev_branch_arg else dev_branch_arg.lstrip("#")
     sanitized = re.sub(r"[^a-zA-Z0-9._-]", "-", raw)
     return sanitized.strip("-")
-
-
-def create_group_branch(group_id: str, base: str, namespace: str) -> str:
-    branch_name = f"{BRANCH_PREFIX}{namespace}/{group_id}"
-    logger.info(logs.CREATING_BRANCH.format(branch=branch_name, base=base))
-    if branch_exists(branch_name):
-        checkout_branch(base)
-        run_git("branch", "-D", branch_name)
-    checkout_new_branch(branch_name, base)
-    return branch_name
 
 
 def add_worktree(path: str, branch_name: str, start_point: str) -> None:

--- a/tests/test_git_branches.py
+++ b/tests/test_git_branches.py
@@ -9,11 +9,7 @@ from pr_split.exceptions import GitOperationError
 from pr_split.git_ops.branches import (
     add_worktree,
     branch_exists,
-    checkout_branch,
-    checkout_new_branch,
-    commit_files,
     commit_files_in_dir,
-    create_group_branch,
     delete_branch,
     derive_split_namespace,
     is_worktree_clean,
@@ -79,34 +75,6 @@ class TestMergeBase:
         assert merge_base("main", "feature") == "abc123def"
 
 
-class TestCommitFiles:
-    @patch("pr_split.git_ops.branches.run_git")
-    def test_basic_commit(self, mock_git: MagicMock) -> None:
-        mock_git.side_effect = ["", "", "abc123"]
-        sha = commit_files(["file.py"], "test commit")
-        assert sha == "abc123"
-
-    @patch("pr_split.git_ops.branches.run_git")
-    def test_commit_with_author(self, mock_git: MagicMock) -> None:
-        mock_git.side_effect = ["", "", "abc123"]
-        sha = commit_files(["file.py"], "test commit", author="Jane <jane@x.com>")
-        assert sha == "abc123"
-        commit_call = mock_git.call_args_list[1]
-        assert "--author" in commit_call.args[0] or "--author" in commit_call[0]
-
-    @patch("pr_split.git_ops.branches.run_git")
-    def test_commit_fallback_on_failure(self, mock_git: MagicMock) -> None:
-        mock_git.side_effect = [
-            "",
-            GitOperationError("nothing to commit"),
-            "",
-            "",
-            "def456",
-        ]
-        sha = commit_files(["file.py"], "test commit")
-        assert sha == "def456"
-
-
 class TestPushBranch:
     @patch("pr_split.git_ops.branches.run_git")
     def test_calls_push(self, mock_git: MagicMock) -> None:
@@ -151,32 +119,6 @@ class TestDeriveSplitNamespace:
         assert "!" not in result
 
 
-class TestCreateGroupBranch:
-    @patch("pr_split.git_ops.branches.checkout_new_branch")
-    @patch("pr_split.git_ops.branches.branch_exists")
-    def test_creates_new_branch(self, mock_exists: MagicMock, mock_checkout: MagicMock) -> None:
-        mock_exists.return_value = False
-        result = create_group_branch("pr-1", "abc123", "my-feat")
-        assert result == "pr-split/my-feat/pr-1"
-        mock_checkout.assert_called_once()
-
-    @patch("pr_split.git_ops.branches.checkout_new_branch")
-    @patch("pr_split.git_ops.branches.run_git")
-    @patch("pr_split.git_ops.branches.checkout_branch")
-    @patch("pr_split.git_ops.branches.branch_exists")
-    def test_deletes_existing_branch(
-        self,
-        mock_exists: MagicMock,
-        mock_checkout: MagicMock,
-        mock_run_git: MagicMock,
-        mock_checkout_new: MagicMock,
-    ) -> None:
-        mock_exists.return_value = True
-        mock_run_git.return_value = ""
-        create_group_branch("pr-1", "abc123", "my-feat")
-        mock_run_git.assert_called_once_with("branch", "-D", "pr-split/my-feat/pr-1")
-
-
 class TestRunGitExtended:
     @patch("pr_split.git_ops.branches.subprocess.run")
     def test_strips_trailing_whitespace(self, mock_run: MagicMock) -> None:
@@ -218,20 +160,6 @@ class TestIsWorktreeCleanExtended:
     def test_renamed_file_is_dirty(self, mock_git: MagicMock) -> None:
         mock_git.return_value = "R  old.py -> new.py"
         assert is_worktree_clean() is False
-
-
-class TestCheckoutWrappers:
-    @patch("pr_split.git_ops.branches.run_git")
-    def test_checkout_new_branch_args(self, mock_git: MagicMock) -> None:
-        mock_git.return_value = ""
-        checkout_new_branch("feature/x", "abc123")
-        mock_git.assert_called_once_with("checkout", "-b", "feature/x", "abc123")
-
-    @patch("pr_split.git_ops.branches.run_git")
-    def test_checkout_branch_args(self, mock_git: MagicMock) -> None:
-        mock_git.return_value = ""
-        checkout_branch("main")
-        mock_git.assert_called_once_with("checkout", "main")
 
 
 class TestRunGitInDir:


### PR DESCRIPTION
## Summary
`create_group_branch`, `checkout_new_branch`, `checkout_branch` and `commit_files` in `git_ops/branches.py` have no callers — they were the pre-worktree path that ran `git checkout` in the user's working tree. Branch creation now happens in isolated worktrees (`add_worktree` / `commit_files_in_dir`), so these are dead code. Remove them, their `git_ops` re-exports, and their three test classes.

Net: −111 lines, no behaviour change.

## Test plan
- [x] `grep -rnw` confirms zero call sites outside the removed functions
- [x] `uv run ruff check` / `ruff format --check` clean
- [x] `uv run pytest -q` — 437 passed (9 tests for the removed functions dropped)