### PR TITLE
fix: never merge a PR whose dependency was skipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Shows a table with each sub-PR's ID, title, branch, PR number, live state (OPEN/
 pr-split merge
 ```
 
-Walks the dependency DAG and merges each PR in topological order. Skips already-merged, closed, draft, review-required, or changes-requested PRs. Stops if a merge fails or a dependency wasn't merged to prevent out-of-order merges.
+Walks the dependency DAG and merges each PR in topological order. Skips already-merged, closed, draft, review-required, or changes-requested PRs, and every PR whose dependency was not merged in this run (independent subtrees still proceed). Stops if a merge fails. Exits 1 whenever a merge failed or any PR was left blocked, so re-run once the blocking PRs are ready.
 
 Use `--auto` to queue merges behind CI checks (uses `gh pr merge --auto`):
 

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -1138,12 +1138,22 @@ def merge_all(
     merged: list[str] = []
     skipped: list[str] = []
     skipped_ids: set[str] = set()
+    blocked: list[str] = []
     failed: list[str] = []
 
     stopped = False
     exited_early = False
     for batch in dag.iter_ready():
         for group_id in batch:
+            unmerged_parents = [dep for dep in dag.parents(group_id) if dep not in merged]
+            if unmerged_parents:
+                deps = ", ".join(unmerged_parents)
+                logger.warning(f"{group_id} depends on unmerged {deps}, skipping")
+                skipped_ids.add(group_id)
+                blocked.append(group_id)
+                skipped.append(f"{group_id} (dependency {deps} not merged)")
+                continue
+
             pr_record = pr_map.get(group_id)
             if not pr_record:
                 skipped_ids.add(group_id)
@@ -1227,9 +1237,20 @@ def merge_all(
         console.print(f"[yellow]Skipped ({len(skipped)}): {', '.join(skipped)}[/yellow]")
     if failed:
         console.print(f"[red]Failed ({len(failed)}): {', '.join(failed)}[/red]")
+    if blocked:
+        console.print(
+            f"[yellow]Blocked by unmerged dependencies ({len(blocked)}): "
+            f"{', '.join(blocked)}. Re-run once those PRs are merged.[/yellow]"
+        )
     if notify:
         exit_reason = (
-            "merge_error" if stopped else "incomplete_batch" if exited_early else "success"
+            "merge_error"
+            if stopped
+            else "incomplete_batch"
+            if exited_early
+            else "unmerged_dependency"
+            if blocked
+            else "success"
         )
         skipped_structured = [{"id": s.split(" (")[0], "reason": s} for s in skipped]
         _send_webhook(
@@ -1239,11 +1260,11 @@ def merge_all(
                 "merged": merged,
                 "skipped": skipped_structured,
                 "failed": failed,
-                "success": not (failed or stopped or exited_early),
+                "success": not (failed or stopped or exited_early or blocked),
                 "exit_reason": exit_reason,
             },
         )
 
-    if failed or stopped or exited_early:
+    if failed or stopped or exited_early or blocked:
         raise typer.Exit(1)
     logger.success(f"Merge complete: {len(merged)} PRs merged")

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -1145,15 +1145,6 @@ def merge_all(
     exited_early = False
     for batch in dag.iter_ready():
         for group_id in batch:
-            unmerged_parents = [dep for dep in dag.parents(group_id) if dep not in merged]
-            if unmerged_parents:
-                deps = ", ".join(unmerged_parents)
-                logger.warning(f"{group_id} depends on unmerged {deps}, skipping")
-                skipped_ids.add(group_id)
-                blocked.append(group_id)
-                skipped.append(f"{group_id} (dependency {deps} not merged)")
-                continue
-
             pr_record = pr_map.get(group_id)
             if not pr_record:
                 skipped_ids.add(group_id)
@@ -1174,6 +1165,18 @@ def merge_all(
             if state == "MERGED":
                 logger.info(f"PR #{pr_record.pr_number} ({group_id}) already merged")
                 merged.append(group_id)
+                continue
+
+            # Checked after the live state so a PR that already merged on GitHub
+            # (e.g. into a still-open parent branch) counts as merged rather
+            # than being reported as blocked.
+            unmerged_parents = [dep for dep in dag.parents(group_id) if dep not in merged]
+            if unmerged_parents:
+                deps = ", ".join(unmerged_parents)
+                logger.warning(f"{group_id} depends on unmerged {deps}, skipping")
+                skipped_ids.add(group_id)
+                blocked.append(group_id)
+                skipped.append(f"{group_id} (dependency {deps} not merged)")
                 continue
 
             if state != "OPEN":

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -437,6 +437,36 @@ class TestMergeBlockedDependencies:
     @patch("pr_split.cli.get_pr_state")
     @patch("pr_split.cli.load_plan")
     @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_already_merged_child_under_unmerged_parent_is_not_blocked(
+        self,
+        mock_exists: MagicMock,
+        mock_load: MagicMock,
+        mock_state: MagicMock,
+        mock_merge: MagicMock,
+    ) -> None:
+        groups = [
+            _group("pr-1", "draft parent", files=["a.py"]),
+            _group("pr-2", "child already merged", depends_on=["pr-1"], files=["b.py"]),
+            _group("pr-3", "grandchild", depends_on=["pr-2"], files=["c.py"]),
+        ]
+        mock_load.return_value = _plan_with_prs(groups)
+        states = {
+            1: {"state": "OPEN", "isDraft": True, "reviewDecision": None},
+            2: {"state": "MERGED", "isDraft": False, "reviewDecision": None},
+            3: {"state": "OPEN", "isDraft": False, "reviewDecision": None},
+        }
+        mock_state.side_effect = lambda n: states[n]
+
+        result = runner.invoke(app, ["merge"])
+
+        mock_merge.assert_called_once_with(3, auto=False)
+        assert "pr-2 (dependency" not in result.output
+        assert "Merged (2): pr-2, pr-3" in result.output
+
+    @patch("pr_split.cli.merge_pr")
+    @patch("pr_split.cli.get_pr_state")
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
     def test_child_of_merged_parent_merges(
         self,
         mock_exists: MagicMock,

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -332,3 +332,126 @@ class TestSplitCliEnvVars:
         assert mock_validate_plan.call_args_list[0].kwargs["min_loc"] == 50
         assert mock_validate_plan.call_args_list[1].kwargs["min_loc"] == 50
         mock_save_plan.assert_not_called()
+
+
+def _plan_with_prs(groups: list[Group]) -> MagicMock:
+    plan_file = MagicMock()
+    plan_file.plan.groups = groups
+    plan_file.git_state.prs = [
+        PRRecord(group_id=g.id, pr_number=index + 1, pr_url=f"url{index + 1}")
+        for index, g in enumerate(groups)
+    ]
+    return plan_file
+
+
+class TestMergeBlockedDependencies:
+    @patch("pr_split.cli._send_webhook")
+    @patch("pr_split.cli.merge_pr")
+    @patch("pr_split.cli.get_pr_state")
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_child_of_skipped_parent_is_not_merged(
+        self,
+        mock_exists: MagicMock,
+        mock_load: MagicMock,
+        mock_state: MagicMock,
+        mock_merge: MagicMock,
+        mock_webhook: MagicMock,
+    ) -> None:
+        groups = [
+            _group("pr-1", "parent", files=["a.py"]),
+            _group("pr-2", "child", depends_on=["pr-1"], files=["b.py"]),
+        ]
+        mock_load.return_value = _plan_with_prs(groups)
+        mock_state.side_effect = lambda n: (
+            {"state": "OPEN", "isDraft": True, "reviewDecision": "APPROVED"}
+            if n == 1
+            else {"state": "OPEN", "isDraft": False, "reviewDecision": "APPROVED"}
+        )
+
+        result = runner.invoke(app, ["merge", "--notify", "https://example.invalid/hook"])
+
+        mock_merge.assert_not_called()
+        assert result.exit_code == 1
+        assert "pr-2 (dependency pr-1 not merged)" in result.output
+        payload = mock_webhook.call_args[0][1]
+        assert payload["success"] is False
+        assert payload["exit_reason"] == "unmerged_dependency"
+
+    @patch("pr_split.cli.merge_pr")
+    @patch("pr_split.cli.get_pr_state")
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_child_of_group_without_pr_is_not_merged(
+        self,
+        mock_exists: MagicMock,
+        mock_load: MagicMock,
+        mock_state: MagicMock,
+        mock_merge: MagicMock,
+    ) -> None:
+        groups = [
+            _group("pr-1", "parent", files=["a.py"]),
+            _group("pr-2", "child", depends_on=["pr-1"], files=["b.py"]),
+        ]
+        plan_file = _plan_with_prs(groups)
+        plan_file.git_state.prs = plan_file.git_state.prs[1:]
+        mock_load.return_value = plan_file
+        mock_state.return_value = {"state": "OPEN", "isDraft": False, "reviewDecision": None}
+
+        result = runner.invoke(app, ["merge"])
+
+        mock_merge.assert_not_called()
+        assert result.exit_code == 1
+        assert "pr-2 (dependency pr-1 not merged)" in result.output
+
+    @patch("pr_split.cli.merge_pr")
+    @patch("pr_split.cli.get_pr_state")
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_independent_subtree_still_merges(
+        self,
+        mock_exists: MagicMock,
+        mock_load: MagicMock,
+        mock_state: MagicMock,
+        mock_merge: MagicMock,
+    ) -> None:
+        groups = [
+            _group("pr-1", "draft parent", files=["a.py"]),
+            _group("pr-2", "child", depends_on=["pr-1"], files=["b.py"]),
+            _group("pr-3", "independent", files=["c.py"]),
+        ]
+        mock_load.return_value = _plan_with_prs(groups)
+        mock_state.side_effect = lambda n: {
+            "state": "OPEN",
+            "isDraft": n == 1,
+            "reviewDecision": None,
+        }
+
+        result = runner.invoke(app, ["merge"])
+
+        mock_merge.assert_called_once_with(3, auto=False)
+        assert result.exit_code == 1
+        assert "Merged (1): pr-3" in result.output
+
+    @patch("pr_split.cli.merge_pr")
+    @patch("pr_split.cli.get_pr_state")
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_child_of_merged_parent_merges(
+        self,
+        mock_exists: MagicMock,
+        mock_load: MagicMock,
+        mock_state: MagicMock,
+        mock_merge: MagicMock,
+    ) -> None:
+        groups = [
+            _group("pr-1", "parent", files=["a.py"]),
+            _group("pr-2", "child", depends_on=["pr-1"], files=["b.py"]),
+        ]
+        mock_load.return_value = _plan_with_prs(groups)
+        mock_state.return_value = {"state": "OPEN", "isDraft": False, "reviewDecision": None}
+
+        result = runner.invoke(app, ["merge"])
+
+        assert [c.args[0] for c in mock_merge.call_args_list] == [1, 2]
+        assert result.exit_code == 0


### PR DESCRIPTION
## Problem

`merge` walks batches from `dag.iter_ready()` and stops a batch only when some PR was *neither merged nor skipped*. Skipped PRs are excluded from that check, so a parent skipped for any reason — draft, `REVIEW_REQUIRED`, `CHANGES_REQUESTED`, closed, no PR record, or a `get_pr_state` fetch error — did **not** block its children. With `pr-2` depending on `pr-1` and `pr-1` a draft:

```
Merged (1): pr-2
Skipped (1): pr-1 (draft)
```

`merge_pr(2)` was called, exit 0, and `pr-2` landed on the base branch without the code it depends on. README promised the opposite ("Stops if … a dependency wasn't merged").

## Fix

Before handling each group, check that every `dag.parents(group_id)` is in the `merged` set for this run. If not, skip it as `<id> (dependency <parents> not merged)`. Independent subtrees in later batches still merge. If anything was blocked the command exits 1 and prints which PRs to come back for; the webhook payload gets `success: false, exit_reason: "unmerged_dependency"`. README wording updated to match.

## Tests

- child of a draft parent → `merge_pr` never called, exit 1, webhook `unmerged_dependency`
- child of a parent with no PR record → not merged, exit 1
- draft parent + child + independent sibling → only the sibling merges, exit 1
- healthy parent + child → both merged in order, exit 0

3 of 4 fail without the fix. 448 tests pass, ruff clean.