### PR TITLE
fix: reject mode-only changes instead of silently dropping them

### DIFF
--- a/pr_split/exceptions.py
+++ b/pr_split/exceptions.py
@@ -31,6 +31,10 @@ class ErrorMsg(StrEnum):
         "Diff contains binary files, which cannot be split into hunks: {files}."
         " Commit them separately and re-run"
     )
+    HUNKLESS_FILES_UNSUPPORTED = (
+        "Diff contains files with no text hunks (mode-only or empty changes), which"
+        " cannot be assigned to a sub-PR: {files}. Commit them separately and re-run"
+    )
 
     def __call__(self, **kwargs: object) -> str:
         return self.value.format(**kwargs) if kwargs else self.value

--- a/pr_split/planner/validator.py
+++ b/pr_split/planner/validator.py
@@ -10,15 +10,20 @@ from ..types_defs import LocBoundViolation
 
 
 def validate_no_binary_files(parsed_diff: ParsedDiff) -> None:
-    """Refuse diffs with binary files.
+    """Refuse diffs with binary files or hunk-less entries.
 
-    Binary patches carry no hunks, so coverage validation would pass
-    without any group claiming them and the change would silently be
-    dropped from every sub-PR.
+    Binary patches and mode-only changes carry no hunks, so coverage
+    validation would pass without any group claiming them and the change
+    would silently be dropped from every sub-PR.
     """
     binary = [pf.path for pf in parsed_diff.patch_set if pf.is_binary_file]
     if binary:
         raise PlanValidationError(ErrorMsg.BINARY_FILES_UNSUPPORTED(files=", ".join(binary)))
+    # Mode-only changes (chmod +x) and other hunk-less entries have the same
+    # failure mode: nothing for a group to claim, so the change vanishes.
+    hunkless = [pf.path for pf in parsed_diff.patch_set if len(pf) == 0]
+    if hunkless:
+        raise PlanValidationError(ErrorMsg.HUNKLESS_FILES_UNSUPPORTED(files=", ".join(hunkless)))
 
 
 def validate_coverage(groups: list[Group], parsed_diff: ParsedDiff) -> None:

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -226,3 +226,29 @@ class TestValidateCoverageWholeFileExpansion:
         ]
         with pytest.raises(PlanValidationError, match="multiple groups"):
             validate_coverage(groups, parsed)
+
+
+MODE_ONLY_DIFF = """\
+diff --git a/run.sh b/run.sh
+old mode 100644
+new mode 100755
+diff --git a/a.py b/a.py
+--- a/a.py
++++ b/a.py
+@@ -1 +1 @@
+-x
++y
+"""
+
+
+class TestValidateNoHunklessFiles:
+    def test_mode_only_change_raises(self) -> None:
+        parsed = parse_diff(MODE_ONLY_DIFF)
+        with pytest.raises(PlanValidationError, match=r"no text hunks.*run\.sh"):
+            validate_no_binary_files(parsed)
+
+    def test_validate_plan_rejects_mode_only_even_when_text_hunks_are_covered(self) -> None:
+        parsed = parse_diff(MODE_ONLY_DIFF)
+        groups = [_make_group("g1", [_ga("a.py", WHOLE, [0])], 2)]
+        with pytest.raises(PlanValidationError, match="no text hunks"):
+            validate_plan(groups, parsed, PlanDAG(groups), max_loc=400)


### PR DESCRIPTION
## Problem

A mode-only change (`chmod +x run.sh`) shows up in the diff as

```
diff --git a/run.sh b/run.sh
old mode 100644
new mode 100755
```

with zero hunks. The planner has nothing to assign, `validate_coverage` passes (no hunks means no gap), and the mode change is absent from every sub-PR — the same silent-drop failure mode #61 fixed for binary files. (Pure renames used to hit this too; #49's `--no-renames` turns them into delete+add with hunks, so they are handled.)

## Fix

`validate_no_binary_files` also rejects hunk-less entries with `HUNKLESS_FILES_UNSUPPORTED`: `Diff contains files with no text hunks (mode-only or empty changes), which cannot be assigned to a sub-PR: run.sh. Commit them separately and re-run`. Because it lives in the same check it is enforced everywhere #61 enforces it: `split` before planning, `validate_plan`, and `execute` on a saved plan.

Applying mode changes in the worktree is the real feature (read `new mode` from the header and `chmod` in the group's worktree); this PR makes the drop loud rather than silent.

## Tests

Mode-only entry alongside a text file: the validator raises with the path; `validate_plan` rejects even when the text hunks are fully covered. 450 tests pass, ruff clean.

Stacked on #61 (`fix/reject-binary-files`).