### PR TITLE
fix: make split branch namespaces ref-safe and collision-free

### DIFF
--- a/pr_split/git_ops/branches.py
+++ b/pr_split/git_ops/branches.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import re
 import subprocess
 
@@ -82,9 +83,24 @@ def merge_base(ref_a: str, ref_b: str) -> str:
 
 
 def derive_split_namespace(dev_branch_arg: str) -> str:
-    raw = dev_branch_arg.split(":", 1)[1] if ":" in dev_branch_arg else dev_branch_arg.lstrip("#")
+    """Derive the branch namespace for a split from its dev-branch argument.
+
+    The result must be a valid git ref component and distinct per source:
+    ``user:branch`` keeps the user so a fork branch cannot collide with a
+    local branch of the same name, ``..`` is never emitted, and an argument
+    that sanitises to nothing falls back to a short hash rather than an
+    empty component (``pr-split//pr-1`` is not a valid ref).
+    """
+    if ":" in dev_branch_arg:
+        user, branch = dev_branch_arg.split(":", 1)
+        raw = f"{user}-{branch}"
+    else:
+        raw = dev_branch_arg.lstrip("#")
     sanitized = re.sub(r"[^a-zA-Z0-9._-]", "-", raw)
-    return sanitized.strip("-")
+    sanitized = re.sub(r"\.{2,}", "-", sanitized).strip("-.")
+    if not sanitized:
+        return hashlib.sha1(dev_branch_arg.encode("utf-8")).hexdigest()[:8]
+    return sanitized
 
 
 def create_group_branch(group_id: str, base: str, namespace: str) -> str:

--- a/tests/test_git_branches.py
+++ b/tests/test_git_branches.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import re
 import subprocess
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -314,3 +316,29 @@ class TestCommitFilesInDir:
     def test_empty_file_paths_raises(self) -> None:
         with pytest.raises(GitOperationError, match="no file paths"):
             commit_files_in_dir("/tmp/wt", [], "msg")
+
+
+class TestDeriveSplitNamespaceRefSafety:
+    def test_fork_namespace_includes_user(self) -> None:
+        assert derive_split_namespace("user:feat/x") == "user-feat-x"
+        assert derive_split_namespace("user:feat/x") != derive_split_namespace("feat/x")
+
+    def test_all_invalid_characters_fall_back_to_hash(self) -> None:
+        result = derive_split_namespace("---")
+        assert re.fullmatch(r"[0-9a-f]{8}", result)
+        assert derive_split_namespace("---") == result
+        assert derive_split_namespace("user:---") == "user"
+
+    def test_double_dots_and_edge_dots_are_removed(self) -> None:
+        result = derive_split_namespace(".feat..x.")
+        assert ".." not in result
+        assert not result.startswith(".")
+        assert not result.endswith(".")
+
+    def test_namespace_is_a_valid_ref_component(self, tmp_path: Path) -> None:
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+        for arg in ("---", "user:---", ".feat..x.", "#42", "a b/c", "weird@chars!"):
+            ref = f"refs/heads/pr-split/{derive_split_namespace(arg)}/pr-1"
+            subprocess.run(
+                ["git", "check-ref-format", ref], cwd=tmp_path, check=True, capture_output=True
+            )


### PR DESCRIPTION
## Problem

`derive_split_namespace` (which becomes the middle component of every `pr-split/<ns>/pr-N` branch) had three failure modes:

- `user:---` sanitised to `""`, producing `pr-split//pr-1`, which git rejects at `worktree add -b`.
- `..` and leading/trailing dots survived sanitisation; `..` is invalid in a ref.
- `user:feat/x` and a local `feat-x` both mapped to `feat-x`, so a second split's `add_worktree` force-deleted the first split's branches (it does `branch -D` on an existing name).

## Fix

- Fork arguments keep the user: `user:feat/x` → `user-feat-x`.
- `..` runs collapse to `-`; edge `-`/`.` are stripped.
- If nothing survives, fall back to an 8-hex sha1 of the argument (stable, non-empty).

`#42` → `42` and plain branch names are unchanged. Existing plans are unaffected: `clean`/`status` read stored branch names, and `execute` refuses plans that already have branches.

## Tests

Fork namespace includes the user and differs from the local one; all-invalid input falls back to a hash; `..`/edge dots removed; and every sample argument yields a ref that passes `git check-ref-format`. 4 tests fail on base.

Local review: 5/5. 448 tests pass, ruff clean.