### PR TITLE
fix: count WHOLE_FILE assignments with empty hunk_indices everywhere

### DIFF
--- a/pr_split/diff_ops/reconstructor.py
+++ b/pr_split/diff_ops/reconstructor.py
@@ -23,13 +23,9 @@ def merge_chain_assignments(
     ancestor_hunks: dict[str, set[int]] = {}
     for ancestor in ancestors:
         for assignment in ancestor.assignments:
-            # A WHOLE_FILE assignment covers every hunk even when its
-            # hunk_indices list was left empty, so expand from the diff.
-            if assignment.assignment_type is AssignmentType.WHOLE_FILE:
-                covered = set(range(counts.get(assignment.file_path, 0)))
-                covered.update(assignment.hunk_indices)
-            else:
-                covered = set(assignment.hunk_indices)
+            # Expand exactly like the validator does: a WHOLE_FILE assignment
+            # is every parsed hunk (stale stored indices are ignored).
+            covered = set(assignment.covered_indices(counts.get(assignment.file_path, 0)))
             ancestor_hunks.setdefault(assignment.file_path, set()).update(covered)
 
     merged = []

--- a/pr_split/planner/chunker.py
+++ b/pr_split/planner/chunker.py
@@ -7,7 +7,7 @@ from loguru import logger
 from .. import logs
 from ..constants import AssignmentType, ChunkStrategy
 from ..diff_ops import ParsedDiff
-from ..exceptions import ErrorMsg
+from ..exceptions import ErrorMsg, PlanValidationError
 from ..schemas import Group, GroupAssignment
 from ..types_defs import DiffStats, FileSummary, HunkRef
 
@@ -204,7 +204,7 @@ def recompute_estimated_loc(groups: list[Group], parsed_diff: ParsedDiff) -> Non
         removed = 0
         for assignment in group.assignments:
             max_idx = file_hunk_counts.get(assignment.file_path, 0)
-            for idx in assignment.hunk_indices:
+            for idx in assignment.covered_indices(max_idx):
                 if idx >= max_idx:
                     logger.warning(
                         logs.INVALID_HUNK_INDEX.format(
@@ -224,14 +224,21 @@ def recompute_estimated_loc(groups: list[Group], parsed_diff: ParsedDiff) -> Non
 
 
 def assign_uncovered_hunks(groups: list[Group], parsed_diff: ParsedDiff) -> int:
+    hunk_counts = {pf.path: len(pf) for pf in parsed_diff.patch_set}
     assigned = {
-        (a.file_path, idx) for g in groups for a in g.assignments for idx in a.hunk_indices
+        (a.file_path, idx)
+        for g in groups
+        for a in g.assignments
+        for idx in a.covered_indices(hunk_counts.get(a.file_path, 0))
     }
 
     all_hunks = {(pf.path, i) for pf in parsed_diff.patch_set for i in range(len(pf))}
     unassigned = sorted(all_hunks - assigned)
     if not unassigned:
         return 0
+    if not groups:
+        file_path, idx = unassigned[0]
+        raise PlanValidationError(ErrorMsg.COVERAGE_GAP(file=file_path, index=idx))
 
     file_groups: dict[str, Group] = {}
     for group in groups:

--- a/pr_split/planner/validator.py
+++ b/pr_split/planner/validator.py
@@ -46,12 +46,16 @@ def validate_loc(groups: list[Group], parsed_diff: ParsedDiff) -> None:
         )
 
 
-def validate_no_conflicts(groups: list[Group], dag: PlanDAG) -> None:
+def validate_no_conflicts(
+    groups: list[Group], dag: PlanDAG, hunk_counts: dict[str, int] | None = None
+) -> None:
+    counts = hunk_counts or {}
     group_files: dict[str, dict[str, set[int]]] = {}
     for group in groups:
         file_hunks: dict[str, set[int]] = {}
         for assignment in group.assignments:
-            file_hunks.setdefault(assignment.file_path, set()).update(assignment.hunk_indices)
+            covered = assignment.covered_indices(counts.get(assignment.file_path, 0))
+            file_hunks.setdefault(assignment.file_path, set()).update(covered)
         group_files[group.id] = file_hunks
 
     group_ids = [g.id for g in groups]
@@ -140,5 +144,5 @@ def validate_plan(
     dag.validate_acyclic()
     validate_coverage(groups, parsed_diff)
     validate_loc(groups, parsed_diff)
-    validate_no_conflicts(groups, dag)
+    validate_no_conflicts(groups, dag, {pf.path: len(pf) for pf in parsed_diff.patch_set})
     return validate_loc_bounds(groups, max_loc, min_loc)

--- a/pr_split/schemas.py
+++ b/pr_split/schemas.py
@@ -15,11 +15,13 @@ class GroupAssignment(BaseModel):
     def covered_indices(self, hunk_count: int) -> list[int]:
         """Hunk indices this assignment claims for a file with ``hunk_count`` hunks.
 
-        A WHOLE_FILE assignment covers every hunk even when ``hunk_indices``
-        was left empty; PARTIAL_HUNKS covers exactly what it lists.
+        A WHOLE_FILE assignment covers every hunk of the parsed file, no more
+        and no less, whatever ``hunk_indices`` says (it may be empty, partial,
+        or carry a stale index that no longer exists); PARTIAL_HUNKS covers
+        exactly what it lists.
         """
         if self.assignment_type is AssignmentType.WHOLE_FILE:
-            return sorted(set(range(hunk_count)) | set(self.hunk_indices))
+            return list(range(hunk_count))
         return list(self.hunk_indices)
 
 

--- a/pr_split/schemas.py
+++ b/pr_split/schemas.py
@@ -12,6 +12,16 @@ class GroupAssignment(BaseModel):
     assignment_type: AssignmentType
     hunk_indices: list[int] = Field(default_factory=list)
 
+    def covered_indices(self, hunk_count: int) -> list[int]:
+        """Hunk indices this assignment claims for a file with ``hunk_count`` hunks.
+
+        A WHOLE_FILE assignment covers every hunk even when ``hunk_indices``
+        was left empty; PARTIAL_HUNKS covers exactly what it lists.
+        """
+        if self.assignment_type is AssignmentType.WHOLE_FILE:
+            return sorted(set(range(hunk_count)) | set(self.hunk_indices))
+        return list(self.hunk_indices)
+
 
 class Group(BaseModel):
     id: str

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -4,6 +4,7 @@ import pytest
 
 from pr_split.constants import AssignmentType, ChunkStrategy
 from pr_split.diff_ops.parser import parse_diff
+from pr_split.exceptions import PlanValidationError
 from pr_split.planner.chunker import (
     assign_uncovered_hunks,
     build_chunk_diff_from_hunks,
@@ -223,6 +224,15 @@ class TestRecomputeEstimatedLoc:
         assert groups[0].estimated_added == 3
         assert groups[0].estimated_removed == 0
 
+    def test_whole_file_with_empty_indices_counts_every_hunk(self) -> None:
+        parsed = parse_diff(TWO_HUNK_DIFF)
+        whole = GroupAssignment(
+            file_path="c.py", assignment_type=AssignmentType.WHOLE_FILE, hunk_indices=[]
+        )
+        groups = [_group("g1", [whole])]
+        recompute_estimated_loc(groups, parsed)
+        assert groups[0].estimated_loc == parsed.stats["total_loc"]
+
     def test_invalid_hunk_index_skipped(self) -> None:
         parsed = parse_diff(SAMPLE_DIFF)
         groups = [_group("g1", [_ga("a.py", [0, 99])])]
@@ -249,6 +259,20 @@ class TestAssignUncoveredHunks:
         ]
         count = assign_uncovered_hunks(groups, parsed)
         assert count == 0
+
+    def test_whole_file_with_empty_indices_is_fully_covered(self) -> None:
+        parsed = parse_diff(TWO_HUNK_DIFF)
+        whole = GroupAssignment(
+            file_path="c.py", assignment_type=AssignmentType.WHOLE_FILE, hunk_indices=[]
+        )
+        groups = [_group("g1", [whole])]
+        assert assign_uncovered_hunks(groups, parsed) == 0
+        assert groups[0].assignments == [whole]
+
+    def test_zero_groups_raises_validation_error(self) -> None:
+        parsed = parse_diff(SAMPLE_DIFF)
+        with pytest.raises(PlanValidationError, match=r"a\.py\[0\] not assigned"):
+            assign_uncovered_hunks([], parsed)
 
     def test_uncovered_assigned_to_file_group(self) -> None:
         parsed = parse_diff(SAMPLE_DIFF)

--- a/tests/test_reconstructor.py
+++ b/tests/test_reconstructor.py
@@ -362,6 +362,28 @@ class TestMergeChainAssignmentsCarryAncestorFiles:
         by_path = {a.file_path: a for a in merged.assignments}
         assert by_path["parent_only.py"].hunk_indices == [0]
 
+    def test_stale_whole_file_index_on_ancestor_is_not_carried(self) -> None:
+        stale = Group(
+            id="pr-1",
+            title="stale",
+            description="stale",
+            assignments=[
+                GroupAssignment(
+                    file_path="parent_only.py",
+                    assignment_type=AssignmentType.WHOLE_FILE,
+                    hunk_indices=[0, 99],
+                ),
+            ],
+        )
+        merged = merge_chain_assignments(
+            self._child(),
+            [stale],
+            hunk_counts={"parent_only.py": 1, "child.py": 1},
+            carry_ancestor_files=True,
+        )
+        by_path = {a.file_path: a for a in merged.assignments}
+        assert by_path["parent_only.py"].hunk_indices == [0]
+
 
 class TestAddedFileLineEndings:
     def test_added_file_content_is_not_double_spaced(self) -> None:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -42,6 +42,24 @@ class TestGroupAssignment:
         )
         assert assignment.assignment_type == AssignmentType.WHOLE_FILE
 
+    def test_whole_file_covers_exactly_the_parsed_range(self) -> None:
+        for stored in ([], [1], [0, 1, 2], [99]):
+            assignment = GroupAssignment(
+                file_path="hello.py",
+                assignment_type=AssignmentType.WHOLE_FILE,
+                hunk_indices=stored,
+            )
+            assert assignment.covered_indices(3) == [0, 1, 2]
+            assert assignment.hunk_indices == stored
+
+    def test_partial_hunks_cover_exactly_what_they_list(self) -> None:
+        assignment = GroupAssignment(
+            file_path="hello.py",
+            assignment_type=AssignmentType.PARTIAL_HUNKS,
+            hunk_indices=[2, 0],
+        )
+        assert assignment.covered_indices(3) == [2, 0]
+
     def test_partial_hunks_assignment(self) -> None:
         assignment = GroupAssignment(
             file_path="hello.py",

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -12,6 +12,7 @@ from pr_split.planner.validator import (
     validate_loc,
     validate_loc_bounds,
     validate_no_conflicts,
+    validate_plan,
 )
 from pr_split.schemas import Group, GroupAssignment
 
@@ -203,3 +204,16 @@ class TestValidateCoverageWholeFileExpansion:
         ]
         with pytest.raises(PlanValidationError, match="multiple groups"):
             validate_coverage(groups, parsed)
+
+    def test_stale_whole_file_index_does_not_create_a_phantom_conflict(self) -> None:
+        # a.py has exactly one hunk. g1's WHOLE_FILE assignment carries a stale
+        # index 99; an independent g2 lists the same bogus index for a.py. The
+        # only real hunk (0) is covered once, so the plan must validate: 99 is
+        # not a hunk and must not be reported as an overlapping region.
+        parsed = parse_diff(SAMPLE_DIFF)
+        groups = [
+            _make_group("g1", [_ga("a.py", WHOLE, [0, 99])], 3),
+            _make_group("g2", [_ga("b.py", WHOLE, [0]), _ga("a.py", PARTIAL, [99])], 4),
+        ]
+        dag = PlanDAG(groups)
+        assert validate_plan(groups, parsed, dag, max_loc=400) == []

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -131,6 +131,14 @@ class TestValidateNoConflicts:
         with pytest.raises(PlanValidationError, match="overlapping"):
             validate_no_conflicts(groups, dag)
 
+    def test_whole_file_with_empty_indices_conflicts_with_partial(self) -> None:
+        groups = [
+            _make_group("g1", [_ga("a.py", WHOLE, [])], 3),
+            _make_group("g2", [_ga("a.py", PARTIAL, [0])], 0),
+        ]
+        with pytest.raises(PlanValidationError, match=r"overlapping regions in 'a\.py'"):
+            validate_no_conflicts(groups, PlanDAG(groups), {"a.py": 1, "b.py": 1})
+
     def test_dependent_groups_skip_conflict_check(self) -> None:
         groups = [
             _make_group("g1", [_ga("a.py", PARTIAL, [0])], 3),


### PR DESCRIPTION
## Summary
Commit `1984630` taught `validate_coverage` and `merge_chain_assignments` to treat a `WHOLE_FILE` assignment with an empty `hunk_indices` list as full coverage, but three other consumers still iterated only `hunk_indices`:

- `recompute_estimated_loc` → such a group got `estimated_loc = 0`, so the plan passed coverage and then failed `validate_loc` with `Total LOC 0 does not match diff LOC N`
- `assign_uncovered_hunks` → the file's hunks were seen as unassigned and re-added as `PARTIAL_HUNKS`
- `validate_no_conflicts` → overlaps with a whole-file assignment were invisible

The expansion now lives in one place, `GroupAssignment.covered_indices(hunk_count)`, and all three use it (`validate_no_conflicts` gains an optional `hunk_counts` argument, passed from `validate_plan`).

Also: `assign_uncovered_hunks` raised a bare `ValueError` from `max([])` when the LLM returned zero groups in chunked mode; it now raises `PlanValidationError(COVERAGE_GAP)`.

## Test plan
- [x] New tests: whole-file LOC recompute, whole-file counts as covered, zero groups raises, whole-file vs partial conflict detected
- [x] `uv run ruff check` / `ruff format --check` clean
- [x] `uv run pytest -q` — 448 passed