### PR TITLE
fix: list per-file global hunk indices in chunk prompt summaries

### DIFF
--- a/pr_split/diff_ops/parser.py
+++ b/pr_split/diff_ops/parser.py
@@ -60,6 +60,7 @@ class ParsedDiff:
                     is_deleted=pf.is_removed_file,
                     is_renamed=pf.is_rename,
                     hunk_count=len(pf),
+                    hunk_indices=list(range(len(pf))),
                 )
             )
         return DiffStats(

--- a/pr_split/planner/chunker.py
+++ b/pr_split/planner/chunker.py
@@ -184,6 +184,7 @@ def build_chunk_stats_from_hunks(parsed_diff: ParsedDiff, hunk_refs: list[HunkRe
                 is_deleted=pf.is_removed_file,
                 is_renamed=pf.is_rename,
                 hunk_count=len(indices),
+                hunk_indices=sorted(indices),
             )
         )
     return DiffStats(

--- a/pr_split/planner/prompts.py
+++ b/pr_split/planner/prompts.py
@@ -209,7 +209,17 @@ def _format_file_summary(diff_stats: DiffStats) -> str:
         ]
         flag_str = f" [{', '.join(flags)}]" if flags else ""
         hunk_count = fs["hunk_count"]
-        idx_range = f"indices 0..{hunk_count - 1}" if hunk_count > 0 else "no hunks"
+        indices = fs["hunk_indices"]
+        # In chunked mode a file's hunks in this chunk keep their per-file
+        # global indices, which need not start at 0 or be contiguous; list
+        # them explicitly so the model does not re-use indices from earlier
+        # chunks.
+        if not indices:
+            idx_range = "no hunks"
+        elif indices == list(range(len(indices))):
+            idx_range = f"indices 0..{indices[-1]}"
+        else:
+            idx_range = f"indices {', '.join(str(i) for i in indices)} (this chunk only)"
         lines.append(
             f"  {fs['path']}: +{fs['added']}/-{fs['removed']}"
             f" ({hunk_count} hunks, {idx_range}){flag_str}"

--- a/pr_split/types_defs.py
+++ b/pr_split/types_defs.py
@@ -23,6 +23,7 @@ class FileSummary(TypedDict):
     is_deleted: bool
     is_renamed: bool
     hunk_count: int
+    hunk_indices: list[int]
 
 
 class ForkPRInfo(TypedDict):

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -330,3 +330,22 @@ class TestFormatGroupCatalogExtended:
     def test_empty_groups(self) -> None:
         result = format_group_catalog([])
         assert result == ""
+
+
+class TestChunkStatsKeepGlobalIndices:
+    def test_second_chunk_summary_uses_per_file_global_indices(self) -> None:
+        from pr_split.diff_ops.parser import parse_diff
+        from pr_split.planner.chunker import build_chunk_stats_from_hunks, build_hunk_sequence
+        from pr_split.planner.prompts import build_chunk_continuation_prompt
+
+        diff = "diff --git a/f.py b/f.py\n--- a/f.py\n+++ b/f.py\n" + "".join(
+            f"@@ -{10 * i + 1},1 +{10 * i + 1},2 @@\n x\n+y{i}\n" for i in range(4)
+        )
+        parsed = parse_diff(diff)
+        refs = build_hunk_sequence(parsed, 0.25)
+        second_chunk = refs[2:]
+        stats = build_chunk_stats_from_hunks(parsed, second_chunk)
+        assert stats["file_summaries"][0]["hunk_indices"] == [2, 3]
+        prompt = build_chunk_continuation_prompt(stats, "diff", 2, 2, "catalog")
+        assert "indices 2, 3 (this chunk only)" in prompt
+        assert "indices 0..1" not in prompt

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -27,6 +27,7 @@ def _make_diff_stats() -> DiffStats:
                 is_deleted=False,
                 is_renamed=False,
                 hunk_count=2,
+                hunk_indices=[0, 1],
             ),
             FileSummary(
                 path="bar.py",
@@ -36,6 +37,7 @@ def _make_diff_stats() -> DiffStats:
                 is_deleted=False,
                 is_renamed=False,
                 hunk_count=1,
+                hunk_indices=[0],
             ),
         ],
     )
@@ -101,6 +103,7 @@ class TestBuildUserPrompt:
                     is_deleted=False,
                     is_renamed=False,
                     hunk_count=0,
+                    hunk_indices=[],
                 ),
             ],
         )
@@ -130,3 +133,28 @@ class TestBuildSystemPromptExtended:
     def test_returns_nonempty_string(self) -> None:
         result = build_system_prompt(Priority.ORTHOGONAL, 400)
         assert len(result) > 100
+
+
+class TestChunkSummaryIndices:
+    def test_later_chunk_lists_global_indices(self) -> None:
+        stats = DiffStats(
+            total_files=1,
+            total_added=1,
+            total_removed=0,
+            total_loc=1,
+            file_summaries=[
+                FileSummary(
+                    path="f.py",
+                    added=1,
+                    removed=0,
+                    is_new=False,
+                    is_deleted=False,
+                    is_renamed=False,
+                    hunk_count=2,
+                    hunk_indices=[1, 3],
+                )
+            ],
+        )
+        result = build_user_prompt(stats, "diff")
+        assert "indices 1, 3 (this chunk only)" in result
+        assert "indices 0..1" not in result

--- a/tests/test_types_defs.py
+++ b/tests/test_types_defs.py
@@ -55,6 +55,7 @@ class TestFileSummary:
             "is_deleted": False,
             "is_renamed": False,
             "hunk_count": 2,
+            "hunk_indices": [0, 1],
         }
         assert fs["path"] == "test.py"
         assert fs["added"] == 10


### PR DESCRIPTION
## Problem

In chunked mode every hunk in the diff is labelled with its per-file global index (`[hunk_index=N]`), and system-prompt rule 6 tells the model to use exactly those. But the chunk's file summary was built from `hunk_count=len(indices_in_this_chunk)` and printed `indices 0..{count-1}`. For a file split across chunks, chunk 2's summary said e.g. `f.py: … (1 hunks, indices 0..0)` while the diff below it showed `[hunk_index=1]` — a direct contradiction that invites the model to re-use index 0 (already assigned in chunk 1), producing overlaps and uncovered hunks that `assign_uncovered_hunks` then repairs noisily.

## Fix

- `FileSummary` gains `hunk_indices`.
- `ParsedDiff.stats` fills `0..n-1`; `build_chunk_stats_from_hunks` fills the chunk's actual sorted per-file global indices.
- `_format_file_summary` prints `indices 0..N` when they are contiguous from 0 (unchanged wording for the single-shot prompt) and `indices 1, 3 (this chunk only)` otherwise.

## Tests

- second chunk of a 4-hunk file: summary carries `[2, 3]` and the continuation prompt says `indices 2, 3 (this chunk only)`, not `0..1`
- prompt formatting for a non-contiguous index list
- existing summary tests updated for the new field

Local review: 5/5. 446 tests pass, ruff clean.