### PR TITLE
fix: do not attempt LOC refinement after chunked planning

### DIFF
--- a/pr_split/logs.py
+++ b/pr_split/logs.py
@@ -59,6 +59,11 @@ REFINEMENT_RESOLVED = (
 REFINEMENT_EXHAUSTED = (
     "Refinement iteration limit reached ({iterations}), {remaining} violation(s) remain"
 )
+REFINEMENT_SKIPPED_CHUNKED = (
+    "Skipping LOC refinement: the diff exceeded the context window and was planned in"
+    " chunks, and the refinement prompt embeds the full diff; {remaining} violation(s)"
+    " remain. Adjust --min-loc/--max-loc or use the interactive editor"
+)
 STACK_LINKED = "Linked stack for PRs {prs}"
 STACK_LINK_FAILED = "Could not link stack for PRs {prs}: {detail}"
 MERGE_NODE_NOT_STACKED = (

--- a/pr_split/planner/client.py
+++ b/pr_split/planner/client.py
@@ -407,7 +407,14 @@ def _plan_split_with_llm(
         logger.warning(logs.DIFF_TOO_LARGE.format(tokens=token_count, limit=effective_limit))
         groups = _plan_split_chunked(parsed_diff, settings, system, token_count)
         logger.info(logs.LLM_RESPONSE_RECEIVED.format(count=len(groups)))
-        return _refine_plan_with_llm(groups, parsed_diff, settings, system)
+        # The refinement prompt embeds the full labeled diff, which is exactly
+        # what did not fit; sending it would fail and be swallowed as an
+        # exhausted refinement. Say so instead of wasting the call.
+        if settings.max_refinement_iterations > 0:
+            violations = detect_loc_bound_violations(groups, settings.max_loc, settings.min_loc)
+            if violations:
+                logger.warning(logs.REFINEMENT_SKIPPED_CHUNKED.format(remaining=len(violations)))
+        return groups
 
     logger.info(logs.SENDING_TO_LLM.format(model=settings.model))
     raw = _call_llm(system=system, user=user, settings=settings)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -986,3 +986,38 @@ class TestPlanSplitWithLlm:
         result = _plan_split_with_llm(parsed, settings)
         assert len(result) == 1
         mock_chunked.assert_called_once()
+
+
+class TestChunkedPlanningSkipsRefinement:
+    @patch("pr_split.planner.client._call_llm")
+    @patch("pr_split.planner.client._plan_split_chunked")
+    @patch("pr_split.planner.client._count_tokens", return_value=10**9)
+    def test_no_refinement_call_after_chunking(
+        self, mock_count: MagicMock, mock_chunked: MagicMock, mock_call: MagicMock
+    ) -> None:
+        parsed = parse_diff(_TWO_FILE_DIFF)
+        settings = _make_settings(
+            Provider.ANTHROPIC, max_refinement_iterations=2, min_loc=50, max_loc=100
+        )
+        oversized = Group(id="pr-1", title="t", description="d", estimated_loc=500)
+        mock_chunked.return_value = [oversized]
+
+        result = _plan_split_with_llm(parsed, settings)
+
+        assert result == [oversized]
+        mock_call.assert_not_called()
+
+    @patch("pr_split.planner.client._refine_plan_with_llm")
+    @patch("pr_split.planner.client._call_llm")
+    @patch("pr_split.planner.client._count_tokens", return_value=1)
+    def test_single_shot_planning_still_refines(
+        self, mock_count: MagicMock, mock_call: MagicMock, mock_refine: MagicMock
+    ) -> None:
+        parsed = parse_diff(_TWO_FILE_DIFF)
+        settings = _make_settings(Provider.ANTHROPIC, max_refinement_iterations=2)
+        mock_call.return_value = {"groups": []}
+        mock_refine.return_value = []
+
+        _plan_split_with_llm(parsed, settings)
+
+        mock_refine.assert_called_once()


### PR DESCRIPTION
## Problem

When the diff exceeds the context window, `_plan_split_with_llm` plans it in chunks and then calls `_refine_plan_with_llm`, whose prompt is built with `full_diff=parsed_diff.labeled_diff` — the very diff that just didn't fit. The API call is guaranteed to fail; the `LLMError` is caught and logged as "Refinement iteration limit reached", so `--max-refinement-iterations` is a silent no-op (plus one wasted, possibly billed, oversized request) on exactly the diffs where LOC-bound violations are most likely.

Observed via the hunt's trace with `_count_tokens` forced over the limit: `[('chunk', …), ('chunk', …), ('refine', <full diff>), ('refine', <full diff>)]`.

## Fix

In the chunked path, skip refinement. If refinement was requested and violations remain, log a warning (`REFINEMENT_SKIPPED_CHUNKED`) that says why and how many violations remain, pointing at `--min-loc`/`--max-loc` and the interactive editor. Single-shot planning is unchanged.

Sending only the violating groups' hunks would be the real feature; that is a prompt-design change and out of scope for a correctness fix.

## Tests

- chunked path with an oversized group and `max_refinement_iterations=2`: `_call_llm` never called, groups returned as-is (fails without the fix)
- single-shot path still calls `_refine_plan_with_llm`

446 tests pass, ruff clean.