### PR TITLE
fix: split base file content on newline only when applying hunks

### DIFF
--- a/pr_split/diff_ops/reconstructor.py
+++ b/pr_split/diff_ops/reconstructor.py
@@ -97,8 +97,24 @@ def _hunk_target_lines(hunk: Hunk) -> list[str]:
     return target
 
 
+def split_git_lines(content: str) -> list[str]:
+    """Split file content into lines the way git counts them: on ``\\n`` only.
+
+    ``str.splitlines`` also breaks on form feed, vertical tab, ``\\x1c``-``\\x1e``,
+    ``\\x85``, ``\\u2028`` and ``\\u2029``, none of which git treats as a line
+    break, so every hunk after such a character would land at the wrong offset.
+    """
+    if not content:
+        return []
+    parts = content.split("\n")
+    lines = [part + "\n" for part in parts[:-1]]
+    if parts[-1]:
+        lines.append(parts[-1])
+    return lines
+
+
 def apply_hunks(base_content: str, patch_file: PatchedFile, assigned_indices: list[int]) -> str:
-    lines = base_content.splitlines(keepends=True)
+    lines = split_git_lines(base_content)
     sorted_indices = sorted(assigned_indices, reverse=True)
     for idx in sorted_indices:
         hunk = patch_file[idx]

--- a/tests/test_reconstructor.py
+++ b/tests/test_reconstructor.py
@@ -12,6 +12,7 @@ from pr_split.diff_ops.reconstructor import (
     apply_hunks,
     materialize_group_files,
     merge_chain_assignments,
+    split_git_lines,
 )
 from pr_split.exceptions import GitOperationError
 from pr_split.schemas import Group, GroupAssignment
@@ -450,3 +451,31 @@ new file mode 100644
             estimated_loc=2,
         )
         assert materialize_group_files(parsed, group, "base")["n.txt"] == "x\ny"
+
+
+class TestSplitGitLines:
+    @pytest.mark.parametrize(
+        ("content", "expected"),
+        [
+            pytest.param("", [], id="empty"),
+            pytest.param("a\n", ["a\n"], id="one-line"),
+            pytest.param("a\nb", ["a\n", "b"], id="no-trailing-newline"),
+            pytest.param("a\x0cb\nc\n", ["a\x0cb\n", "c\n"], id="form-feed"),
+            pytest.param("a\x0bb\nc\n", ["a\x0bb\n", "c\n"], id="vertical-tab"),
+            pytest.param("a\u2028b\nc\n", ["a\u2028b\n", "c\n"], id="line-separator"),
+            pytest.param("a\x85b\n", ["a\x85b\n"], id="nel"),
+            pytest.param("a\r\nb\r\n", ["a\r\n", "b\r\n"], id="crlf"),
+            pytest.param("\n\n", ["\n", "\n"], id="blank-lines"),
+        ],
+    )
+    def test_splits_on_newline_only(self, content: str, expected: list[str]) -> None:
+        assert split_git_lines(content) == expected
+
+
+class TestApplyHunksWithSplitlinesSeparators:
+    def test_form_feed_in_earlier_line_does_not_shift_hunk(self) -> None:
+        base = "a\x0cb\n" + "".join(f"{c}\n" for c in "cdefghijkl")
+        dev = base.replace("k\n", "K\n")
+        diff = "--- a/f.txt\n+++ b/f.txt\n@@ -7,5 +7,5 @@\n h\n i\n j\n-k\n+K\n l\n"
+        pf = PatchSet(diff)[0]
+        assert apply_hunks(base, pf, [0]) == dev


### PR DESCRIPTION
## Problem

`apply_hunks` split the base file with `str.splitlines(keepends=True)`, which treats `\x0c` (form feed), `\x0b`, `\x1c`–`\x1e`, `\x85`, ` ` and ` ` as line breaks. git does not, so hunk `source_start` offsets refer to `\n`-counted lines while the slice was applied to a differently-numbered list. Any file containing one of those characters before a hunk (form feeds are common in older Python/C sources and Emacs page breaks) is silently corrupted in every sub-PR:

```
base: "a\x0cb\nc\nd\n…\nk\nl\n", dev changes k→K
materialized: 'a\x0cb\nc\nd\ne\nf\nh\ni\nj\nK\nl\nl\n'   # 'g' lost, 'l' duplicated
```

## Fix

`split_git_lines(content)` splits on `\n` only (keeping the terminator, handling a missing trailing newline and empty content), and `apply_hunks` uses it.

## Tests

- `split_git_lines` parametrised over empty / trailing-newline-less / form feed / vertical tab / U+2028 / NEL / CRLF / blank lines
- `apply_hunks` regression with a form feed on line 1 and a hunk at line 7 reconstructs the dev content exactly

458 tests pass, ruff clean.

Stacked on #50 (`fix/preserve-missing-trailing-newline`) because both edit `apply_hunks`; retargets `main` when #50 merges.