### PR TITLE
fix: report unreadable plan files instead of a pydantic traceback

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -140,6 +140,14 @@ def _validate_inputs(dev_branch: str, base: str, *, dry_run: bool = False) -> No
         raise typer.Exit(1)
 
 
+def _load_plan_or_exit() -> PlanFile:
+    try:
+        return load_plan()
+    except PRSplitError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
+
+
 def _handle_loc_bound_warnings(warnings: list[str], *, strict_loc_bounds: bool) -> None:
     if strict_loc_bounds and warnings:
         console.print(f"[red]{ErrorMsg.LOC_BOUNDS_STRICT_FAILED()}[/red]")
@@ -743,7 +751,7 @@ def split(
     _validate_inputs(dev_branch, base, dry_run=dry_run)
 
     if plan_exists():
-        existing = load_plan()
+        existing = _load_plan_or_exit()
         has_git_state = existing.git_state.branches or existing.git_state.prs
         if has_git_state:
             console.print("[yellow]An existing split plan with branches/PRs was found.[/yellow]")
@@ -878,7 +886,7 @@ def status() -> None:
         console.print(ErrorMsg.NO_PLAN())
         raise typer.Exit(0)
 
-    plan_file = load_plan()
+    plan_file = _load_plan_or_exit()
     plan = plan_file.plan
     git_state = plan_file.git_state
 
@@ -951,7 +959,7 @@ def clean() -> None:
         console.print(ErrorMsg.NO_PLAN())
         raise typer.Exit(0)
 
-    plan_file = load_plan()
+    plan_file = _load_plan_or_exit()
     git_state = plan_file.git_state
 
     typer.confirm("Delete all pr-split branches and close PRs?", abort=True)
@@ -985,7 +993,7 @@ def execute(
         console.print(ErrorMsg.NO_PLAN())
         raise typer.Exit(1)
 
-    plan_file = load_plan()
+    plan_file = _load_plan_or_exit()
     plan = plan_file.plan
     if stack and not plan.stacked:
         plan = plan.model_copy(update={"stacked": True})
@@ -1125,7 +1133,7 @@ def merge_all(
         console.print(ErrorMsg.NO_PLAN())
         raise typer.Exit(0)
 
-    plan_file = load_plan()
+    plan_file = _load_plan_or_exit()
     plan = plan_file.plan
     git_state = plan_file.git_state
     pr_map = {r.group_id: r for r in git_state.prs}

--- a/pr_split/exceptions.py
+++ b/pr_split/exceptions.py
@@ -17,6 +17,9 @@ class ErrorMsg(StrEnum):
     LOC_MISMATCH = "Total LOC {actual} does not match diff LOC {expected}"
     MERGE_CONFLICT = "Groups '{a}' and '{b}' modify overlapping regions in '{file}'"
     NO_PLAN = "No split plan found; run 'pr-split split' first"
+    PLAN_LOAD_FAILED = (
+        "Cannot load split plan from '{path}': {detail}; delete it and run 'pr-split split' again"
+    )
     LLM_PARSE_ERROR = "Failed to parse LLM response: {detail}"
     BRANCH_CREATE_FAILED = "Failed to create branch '{branch}': {detail}"
     PR_CREATE_FAILED = "Failed to create PR for group '{group}': {detail}"

--- a/pr_split/plan_store.py
+++ b/pr_split/plan_store.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from loguru import logger
+from pydantic import ValidationError
 
 from . import logs
 from .constants import PLAN_DIR, PLAN_FILE
@@ -20,7 +21,10 @@ def load_plan() -> PlanFile:
     plan_path = Path(PLAN_FILE)
     if not plan_path.exists():
         raise PRSplitError(ErrorMsg.NO_PLAN())
-    plan_file = PlanFile.model_validate_json(plan_path.read_text())
+    try:
+        plan_file = PlanFile.model_validate_json(plan_path.read_text())
+    except (OSError, ValidationError) as exc:
+        raise PRSplitError(ErrorMsg.PLAN_LOAD_FAILED(path=plan_path, detail=exc)) from exc
     logger.info(logs.PLAN_LOADED.format(count=len(plan_file.plan.groups), path=plan_path))
     return plan_file
 

--- a/pr_split/plan_store.py
+++ b/pr_split/plan_store.py
@@ -23,7 +23,7 @@ def load_plan() -> PlanFile:
         raise PRSplitError(ErrorMsg.NO_PLAN())
     try:
         plan_file = PlanFile.model_validate_json(plan_path.read_text())
-    except (OSError, ValidationError) as exc:
+    except (OSError, UnicodeDecodeError, ValidationError) as exc:
         raise PRSplitError(ErrorMsg.PLAN_LOAD_FAILED(path=plan_path, detail=exc)) from exc
     logger.info(logs.PLAN_LOADED.format(count=len(plan_file.plan.groups), path=plan_path))
     return plan_file

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -332,3 +332,41 @@ class TestSplitCliEnvVars:
         assert mock_validate_plan.call_args_list[0].kwargs["min_loc"] == 50
         assert mock_validate_plan.call_args_list[1].kwargs["min_loc"] == 50
         mock_save_plan.assert_not_called()
+
+
+class TestCorruptPlanFile:
+    @pytest.mark.parametrize("command", ["status", "clean", "execute", "merge"])
+    def test_commands_report_corrupt_plan(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, command: str
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".pr-split").mkdir()
+        (tmp_path / ".pr-split" / "plan.json").write_text("{not json")
+
+        result = runner.invoke(app, [command])
+
+        assert result.exit_code == 1
+        assert "Cannot load split plan" in result.output
+        assert not isinstance(result.exception, Exception) or isinstance(
+            result.exception, SystemExit
+        )
+
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_split_reports_corrupt_plan(
+        self,
+        mock_branch_exists: MagicMock,
+        mock_validate_inputs: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".pr-split").mkdir()
+        (tmp_path / ".pr-split" / "plan.json").write_text("")
+
+        result = runner.invoke(
+            app, ["split", "feature-branch", "--dry-run"], env={"ANTHROPIC_API_KEY": "sk-test"}
+        )
+
+        assert result.exit_code == 1
+        assert "Cannot load split plan" in result.output

--- a/tests/test_plan_store.py
+++ b/tests/test_plan_store.py
@@ -106,3 +106,34 @@ class TestPlanStoreJson:
         assert raw["plan"]["priority"] == "logical"
         assert raw["plan"]["min_loc"] == 25
         assert raw["plan"]["strict_loc_bounds"] is True
+
+
+class TestPlanStoreCorruptFiles:
+    @pytest.mark.parametrize(
+        "content",
+        [
+            pytest.param("", id="empty"),
+            pytest.param("{not json", id="not-json"),
+            pytest.param('{"plan": {"dev_branch": "x"}}', id="missing-fields"),
+            pytest.param('{"plan": {"groups": []}, "git_state": {}}', id="old-schema"),
+        ],
+    )
+    def test_unreadable_plan_raises_pr_split_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, content: str
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        plan_dir = tmp_path / ".pr-split"
+        plan_dir.mkdir()
+        (plan_dir / "plan.json").write_text(content)
+        with pytest.raises(PRSplitError, match="Cannot load split plan") as excinfo:
+            load_plan()
+        assert "pr-split split" in str(excinfo.value)
+
+    def test_read_error_raises_pr_split_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".pr-split").mkdir()
+        (tmp_path / ".pr-split" / "plan.json").mkdir()
+        with pytest.raises(PRSplitError, match="Cannot load split plan"):
+            load_plan()

--- a/tests/test_plan_store.py
+++ b/tests/test_plan_store.py
@@ -129,6 +129,15 @@ class TestPlanStoreCorruptFiles:
             load_plan()
         assert "pr-split split" in str(excinfo.value)
 
+    def test_invalid_utf8_raises_pr_split_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".pr-split").mkdir()
+        (tmp_path / ".pr-split" / "plan.json").write_bytes(b'{"plan": "\xff\xfe"}')
+        with pytest.raises(PRSplitError, match="Cannot load split plan"):
+            load_plan()
+
     def test_read_error_raises_pr_split_error(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Problem

`load_plan` calls `PlanFile.model_validate_json` unguarded and none of the five callers (`split`, `status`, `clean`, `execute`, `merge`) catch anything around it. Any `.pr-split/plan.json` that isn't a valid current-schema plan — empty (interrupted save), truncated, hand-edited, or written by an older pr-split before `priority`/`max_loc` were required — crashes every command with a raw pydantic traceback:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for PlanFile
  Invalid JSON: EOF while parsing a value at line 1 column 0
```

`split` is the worst case: the user cannot re-plan because the pre-existing-plan check dies before the prompt.

## Fix

- `load_plan` wraps the read+validate in `try/except (OSError, ValidationError)` and raises `PRSplitError(ErrorMsg.PLAN_LOAD_FAILED)`: `Cannot load split plan from '.pr-split/plan.json': <detail>; delete it and run 'pr-split split' again`.
- New `cli._load_plan_or_exit()` prints that message in red and exits 1; all five call sites use it.

## Tests

- `load_plan` on empty / non-JSON / missing-fields / old-schema content and on an unreadable path raises `PRSplitError` with the hint.
- `status`, `clean`, `execute`, `merge` and `split` each exit 1 with the message (no traceback) on a corrupt plan file.

454 tests pass, ruff clean.