### PR TITLE
fix: report cyclic plans from the planner instead of crashing

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -787,7 +787,11 @@ def split(
     except (ValidationError, ValueError) as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(1) from exc
-    groups = plan_split(parsed_diff, settings)
+    try:
+        groups = plan_split(parsed_diff, settings)
+    except PRSplitError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
 
     logger.info(logs.VALIDATING_PLAN)
     dag = PlanDAG(groups)

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -794,8 +794,14 @@ def split(
         raise typer.Exit(1) from exc
 
     logger.info(logs.VALIDATING_PLAN)
-    dag = PlanDAG(groups)
-    warnings = validate_plan(groups, parsed_diff, dag, settings.max_loc, min_loc=settings.min_loc)
+    try:
+        dag = PlanDAG(groups)
+        warnings = validate_plan(
+            groups, parsed_diff, dag, settings.max_loc, min_loc=settings.min_loc
+        )
+    except PRSplitError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
     _handle_loc_bound_warnings(warnings, strict_loc_bounds=settings.strict_loc_bounds)
     logger.success(logs.VALIDATION_PASSED)
 

--- a/pr_split/planner/client.py
+++ b/pr_split/planner/client.py
@@ -204,6 +204,16 @@ def _call_chunk_with_retry(
 
 
 def _parse_groups(raw: RawToolOutput) -> list[Group]:
+    # Malformed shapes (missing keys, bad enum values, wrong types) must
+    # surface as LLMError so the chunk retry loop and the refinement
+    # fallback can handle them; pydantic's ValidationError is a ValueError.
+    try:
+        return _parse_groups_strict(raw)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise LLMError(ErrorMsg.LLM_PARSE_ERROR(detail=f"{type(exc).__name__}: {exc}")) from exc
+
+
+def _parse_groups_strict(raw: RawToolOutput) -> list[Group]:
     groups: list[Group] = []
     for entry in raw["groups"]:
         assignments = [

--- a/pr_split/planner/scoring.py
+++ b/pr_split/planner/scoring.py
@@ -31,6 +31,7 @@ def _dag_depth(dag: PlanDAG) -> int:
 
 def score_plan(groups: list[Group], max_loc: int, min_loc: int | None = None) -> PlanMetrics:
     dag = PlanDAG(groups)
+    dag.validate_acyclic()
 
     max_group_loc = max((group.estimated_loc for group in groups), default=0)
     loc_underflow = (

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -414,3 +414,46 @@ class TestSplitMalformedLlmOutput:
         assert result.exception is None or isinstance(result.exception, SystemExit)
         assert "Failed to parse LLM response" in result.output
         mock_save_plan.assert_not_called()
+
+
+class TestSplitInvalidPlanFromPlanner:
+    @patch("pr_split.cli.save_plan")
+    @patch("pr_split.cli.plan_split")
+    @patch("pr_split.cli.extract_diff")
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_coverage_gap_is_reported_not_raised(
+        self,
+        mock_branch_exists: MagicMock,
+        mock_validate_inputs: MagicMock,
+        mock_extract_diff: MagicMock,
+        mock_plan_split: MagicMock,
+        mock_save_plan: MagicMock,
+    ) -> None:
+        mock_extract_diff.return_value = (
+            "diff --git a/f.py b/f.py\n--- a/f.py\n+++ b/f.py\n"
+            "@@ -1 +1 @@\n-a\n+b\n@@ -10 +10 @@\n-c\n+d\n"
+        )
+        only_first_hunk = Group(
+            id="pr-1",
+            title="t",
+            description="d",
+            assignments=[
+                GroupAssignment(
+                    file_path="f.py",
+                    assignment_type=AssignmentType.PARTIAL_HUNKS,
+                    hunk_indices=[0],
+                )
+            ],
+            estimated_loc=2,
+        )
+        mock_plan_split.return_value = [only_first_hunk]
+
+        result = runner.invoke(
+            app, ["split", "feature-branch", "--dry-run"], env={"ANTHROPIC_API_KEY": "sk-test"}
+        )
+
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "Hunk f.py[1] not assigned to any group" in result.output
+        mock_save_plan.assert_not_called()

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -14,7 +14,7 @@ from pr_split.cli import (
     app,
 )
 from pr_split.constants import AssignmentType
-from pr_split.exceptions import GitOperationError, PRSplitError
+from pr_split.exceptions import GitOperationError, PlanValidationError, PRSplitError
 from pr_split.git_ops.prs import get_pr_state, merge_pr
 from pr_split.schemas import (
     BranchRecord,
@@ -331,4 +331,41 @@ class TestSplitCliEnvVars:
         assert result.exit_code == 1
         assert mock_validate_plan.call_args_list[0].kwargs["min_loc"] == 50
         assert mock_validate_plan.call_args_list[1].kwargs["min_loc"] == 50
+        mock_save_plan.assert_not_called()
+
+
+class TestSplitPlannerErrors:
+    @patch("pr_split.cli.save_plan")
+    @patch("pr_split.cli.plan_split", side_effect=PlanValidationError("Dependency cycle detected"))
+    @patch("pr_split.cli.parse_diff")
+    @patch("pr_split.cli.extract_diff", return_value="diff --git a/a.py b/a.py\n")
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_planner_error_is_reported_not_raised(
+        self,
+        mock_branch_exists: MagicMock,
+        mock_validate_inputs: MagicMock,
+        mock_extract_diff: MagicMock,
+        mock_parse_diff: MagicMock,
+        mock_plan_split: MagicMock,
+        mock_save_plan: MagicMock,
+    ) -> None:
+        parsed_diff = MagicMock()
+        parsed_diff.stats = {
+            "total_files": 1,
+            "total_added": 1,
+            "total_removed": 0,
+            "total_loc": 1,
+        }
+        mock_parse_diff.return_value = parsed_diff
+
+        result = runner.invoke(
+            app,
+            ["split", "feature-branch", "--dry-run"],
+            env={"ANTHROPIC_API_KEY": "sk-test"},
+        )
+
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "Dependency cycle detected" in result.output
         mock_save_plan.assert_not_called()

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -369,3 +369,48 @@ class TestSplitPlannerErrors:
         assert result.exception is None or isinstance(result.exception, SystemExit)
         assert "Dependency cycle detected" in result.output
         mock_save_plan.assert_not_called()
+
+
+class TestSplitMalformedLlmOutput:
+    @patch("pr_split.cli.save_plan")
+    @patch("pr_split.planner.client._count_tokens", return_value=10)
+    @patch("pr_split.planner.client._call_llm")
+    @patch("pr_split.cli.extract_diff")
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_invalid_assignment_type_is_reported_not_raised(
+        self,
+        mock_branch_exists: MagicMock,
+        mock_validate_inputs: MagicMock,
+        mock_extract_diff: MagicMock,
+        mock_call_llm: MagicMock,
+        mock_count_tokens: MagicMock,
+        mock_save_plan: MagicMock,
+    ) -> None:
+        mock_extract_diff.return_value = (
+            "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n@@ -1 +1 @@\n-x\n+y\n"
+        )
+        mock_call_llm.return_value = {
+            "groups": [
+                {
+                    "id": "pr-1",
+                    "title": "t",
+                    "description": "d",
+                    "depends_on": [],
+                    "assignments": [
+                        {"file_path": "a.py", "assignment_type": "bogus", "hunk_indices": [0]}
+                    ],
+                }
+            ]
+        }
+
+        result = runner.invoke(
+            app,
+            ["split", "feature-branch", "--dry-run"],
+            env={"ANTHROPIC_API_KEY": "sk-test"},
+        )
+
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "Failed to parse LLM response" in result.output
+        mock_save_plan.assert_not_called()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -165,6 +165,53 @@ class TestParseGroupsEdgeCases:
         raw = RawToolOutput(groups=[])
         assert _parse_groups(raw) == []
 
+    @pytest.mark.parametrize(
+        ("entry", "detail"),
+        [
+            (
+                {
+                    "id": "pr-1",
+                    "title": "t",
+                    "depends_on": [],
+                    "assignments": [],
+                    "estimated_loc": 1,
+                },
+                "KeyError",
+            ),
+            (
+                {
+                    "id": "pr-1",
+                    "title": "t",
+                    "description": "d",
+                    "depends_on": [],
+                    "assignments": [
+                        {"file_path": "a.py", "assignment_type": "whole", "hunk_indices": []}
+                    ],
+                    "estimated_loc": 1,
+                },
+                "ValueError",
+            ),
+            (
+                {
+                    "id": "pr-1",
+                    "title": "t",
+                    "description": "d",
+                    "depends_on": [],
+                    "assignments": [
+                        {"file_path": "a.py", "assignment_type": "whole_file", "hunk_indices": "0"}
+                    ],
+                    "estimated_loc": 1,
+                },
+                "ValidationError",
+            ),
+        ],
+        ids=["missing-key", "bad-enum", "wrong-type"],
+    )
+    def test_malformed_entry_raises_llm_error(self, entry: dict, detail: str) -> None:
+        raw = RawToolOutput(groups=[entry])
+        with pytest.raises(LLMError, match=f"Failed to parse LLM response: {detail}"):
+            _parse_groups(raw)
+
     def test_preserves_estimated_loc(self) -> None:
         raw = RawToolOutput(
             groups=[
@@ -462,6 +509,28 @@ class TestRefinePlanWithLlm:
         groups = _undersized_groups()
         result = _refine_plan_with_llm(groups, parsed, settings, system="system")
         assert len(result) == 2
+        mock_call_llm.assert_called_once()
+
+    @patch("pr_split.planner.client._call_llm")
+    def test_refinement_falls_back_on_malformed_response(
+        self, mock_call_llm, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        parsed = parse_diff(_TWO_FILE_DIFF)
+        settings = Settings(
+            partition_strategy=PartitionStrategy.GRAPH,
+            min_loc=5,
+            max_loc=10,
+            max_refinement_iterations=3,
+        )
+        # Missing 'description' used to escape as KeyError and abort the split.
+        mock_call_llm.return_value = RawToolOutput(
+            groups=[{"id": "pr-1", "title": "t", "depends_on": [], "assignments": []}]
+        )
+        groups = _undersized_groups()
+        result = _refine_plan_with_llm(groups, parsed, settings, system="system")
+        assert result == groups
         mock_call_llm.assert_called_once()
 
     def test_no_refinement_when_min_loc_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import pytest
+
 from pr_split.constants import AssignmentType
+from pr_split.exceptions import PlanValidationError
 from pr_split.planner.scoring import score_plan
 from pr_split.schemas import Group, GroupAssignment
 
@@ -66,3 +69,18 @@ class TestScorePlan:
         metrics = score_plan(groups, 100, min_loc=50)
         assert metrics.loc_underflow == 30
         assert metrics.undersized_groups == 1
+
+
+class TestScorePlanCycles:
+    def test_cyclic_plan_raises_plan_validation_error(self) -> None:
+        groups = [
+            _group("g1", "a.py", [0], 50, depends_on=["g2"]),
+            _group("g2", "b.py", [0], 50, depends_on=["g1"]),
+        ]
+        with pytest.raises(PlanValidationError, match="cycle"):
+            score_plan(groups, 100)
+
+    def test_self_dependency_raises_plan_validation_error(self) -> None:
+        groups = [_group("g1", "a.py", [0], 50, depends_on=["g1"])]
+        with pytest.raises(PlanValidationError, match="cycle"):
+            score_plan(groups, 100)


### PR DESCRIPTION
## Problem

`plan_split` calls `score_plan` before `cli.split` ever reaches `validate_plan`. For a cyclic plan (LLM output, or the graph backend before #62) `score_plan` calls `dag.iter_ready()` / `topological_order()` and dies with a raw traceback:

```
graphlib.CycleError: ('nodes are in a cycle', ['pr-1', 'pr-2', 'pr-1'])
```

Separately, `split` never wrapped `plan_split` in a `PRSplitError` handler, so every planner failure (`LLMError` from malformed model output, the missing-`ortools` error for `cp_sat`, this cycle) was shown to the user as a traceback rather than the one-line red message every other validation path prints.

## Fix

- `score_plan` calls `dag.validate_acyclic()` first, raising `PlanValidationError(CYCLE_DETECTED)`.
- `split` wraps `plan_split` in `try/except PRSplitError`, prints the message, and exits 1.

## Tests

- `score_plan` on a two-group cycle and on a self-dependency raises `PlanValidationError`.
- `split` with a planner raising `PlanValidationError` exits 1 with the message in output and no plan saved (3 tests fail without the fix).

447 tests pass, ruff clean. Complements #62 (which stops the graph backend from producing cycles in the first place) and #48 (which validates references in `execute`).

## Follow-up (same boundary)

The *first* `validate_plan` call in `split` (before the interactive editor) was also unwrapped, so a coverage gap / overlap / LOC mismatch / cross-group conflict in the planner's own output still escaped as a `PlanValidationError` traceback. It now goes through the same red-message/exit-1 path; `test_coverage_gap_is_reported_not_raised` runs a real `split --dry-run` with a plan covering only hunk 0 of a 2-hunk file and asserts the message and no saved plan.
