### PR TITLE
fix: floor the auto-derived min_loc at 1

### DIFF
--- a/pr_split/config.py
+++ b/pr_split/config.py
@@ -59,7 +59,9 @@ class Settings(BaseSettings):
     @model_validator(mode="after")
     def auto_derive_min_loc(self):
         if self.min_loc is None and self.max_refinement_iterations > 0:
-            self.min_loc = self.max_loc // DEFAULT_MIN_LOC_RATIO
+            # Floor at 1 so a tiny max_loc cannot derive a min_loc that the
+            # explicit field constraint (ge=1) would have rejected.
+            self.min_loc = max(1, self.max_loc // DEFAULT_MIN_LOC_RATIO)
         return self
 
     @model_validator(mode="after")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -182,3 +182,24 @@ class TestSettingsEmptyKeyValidation:
         monkeypatch.setenv("OPENAI_API_KEY", "")
         with pytest.raises(ValidationError, match="OPENAI_API_KEY"):
             Settings(provider=Provider.OPENAI)
+
+
+class TestDerivedMinLocFloor:
+    @pytest.mark.parametrize("max_loc", [2, 3])
+    def test_tiny_max_loc_derives_min_loc_of_one(
+        self, monkeypatch: pytest.MonkeyPatch, max_loc: int
+    ) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        settings = Settings(max_loc=max_loc, max_refinement_iterations=1)
+        assert settings.min_loc == 1
+
+    def test_max_loc_of_one_with_refinement_is_rejected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        with pytest.raises(ValueError, match="min_loc 1 must be less than max_loc 1"):
+            Settings(max_loc=1, max_refinement_iterations=1)
+
+    def test_normal_max_loc_uses_ratio(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        assert Settings(max_loc=400, max_refinement_iterations=1).min_loc == 100


### PR DESCRIPTION
## Problem

`Settings.auto_derive_min_loc` sets `min_loc = max_loc // DEFAULT_MIN_LOC_RATIO` when refinement is enabled and `min_loc` is unset. For `max_loc < 4` that is `0`, which the explicit field constraint (`min_loc: int | None = Field(ge=1)`) would have rejected. `Settings(max_loc=3, max_refinement_iterations=1).min_loc == 0` then feeds into `detect_loc_bound_violations` / `score_plan` as a real bound.

## Fix

`max(1, max_loc // DEFAULT_MIN_LOC_RATIO)`. `max_loc=1` with refinement now fails the existing `min_loc < max_loc` check with the normal `MIN_LOC_GE_MAX_LOC` message (the CLI already reports `ValidationError`/`ValueError` from `Settings` cleanly) instead of running with `min_loc=0`.

Tests: `max_loc` 2 and 3 derive `min_loc == 1`; `max_loc=1` is rejected; `max_loc=400` still derives 100. 448 tests pass, ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured automatically calculated minimum location values never fall below the supported minimum of 1.
  * Invalid configurations with an incompatible maximum location value now continue to be rejected clearly.

* **Tests**
  * Added coverage for small and typical configuration values, including validation of invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->