### PR TITLE
fix: allow non-fast-forward updates when re-fetching fork refs

### DIFF
--- a/pr_split/git_ops/prs.py
+++ b/pr_split/git_ops/prs.py
@@ -116,7 +116,9 @@ def fetch_fork_pr(pr_number: int) -> ForkPRInfo:
     logger.info(logs.FETCHING_FORK_PR.format(number=pr_number, fork=fork_full_name))
 
     try:
-        run_git("fetch", clone_url, f"{head_ref}:{local_ref}")
+        # "+" allows a non-fast-forward update so a re-split after the fork
+        # was force-pushed or rebased picks up the new head.
+        run_git("fetch", clone_url, f"+{head_ref}:{local_ref}")
     except GitOperationError as exc:
         raise GitOperationError(
             ErrorMsg.PR_FETCH_FAILED(number=pr_number, detail=str(exc))
@@ -154,7 +156,7 @@ def fetch_fork_branch(user: str, branch: str) -> ForkPRInfo:
     logger.info(logs.FETCHING_FORK_BRANCH.format(branch=branch, fork=fork_full_name))
 
     try:
-        run_git("fetch", clone_url, f"{branch}:{local_ref}")
+        run_git("fetch", clone_url, f"+{branch}:{local_ref}")
     except GitOperationError as exc:
         raise GitOperationError(
             ErrorMsg.FORK_FETCH_FAILED(user=user, branch=branch, detail=str(exc))

--- a/tests/test_git_prs_coverage.py
+++ b/tests/test_git_prs_coverage.py
@@ -7,6 +7,8 @@ fetch_fork_branch (happy path and error paths).
 from __future__ import annotations
 
 import json
+import subprocess
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -164,3 +166,74 @@ class TestFetchForkBranch:
 
         with pytest.raises(GitOperationError, match="Failed to fetch"):
             fetch_fork_branch("user", "branch")
+
+
+class TestForkFetchRefspecIsForced:
+    @patch("pr_split.git_ops.branches.run_git")
+    @patch("pr_split.git_ops.prs._run_gh")
+    def test_fetch_fork_pr_uses_forced_refspec(
+        self, mock_gh: MagicMock, mock_git: MagicMock
+    ) -> None:
+        mock_gh.return_value = json.dumps(
+            {
+                "head": {
+                    "ref": "feature",
+                    "repo": {"fork": True, "clone_url": "https://x/f.git", "full_name": "u/f"},
+                },
+                "base": {"ref": "main"},
+            }
+        )
+        mock_git.side_effect = ["", "A <a@x>"]
+        fetch_fork_pr(42)
+        fetch_call = mock_git.call_args_list[0].args
+        assert fetch_call[0] == "fetch"
+        assert fetch_call[2] == "+feature:refs/pr-split/pr-42"
+
+    @patch("pr_split.git_ops.branches.run_git")
+    @patch("pr_split.git_ops.prs._run_gh")
+    def test_fetch_fork_branch_uses_forced_refspec(
+        self, mock_gh: MagicMock, mock_git: MagicMock
+    ) -> None:
+        mock_gh.side_effect = [
+            "repo",
+            json.dumps({"clone_url": "https://x/f.git", "full_name": "u/repo"}),
+            "main",
+        ]
+        mock_git.side_effect = ["", "A <a@x>"]
+        fetch_fork_branch("u", "feature")
+        fetch_call = mock_git.call_args_list[0].args
+        assert fetch_call[2].startswith("+feature:")
+
+    def test_forced_refspec_survives_amended_fork_head(self, tmp_path: Path) -> None:
+        def git(cwd: Path, *args: str) -> str:
+            return subprocess.run(
+                ["git", "-c", "user.name=t", "-c", "user.email=t@x", *args],
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+
+        fork = tmp_path / "fork"
+        fork.mkdir()
+        git(fork, "init", "-q", "-b", "feature")
+        (fork / "f.txt").write_text("one\n")
+        git(fork, "add", "f.txt")
+        git(fork, "commit", "-qm", "first")
+
+        local = tmp_path / "local"
+        local.mkdir()
+        git(local, "init", "-q", "-b", "main")
+        git(local, "fetch", "-q", str(fork), "+feature:refs/pr-split/pr-1")
+
+        # Rewrite the commit the local ref already points at: non-fast-forward.
+        (fork / "f.txt").write_text("two\n")
+        git(fork, "add", "f.txt")
+        git(fork, "commit", "-q", "--amend", "-m", "rewritten")
+        new_head = git(fork, "rev-parse", "HEAD")
+
+        # Without "+" git refuses the non-fast-forward update.
+        with pytest.raises(subprocess.CalledProcessError):
+            git(local, "fetch", "-q", str(fork), "feature:refs/pr-split/pr-1")
+        git(local, "fetch", "-q", str(fork), "+feature:refs/pr-split/pr-1")
+        assert git(local, "rev-parse", "refs/pr-split/pr-1") == new_head


### PR DESCRIPTION
## Problem

`fetch_fork_pr` and `fetch_fork_branch` fetch the fork head into `refs/pr-split/pr-<n>` / `refs/pr-split/fork-<user>-<branch>` with a plain `head:local` refspec. Once that ref exists from an earlier run, any rewritten fork head (rebase, `--amend`, force-push — routine on PR branches) is refused:

```
! [rejected]  feature -> refs/pr-split/pr-42  (non-fast-forward)
```

and `pr-split split '#42'` dies with `PR_FETCH_FAILED`. Re-splitting a fork PR after the contributor updates it is exactly the workflow these commands exist for.

## Fix

Use a forced refspec (`+head:local`) in both functions. These are tool-owned scratch refs, never user branches, so forcing cannot lose anything.

## Tests

- Both functions pass `+<ref>:<local_ref>` to `git fetch` (2 mock tests, fail on base).
- Real-git test: fetch once, amend the fork head, confirm the un-forced fetch is rejected as non-fast-forward and the forced one lands the new head.

Local review: 5/5. 447 tests pass, ruff clean.