### PR TITLE
fix: render multi-parent groups once in the dependency tree

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -85,10 +85,21 @@ console = Console()
 def _render_dag(groups: list[Group]) -> str:
     roots = [g for g in groups if not g.depends_on]
     tree = Tree("Split Plan")
+    # A group with several parents is rendered once, under the last parent
+    # to be visited, so a diamond does not show its merge node (and every
+    # subtree below it) once per parent.
+    rendered: set[str] = set()
+    last_parent = {g.id: g.depends_on[-1] for g in groups if g.depends_on}
 
     def _add_children(parent_tree: Tree, parent_id: str) -> None:
         children = [g for g in groups if parent_id in g.depends_on]
         for child in children:
+            if len(child.depends_on) > 1 and last_parent[child.id] != parent_id:
+                parent_tree.add(f"{child.id}: {child.title} (see below)")
+                continue
+            if child.id in rendered:
+                continue
+            rendered.add(child.id)
             deps_label = ", ".join(child.depends_on)
             branch = parent_tree.add(f"{child.id}: {child.title} (depends on: {deps_label})")
             _add_children(branch, child.id)
@@ -105,14 +116,28 @@ def _render_dag(groups: list[Group]) -> str:
 def _render_dag_markdown(groups: list[Group], current_id: str) -> str:
     roots = [g for g in groups if not g.depends_on]
     lines: list[str] = []
+    rendered: set[str] = set()
+    last_parent = {g.id: g.depends_on[-1] for g in groups if g.depends_on}
 
     def _add_children(parent_id: str, prefix: str) -> None:
         children = [g for g in groups if parent_id in g.depends_on]
         for i, child in enumerate(children):
             is_last = i == len(children) - 1
             connector = "\u2514\u2500\u2500" if is_last else "\u251c\u2500\u2500"
+            if len(child.depends_on) > 1 and last_parent[child.id] != parent_id:
+                # Merge node: drawn in full under its last parent only, so the
+                # subtree and the "<-- this PR" marker appear exactly once.
+                lines.append(f"{prefix}{connector} {child.id}: {child.title} (see below)")
+                continue
+            if child.id in rendered:
+                continue
+            rendered.add(child.id)
             marker = "  <-- this PR" if child.id == current_id else ""
-            lines.append(f"{prefix}{connector} {child.id}: {child.title}{marker}")
+            also = ""
+            if len(child.depends_on) > 1:
+                others = ", ".join(d for d in child.depends_on if d != parent_id)
+                also = f" (also depends on: {others})"
+            lines.append(f"{prefix}{connector} {child.id}: {child.title}{also}{marker}")
             extension = "    " if is_last else "\u2502   "
             _add_children(child.id, prefix + extension)
 

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -85,28 +85,28 @@ console = Console()
 def _render_dag(groups: list[Group]) -> str:
     roots = [g for g in groups if not g.depends_on]
     tree = Tree("Split Plan")
-    # A group with several parents is rendered once, under the last parent
-    # to be visited, so a diamond does not show its merge node (and every
-    # subtree below it) once per parent.
-    rendered: set[str] = set()
-    last_parent = {g.id: g.depends_on[-1] for g in groups if g.depends_on}
+    known = {g.id for g in groups}
+    # A group with several parents is drawn in full under whichever parent is
+    # visited last, so every "(see below)" stub really does point downward and
+    # the subtree appears exactly once.
+    done: set[str] = set()
 
     def _add_children(parent_tree: Tree, parent_id: str) -> None:
         children = [g for g in groups if parent_id in g.depends_on]
         for child in children:
-            if len(child.depends_on) > 1 and last_parent[child.id] != parent_id:
+            pending = [d for d in child.depends_on if d != parent_id and d in known - done]
+            if pending:
                 parent_tree.add(f"{child.id}: {child.title} (see below)")
                 continue
-            if child.id in rendered:
-                continue
-            rendered.add(child.id)
             deps_label = ", ".join(child.depends_on)
             branch = parent_tree.add(f"{child.id}: {child.title} (depends on: {deps_label})")
             _add_children(branch, child.id)
+            done.add(child.id)
 
     for root in roots:
         root_branch = tree.add(f"{root.id}: {root.title}")
         _add_children(root_branch, root.id)
+        done.add(root.id)
 
     with console.capture() as capture:
         console.print(tree)
@@ -116,22 +116,20 @@ def _render_dag(groups: list[Group]) -> str:
 def _render_dag_markdown(groups: list[Group], current_id: str) -> str:
     roots = [g for g in groups if not g.depends_on]
     lines: list[str] = []
-    rendered: set[str] = set()
-    last_parent = {g.id: g.depends_on[-1] for g in groups if g.depends_on}
+    known = {g.id for g in groups}
+    done: set[str] = set()
 
     def _add_children(parent_id: str, prefix: str) -> None:
         children = [g for g in groups if parent_id in g.depends_on]
         for i, child in enumerate(children):
             is_last = i == len(children) - 1
             connector = "\u2514\u2500\u2500" if is_last else "\u251c\u2500\u2500"
-            if len(child.depends_on) > 1 and last_parent[child.id] != parent_id:
-                # Merge node: drawn in full under its last parent only, so the
-                # subtree and the "<-- this PR" marker appear exactly once.
+            pending = [d for d in child.depends_on if d != parent_id and d in known - done]
+            if pending:
+                # Another parent is still to be drawn; the full node (with its
+                # subtree and the "<-- this PR" marker) follows under it.
                 lines.append(f"{prefix}{connector} {child.id}: {child.title} (see below)")
                 continue
-            if child.id in rendered:
-                continue
-            rendered.add(child.id)
             marker = "  <-- this PR" if child.id == current_id else ""
             also = ""
             if len(child.depends_on) > 1:
@@ -140,11 +138,13 @@ def _render_dag_markdown(groups: list[Group], current_id: str) -> str:
             lines.append(f"{prefix}{connector} {child.id}: {child.title}{also}{marker}")
             extension = "    " if is_last else "\u2502   "
             _add_children(child.id, prefix + extension)
+            done.add(child.id)
 
     for root in roots:
         marker = "  <-- this PR" if root.id == current_id else ""
         lines.append(f"{root.id}: {root.title}{marker}")
         _add_children(root.id, "")
+        done.add(root.id)
 
     tree_block = "\n".join(lines)
     return f"## Dependency graph\n\nMerge in this order:\n\n```\n{tree_block}\n```"

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -86,8 +86,8 @@ def _reachable_from_roots(groups: list[Group]) -> set[str]:
     """Ids that a root-first walk will actually visit.
 
     A group that is neither a root nor a descendant of one (unknown
-    dependency chain, cycle) is never drawn, so it must not count as a
-    parent still "pending" for stub placement.
+    dependency chain, cycle) is never drawn, so it must not count towards
+    the number of parents a child expects to be visited from.
     """
     children: dict[str, list[str]] = {g.id: [] for g in groups}
     for g in groups:
@@ -105,32 +105,37 @@ def _reachable_from_roots(groups: list[Group]) -> set[str]:
     return reachable
 
 
+def _expected_visits(groups: list[Group]) -> dict[str, int]:
+    """How many times each group will be reached from a drawn parent.
+
+    Every reachable parent is drawn in full exactly once, so a child is
+    visited once per reachable parent. It is rendered as a stub until its
+    final visit, which guarantees the full node (with its subtree and the
+    "<-- this PR" marker) appears exactly once and every stub precedes it.
+    """
+    reachable = _reachable_from_roots(groups)
+    return {g.id: sum(1 for d in g.depends_on if d in reachable) for g in groups}
+
+
 def _render_dag(groups: list[Group]) -> str:
     roots = [g for g in groups if not g.depends_on]
     tree = Tree("Split Plan")
-    known = _reachable_from_roots(groups)
-    # A group with several parents is drawn in full under whichever parent is
-    # visited last, so every "(see below)" stub really does point downward and
-    # the subtree appears exactly once.
-    done: set[str] = set()
+    expected = _expected_visits(groups)
+    seen: dict[str, int] = {g.id: 0 for g in groups}
 
     def _add_children(parent_tree: Tree, parent_id: str) -> None:
         children = [g for g in groups if parent_id in g.depends_on]
         for child in children:
-            pending = [d for d in child.depends_on if d != parent_id and d in known - done]
-            if pending:
+            seen[child.id] += 1
+            if seen[child.id] < expected[child.id]:
                 parent_tree.add(f"{child.id}: {child.title} (see below)")
                 continue
             deps_label = ", ".join(child.depends_on)
             branch = parent_tree.add(f"{child.id}: {child.title} (depends on: {deps_label})")
-            # Mark on entry: an ancestor still walking its children is not
-            # "pending" for a grandchild that also depends on it.
-            done.add(child.id)
             _add_children(branch, child.id)
 
     for root in roots:
         root_branch = tree.add(f"{root.id}: {root.title}")
-        done.add(root.id)
         _add_children(root_branch, root.id)
 
     with console.capture() as capture:
@@ -141,18 +146,18 @@ def _render_dag(groups: list[Group]) -> str:
 def _render_dag_markdown(groups: list[Group], current_id: str) -> str:
     roots = [g for g in groups if not g.depends_on]
     lines: list[str] = []
-    known = _reachable_from_roots(groups)
-    done: set[str] = set()
+    expected = _expected_visits(groups)
+    seen: dict[str, int] = {g.id: 0 for g in groups}
 
     def _add_children(parent_id: str, prefix: str) -> None:
         children = [g for g in groups if parent_id in g.depends_on]
         for i, child in enumerate(children):
             is_last = i == len(children) - 1
             connector = "\u2514\u2500\u2500" if is_last else "\u251c\u2500\u2500"
-            pending = [d for d in child.depends_on if d != parent_id and d in known - done]
-            if pending:
-                # Another parent is still to be drawn; the full node (with its
-                # subtree and the "<-- this PR" marker) follows under it.
+            seen[child.id] += 1
+            if seen[child.id] < expected[child.id]:
+                # Another parent will visit this node later; the full node
+                # (with its subtree and the "<-- this PR" marker) follows there.
                 lines.append(f"{prefix}{connector} {child.id}: {child.title} (see below)")
                 continue
             marker = "  <-- this PR" if child.id == current_id else ""
@@ -162,13 +167,11 @@ def _render_dag_markdown(groups: list[Group], current_id: str) -> str:
                 also = f" (also depends on: {others})"
             lines.append(f"{prefix}{connector} {child.id}: {child.title}{also}{marker}")
             extension = "    " if is_last else "\u2502   "
-            done.add(child.id)
             _add_children(child.id, prefix + extension)
 
     for root in roots:
         marker = "  <-- this PR" if root.id == current_id else ""
         lines.append(f"{root.id}: {root.title}{marker}")
-        done.add(root.id)
         _add_children(root.id, "")
 
     tree_block = "\n".join(lines)

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -123,13 +123,15 @@ def _render_dag(groups: list[Group]) -> str:
                 continue
             deps_label = ", ".join(child.depends_on)
             branch = parent_tree.add(f"{child.id}: {child.title} (depends on: {deps_label})")
-            _add_children(branch, child.id)
+            # Mark on entry: an ancestor still walking its children is not
+            # "pending" for a grandchild that also depends on it.
             done.add(child.id)
+            _add_children(branch, child.id)
 
     for root in roots:
         root_branch = tree.add(f"{root.id}: {root.title}")
-        _add_children(root_branch, root.id)
         done.add(root.id)
+        _add_children(root_branch, root.id)
 
     with console.capture() as capture:
         console.print(tree)
@@ -160,14 +162,14 @@ def _render_dag_markdown(groups: list[Group], current_id: str) -> str:
                 also = f" (also depends on: {others})"
             lines.append(f"{prefix}{connector} {child.id}: {child.title}{also}{marker}")
             extension = "    " if is_last else "\u2502   "
-            _add_children(child.id, prefix + extension)
             done.add(child.id)
+            _add_children(child.id, prefix + extension)
 
     for root in roots:
         marker = "  <-- this PR" if root.id == current_id else ""
         lines.append(f"{root.id}: {root.title}{marker}")
-        _add_children(root.id, "")
         done.add(root.id)
+        _add_children(root.id, "")
 
     tree_block = "\n".join(lines)
     return f"## Dependency graph\n\nMerge in this order:\n\n```\n{tree_block}\n```"

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -114,7 +114,9 @@ def _expected_visits(groups: list[Group]) -> dict[str, int]:
     "<-- this PR" marker) appears exactly once and every stub precedes it.
     """
     reachable = _reachable_from_roots(groups)
-    return {g.id: sum(1 for d in g.depends_on if d in reachable) for g in groups}
+    # A set, not a count: the walk visits a child once per distinct parent,
+    # so a duplicated depends_on entry must not raise the expected total.
+    return {g.id: len({d for d in g.depends_on if d in reachable}) for g in groups}
 
 
 def _render_dag(groups: list[Group]) -> str:
@@ -130,7 +132,7 @@ def _render_dag(groups: list[Group]) -> str:
             if seen[child.id] < expected[child.id]:
                 parent_tree.add(f"{child.id}: {child.title} (see below)")
                 continue
-            deps_label = ", ".join(child.depends_on)
+            deps_label = ", ".join(dict.fromkeys(child.depends_on))
             branch = parent_tree.add(f"{child.id}: {child.title} (depends on: {deps_label})")
             _add_children(branch, child.id)
 
@@ -162,9 +164,9 @@ def _render_dag_markdown(groups: list[Group], current_id: str) -> str:
                 continue
             marker = "  <-- this PR" if child.id == current_id else ""
             also = ""
-            if len(child.depends_on) > 1:
-                others = ", ".join(d for d in child.depends_on if d != parent_id)
-                also = f" (also depends on: {others})"
+            others = [d for d in dict.fromkeys(child.depends_on) if d != parent_id]
+            if others:
+                also = f" (also depends on: {', '.join(others)})"
             lines.append(f"{prefix}{connector} {child.id}: {child.title}{also}{marker}")
             extension = "    " if is_last else "\u2502   "
             _add_children(child.id, prefix + extension)

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -82,10 +82,33 @@ app = typer.Typer(
 console = Console()
 
 
+def _reachable_from_roots(groups: list[Group]) -> set[str]:
+    """Ids that a root-first walk will actually visit.
+
+    A group that is neither a root nor a descendant of one (unknown
+    dependency chain, cycle) is never drawn, so it must not count as a
+    parent still "pending" for stub placement.
+    """
+    children: dict[str, list[str]] = {g.id: [] for g in groups}
+    for g in groups:
+        for dep in g.depends_on:
+            if dep in children:
+                children[dep].append(g.id)
+    reachable: set[str] = set()
+    stack = [g.id for g in groups if not g.depends_on]
+    while stack:
+        current = stack.pop()
+        if current in reachable:
+            continue
+        reachable.add(current)
+        stack.extend(children[current])
+    return reachable
+
+
 def _render_dag(groups: list[Group]) -> str:
     roots = [g for g in groups if not g.depends_on]
     tree = Tree("Split Plan")
-    known = {g.id for g in groups}
+    known = _reachable_from_roots(groups)
     # A group with several parents is drawn in full under whichever parent is
     # visited last, so every "(see below)" stub really does point downward and
     # the subtree appears exactly once.
@@ -116,7 +139,7 @@ def _render_dag(groups: list[Group]) -> str:
 def _render_dag_markdown(groups: list[Group], current_id: str) -> str:
     roots = [g for g in groups if not g.depends_on]
     lines: list[str] = []
-    known = {g.id for g in groups}
+    known = _reachable_from_roots(groups)
     done: set[str] = set()
 
     def _add_children(parent_id: str, prefix: str) -> None:

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -684,3 +684,18 @@ class TestRenderDagMultiParent:
         assert tree.count("pr-3: merge (depends on: pr-1, pr-2)") == 1
         assert tree.count("pr-3: merge (see below)") == 1
         assert tree.count("pr-4: after") == 1
+
+    def test_duplicate_dependency_entries_do_not_hide_node(self) -> None:
+        groups = [
+            _group("pr-1", "root"),
+            _group("pr-2", "child", depends_on=["pr-1", "pr-1"]),
+            _group("pr-3", "leaf", depends_on=["pr-2"]),
+        ]
+        md = _render_dag_markdown(groups, "pr-3")
+        assert "pr-2: child" in md
+        assert "(see below)" not in md
+        assert "also depends on" not in md
+        assert "pr-3: leaf  <-- this PR" in md
+        tree = _render_dag(groups)
+        assert "pr-2: child (depends on: pr-1)" in tree
+        assert "pr-3: leaf" in tree

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -664,3 +664,23 @@ class TestRenderDagMultiParent:
         tree = _render_dag(groups)
         assert "pr-3: merge (depends on: pr-1, pr-2)" in tree
         assert "pr-4: after" in tree
+
+    def test_topological_order_draws_merge_node_once(self) -> None:
+        # The natural planner order: pr-2 listed before pr-3. pr-3 is reached
+        # from pr-1 (still mid-walk) and from pr-2; it must be drawn once.
+        groups = [
+            _group("pr-1", "root"),
+            _group("pr-2", "mid", depends_on=["pr-1"]),
+            _group("pr-3", "merge", depends_on=["pr-1", "pr-2"]),
+            _group("pr-4", "after", depends_on=["pr-3"]),
+        ]
+        md = _render_dag_markdown(groups, "pr-4")
+        assert md.count("<-- this PR") == 1
+        assert md.count("pr-3: merge (see below)") == 1
+        assert md.count("pr-3: merge (also depends on:") == 1
+        assert md.count("pr-4: after") == 1
+        assert md.index("pr-3: merge (see below)") < md.index("pr-3: merge (also depends on:")
+        tree = _render_dag(groups)
+        assert tree.count("pr-3: merge (depends on: pr-1, pr-2)") == 1
+        assert tree.count("pr-3: merge (see below)") == 1
+        assert tree.count("pr-4: after") == 1

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -602,3 +602,29 @@ class TestRenderDagMultiParent:
         assert result.count("pr-4: merge (depends on: pr-2, pr-3)") == 1
         assert result.count("pr-4: merge (see below)") == 1
         assert result.count("pr-5: after merge") == 1
+
+    def test_stub_always_precedes_full_node(self) -> None:
+        # Traversal visits pr-4's branch before pr-2's even though pr-2 is the
+        # last-listed dependency of pr-5; the stub must still point downward.
+        groups = [
+            _group("pr-1", "root"),
+            _group("pr-4", "short", depends_on=["pr-1"]),
+            _group("pr-6", "mid", depends_on=["pr-1"]),
+            _group("pr-2", "long", depends_on=["pr-6"]),
+            _group("pr-5", "merge", depends_on=["pr-2", "pr-4"]),
+        ]
+        for text, full_label in (
+            (_render_dag_markdown(groups, "pr-5"), "pr-5: merge (also depends on: pr-4)"),
+            (_render_dag(groups), "pr-5: merge (depends on: pr-2, pr-4)"),
+        ):
+            assert text.index("pr-5: merge (see below)") < text.index(full_label)
+            assert text.count("pr-5: merge (see below)") == 1
+            assert text.count(full_label) == 1
+
+    def test_unknown_dependency_does_not_hide_node(self) -> None:
+        groups = [
+            _group("pr-1", "root"),
+            _group("pr-2", "child", depends_on=["pr-1", "ghost"]),
+        ]
+        text = _render_dag_markdown(groups, "pr-2")
+        assert "pr-2: child (also depends on: ghost)  <-- this PR" in text

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -646,3 +646,21 @@ class TestRenderDagMultiParent:
         tree = _render_dag(groups)
         assert "pr-2: leaf (depends on: pr-1, pr-9)" in tree
         assert "pr-5: after" in tree
+
+    def test_parent_still_being_walked_is_not_pending(self) -> None:
+        # pr-3 depends on pr-1 (its grandparent, mid-walk) and pr-2 (a sibling
+        # listed after it); it must be drawn in full under pr-2.
+        groups = [
+            _group("pr-1", "root"),
+            _group("pr-3", "merge", depends_on=["pr-1", "pr-2"]),
+            _group("pr-2", "mid", depends_on=["pr-1"]),
+            _group("pr-4", "after", depends_on=["pr-3"]),
+        ]
+        md = _render_dag_markdown(groups, "pr-4")
+        assert md.count("<-- this PR") == 1
+        assert md.count("pr-3: merge (see below)") == 1
+        assert "pr-3: merge (also depends on: pr-1)" in md
+        assert "pr-4: after  <-- this PR" in md
+        tree = _render_dag(groups)
+        assert "pr-3: merge (depends on: pr-1, pr-2)" in tree
+        assert "pr-4: after" in tree

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -628,3 +628,21 @@ class TestRenderDagMultiParent:
         ]
         text = _render_dag_markdown(groups, "pr-2")
         assert "pr-2: child (also depends on: ghost)  <-- this PR" in text
+
+    def test_unreachable_parent_does_not_hide_node(self) -> None:
+        # pr-9 depends on an unknown group, so it is never visited; pr-2 must
+        # still be drawn in full (with its subtree and marker) under pr-1.
+        groups = [
+            _group("pr-1", "root"),
+            _group("pr-9", "orphan", depends_on=["ghost"]),
+            _group("pr-2", "leaf", depends_on=["pr-1", "pr-9"]),
+            _group("pr-5", "after", depends_on=["pr-2"]),
+        ]
+        md = _render_dag_markdown(groups, "pr-2")
+        assert md.count("<-- this PR") == 1
+        assert "pr-2: leaf (also depends on: pr-9)  <-- this PR" in md
+        assert "pr-5: after" in md
+        assert "(see below)" not in md
+        tree = _render_dag(groups)
+        assert "pr-2: leaf (depends on: pr-1, pr-9)" in tree
+        assert "pr-5: after" in tree

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -574,3 +574,31 @@ class TestTransitivePushFailureGating:
         with pytest.raises(PRSplitError):
             _push_and_create_prs(groups, records)
         assert mock_create.call_count == 0
+
+
+class TestRenderDagMultiParent:
+    def _diamond(self) -> list[Group]:
+        return [
+            _group("pr-1", "base"),
+            _group("pr-2", "left", depends_on=["pr-1"]),
+            _group("pr-3", "right", depends_on=["pr-1"]),
+            _group("pr-4", "merge", depends_on=["pr-2", "pr-3"]),
+            _group("pr-5", "after merge", depends_on=["pr-4"]),
+        ]
+
+    def test_markdown_renders_merge_node_and_subtree_once(self) -> None:
+        result = _render_dag_markdown(self._diamond(), "pr-4")
+        assert result.count("<-- this PR") == 1
+        assert result.count("pr-4: merge (also depends on: pr-2)") == 1
+        assert result.count("pr-4: merge (see below)") == 1
+        assert result.count("pr-5: after merge") == 1
+
+    def test_markdown_marks_descendant_of_merge_once(self) -> None:
+        result = _render_dag_markdown(self._diamond(), "pr-5")
+        assert result.count("<-- this PR") == 1
+
+    def test_tree_renders_merge_node_once(self) -> None:
+        result = _render_dag(self._diamond())
+        assert result.count("pr-4: merge (depends on: pr-2, pr-3)") == 1
+        assert result.count("pr-4: merge (see below)") == 1
+        assert result.count("pr-5: after merge") == 1


### PR DESCRIPTION
## Problem

Both DAG renderers (`_render_dag` for the terminal, `_render_dag_markdown` for the PR body) recurse from each parent to its children, so a group with more than one parent is emitted once per parent — along with its entire subtree and, in the PR body, the `<-- this PR` marker. For a diamond `pr-1 → {pr-2, pr-3} → pr-4 → pr-5` the "Merge in this order" block listed `pr-4` and `pr-5` twice and marked "this PR" twice, which reads as two different PRs.

## Fix

A merge node is drawn in full exactly once, under its last-listed parent, annotated `(also depends on: <other parents>)`; under every other parent it appears as a one-line `<id>: <title> (see below)` reference so the reader still sees the edge. `_render_dag` (rich tree) gets the same treatment.

```
pr-1: base
├── pr-2: left
│   └── pr-4: merge (see below)
└── pr-3: right
    └── pr-4: merge (also depends on: pr-2)  <-- this PR
        └── pr-5: after
```

## Tests

Diamond with a node below the merge: marker appears once, full merge node once, `(see below)` once, descendant once — for both renderers. 447 tests pass, ruff clean.