### PR TITLE
fix: raise PRSplitError for chunking failures

### DIFF
--- a/pr_split/planner/chunker.py
+++ b/pr_split/planner/chunker.py
@@ -7,7 +7,7 @@ from loguru import logger
 from .. import logs
 from ..constants import AssignmentType, ChunkStrategy
 from ..diff_ops import ParsedDiff
-from ..exceptions import ErrorMsg
+from ..exceptions import ErrorMsg, PRSplitError
 from ..schemas import Group, GroupAssignment
 from ..types_defs import DiffStats, FileSummary, HunkRef
 
@@ -37,7 +37,7 @@ def chunk_hunks_greedy(hunk_sequence: list[HunkRef], token_budget: int) -> list[
 
     for href in hunk_sequence:
         if href.token_estimate > token_budget:
-            raise ValueError(
+            raise PRSplitError(
                 ErrorMsg.HUNK_TOO_LARGE(
                     file=href.file_path,
                     index=href.hunk_index,
@@ -80,7 +80,7 @@ def chunk_hunks_dynamic_programming(
 
     for href in hunk_sequence:
         if href.token_estimate > token_budget:
-            raise ValueError(
+            raise PRSplitError(
                 ErrorMsg.HUNK_TOO_LARGE(
                     file=href.file_path,
                     index=href.hunk_index,
@@ -121,7 +121,7 @@ def chunk_hunks_dynamic_programming(
     while cursor > 0:
         cut = previous_cut[cursor]
         if cut < 0:
-            raise ValueError("failed to reconstruct dynamic-programming chunk plan")
+            raise PRSplitError("failed to reconstruct dynamic-programming chunk plan")
         chunks.append(hunk_sequence[cut:cursor])
         cursor = cut
 
@@ -140,7 +140,7 @@ def chunk_hunks(
         case ChunkStrategy.DYNAMIC_PROGRAMMING:
             return chunk_hunks_dynamic_programming(hunk_sequence, token_budget)
         case _:
-            raise ValueError(f"Unknown chunk strategy '{strategy}'")
+            raise PRSplitError(f"Unknown chunk strategy '{strategy}'")
 
 
 def build_chunk_diff_from_hunks(parsed_diff: ParsedDiff, hunk_refs: list[HunkRef]) -> str:

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -4,6 +4,7 @@ import pytest
 
 from pr_split.constants import AssignmentType, ChunkStrategy
 from pr_split.diff_ops.parser import parse_diff
+from pr_split.exceptions import PRSplitError
 from pr_split.planner.chunker import (
     assign_uncovered_hunks,
     build_chunk_diff_from_hunks,
@@ -120,7 +121,7 @@ class TestChunkHunks:
 
     def test_hunk_exceeding_budget_raises(self) -> None:
         refs = [HunkRef("a.py", 0, 500)]
-        with pytest.raises(ValueError, match="exceeds budget"):
+        with pytest.raises(PRSplitError, match="exceeds budget"):
             chunk_hunks(refs, 100)
 
     def test_empty_input_returns_empty(self) -> None:
@@ -145,7 +146,7 @@ class TestChunkHunks:
 
     def test_unknown_strategy_raises(self) -> None:
         refs = [HunkRef("a.py", 0, 100)]
-        with pytest.raises(ValueError, match="Unknown chunk strategy"):
+        with pytest.raises(PRSplitError, match="Unknown chunk strategy"):
             chunk_hunks(refs, 100, "invalid")
 
 
@@ -330,3 +331,11 @@ class TestFormatGroupCatalogExtended:
     def test_empty_groups(self) -> None:
         result = format_group_catalog([])
         assert result == ""
+
+
+class TestChunkerErrorsAreProjectErrors:
+    def test_oversized_hunk_is_pr_split_error_for_both_strategies(self) -> None:
+        refs = [HunkRef("a.py", 0, 500)]
+        for strategy in (ChunkStrategy.GREEDY, ChunkStrategy.DYNAMIC_PROGRAMMING):
+            with pytest.raises(PRSplitError, match=r"a\.py\[0\].*exceeds budget 100"):
+                chunk_hunks(refs, 100, strategy)


### PR DESCRIPTION
## Problem

`chunk_hunks_greedy` / `chunk_hunks_dynamic_programming` raise a bare `ValueError` when a single hunk's token estimate exceeds the per-chunk budget (`ErrorMsg.HUNK_TOO_LARGE`), and `chunk_hunks` does the same for an unknown strategy. Neither is a `PRSplitError`, so on a huge diff with one giant hunk the `split` command dies with a traceback instead of the one-line message every other planner failure gets (and #63's planner error boundary can't catch it either).

## Fix

All four raises in `pr_split/planner/chunker.py` now use `PRSplitError` (the messages are unchanged and already come from `ErrorMsg`). Tests updated and a new test asserts both strategies raise `PRSplitError` with the file/hunk/budget in the message.

445 tests pass, ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Chunking failures now consistently report the application’s standard error type.
  - Improved consistency for oversized changes, unsupported chunking strategies, and reconstruction failures.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->