### PR TITLE
docs: include contents: read in the README action example

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ on:
     branches: [main]
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Problem

The README's GitHub Action example declares only `permissions: pull-requests: write`. A top-level `permissions` block replaces the token's default scopes entirely, so `contents` becomes `none` and `actions/checkout` (plus the script's `git fetch origin <base>` / `refs/pull/N/head`) fails on private repos. The repo's own `.github/workflows/split-score.yml` already declares `contents: read`.

## Change

Add `contents: read` to the example block. Docs only.

Local review: 5/5 (also re-verified every input/output/default in the README action tables against `action.yml` — all match).