### PR TITLE
docs: describe the wait and timeout behaviour of merge --auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Use `--auto` to queue merges behind CI checks (uses `gh pr merge --auto`):
 pr-split merge --auto
 ```
 
+`--auto` is not fire-and-forget: after queueing a batch, `merge` waits for every PR in it to reach `MERGED` before moving on to the dependent batch, polling GitHub every 10 seconds for up to 10 minutes per batch. If a PR is still unmerged when the timeout expires, or gets closed while waiting, the command stops before the dependent batch and exits 1 (webhook `exit_reason: incomplete_batch`); re-run `pr-split merge --auto` once CI has caught up to continue from where it left off.
+
 Use `--notify` to POST merge results to a webhook URL (e.g. Slack, Discord):
 
 ```bash

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -1110,7 +1110,14 @@ def _send_webhook(url: str, payload: dict[str, object]) -> None:
 )
 def merge_all(
     auto: Annotated[
-        bool, typer.Option("--auto", help="Queue merges to run after CI checks pass")
+        bool,
+        typer.Option(
+            "--auto",
+            help=(
+                "Queue merges to run after CI checks pass, waiting up to 10 minutes per "
+                "batch for them to land before merging dependent PRs"
+            ),
+        ),
     ] = False,
     notify: Annotated[
         str | None,


### PR DESCRIPTION
## Problem

README says `--auto` "queues merges behind CI checks (uses `gh pr merge --auto`)", which reads as fire-and-forget. The implementation (`_poll_for_merged`, `_AUTO_MERGE_POLL_INTERVAL = 10`, `_AUTO_MERGE_POLL_TIMEOUT = 600`) additionally blocks after each batch, polling GitHub every 10 s for up to 10 min, and if any PR is still unmerged or was closed it stops before the dependent batch and exits 1 with webhook `exit_reason: incomplete_batch`. Users wiring this into a script get an unexplained non-zero exit.

## Change

Docs only — the behaviour is correct (merging dependents before parents land would be wrong), it was just undocumented:

- README: a paragraph under `merge --auto` describing the per-batch wait, the 10 s / 10 min polling, the exit-1-on-timeout, and that re-running resumes from where it stopped.
- `--auto` option help text mentions the wait so `pr-split merge --help` matches.

No behaviour change; 444 tests pass, ruff clean.