### PR TITLE
fix: reject LLM responses that were cut off by the output limit

### DIFF
--- a/pr_split/exceptions.py
+++ b/pr_split/exceptions.py
@@ -18,6 +18,10 @@ class ErrorMsg(StrEnum):
     MERGE_CONFLICT = "Groups '{a}' and '{b}' modify overlapping regions in '{file}'"
     NO_PLAN = "No split plan found; run 'pr-split split' first"
     LLM_PARSE_ERROR = "Failed to parse LLM response: {detail}"
+    LLM_OUTPUT_TRUNCATED = (
+        "LLM response was cut off before the plan was complete ({detail});"
+        " the partial plan cannot be trusted"
+    )
     BRANCH_CREATE_FAILED = "Failed to create branch '{branch}': {detail}"
     PR_CREATE_FAILED = "Failed to create PR for group '{group}': {detail}"
     MERGE_FAILED = "Merge of '{source}' into '{target}' failed: {detail}"

--- a/pr_split/logs.py
+++ b/pr_split/logs.py
@@ -40,6 +40,7 @@ CHUNK_RECEIVED = "Chunk {index}/{total}: {new_groups} new groups, {total_groups}
 LLM_OUTPUT_TRUNCATED = (
     "LLM output truncated (stop_reason: {stop_reason}), keys in partial output: {keys}"
 )
+LLM_OUTPUT_INCOMPLETE = "LLM output incomplete (status: {status}, reason: {reason})"
 CHUNK_RETRY = "Chunk {index}/{total} failed (attempt {attempt}), retrying: {error}"
 INVALID_HUNK_INDEX = (
     "Group '{group}': invalid hunk index {index} for {file} (max: {max}), skipping"

--- a/pr_split/planner/client.py
+++ b/pr_split/planner/client.py
@@ -131,6 +131,11 @@ def _call_anthropic(system: str, user: str, *, settings: Settings) -> RawToolOut
     except anthropic.APIError as exc:
         raise LLMError(ErrorMsg.LLM_PARSE_ERROR(detail=str(exc))) from exc
     if response.stop_reason != "tool_use":
+        # A max_tokens stop means the tool input was cut off mid-plan.
+        # Accepting it would silently drop groups and let
+        # assign_uncovered_hunks paper over the gap, so fail and let the
+        # chunk retry loop / caller handle it. Other stop reasons without a
+        # tool block are reported below as "no tool_use block".
         stop_reason = getattr(response, "stop_reason", "unknown")
         keys: list[str] = []
         for block in getattr(response, "content", []):
@@ -138,6 +143,8 @@ def _call_anthropic(system: str, user: str, *, settings: Settings) -> RawToolOut
                 keys = list(block.input.keys())
                 break
         logger.warning(logs.LLM_OUTPUT_TRUNCATED.format(stop_reason=stop_reason, keys=keys))
+        if stop_reason == "max_tokens":
+            raise LLMError(ErrorMsg.LLM_OUTPUT_TRUNCATED(detail=f"stop_reason={stop_reason}"))
     for block in response.content:
         if isinstance(block, BetaToolUseBlock) and block.name == SPLIT_TOOL_NAME:
             return RawToolOutput(groups=_extract_raw_output(block.input))
@@ -156,6 +163,12 @@ def _call_openai(system: str, user: str, *, settings: Settings) -> RawToolOutput
         )
     except openai.APIError as exc:
         raise LLMError(ErrorMsg.LLM_PARSE_ERROR(detail=str(exc))) from exc
+    status = getattr(response, "status", None)
+    if status == "incomplete":
+        details = getattr(response, "incomplete_details", None)
+        reason = getattr(details, "reason", None) or "unknown"
+        logger.warning(logs.LLM_OUTPUT_INCOMPLETE.format(status=status, reason=reason))
+        raise LLMError(ErrorMsg.LLM_OUTPUT_TRUNCATED(detail=f"status={status}, reason={reason}"))
     for item in response.output:
         if item.type == "function_call" and item.name == SPLIT_TOOL_NAME:
             try:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,7 +9,7 @@ import pytest
 from pr_split.config import Settings
 from pr_split.constants import AssignmentType, PartitionStrategy, Provider
 from pr_split.diff_ops.parser import parse_diff
-from pr_split.exceptions import LLMError, PRSplitError
+from pr_split.exceptions import ErrorMsg, LLMError, PRSplitError
 from pr_split.planner.client import (
     RawToolOutput,
     _call_anthropic,
@@ -656,7 +656,7 @@ class TestCallAnthropic:
         )
         mock_cls.return_value.beta.messages.create.return_value = mock_response
         settings = _make_settings(Provider.ANTHROPIC)
-        with pytest.raises(LLMError, match="cut off.*stop_reason=max_tokens"):
+        with pytest.raises(LLMError, match=r"cut off.*stop_reason=max_tokens"):
             _call_anthropic("sys", "usr", settings=settings)
 
 
@@ -1003,7 +1003,7 @@ class TestOpenAIIncompleteResponse:
         )
         mock_cls.return_value.responses.create.return_value = mock_response
         settings = _make_settings(Provider.OPENAI)
-        with pytest.raises(LLMError, match="cut off.*max_output_tokens"):
+        with pytest.raises(LLMError, match=r"cut off.*max_output_tokens"):
             _call_openai("sys", "usr", settings=settings)
 
     @patch("pr_split.planner.client.openai.OpenAI")
@@ -1017,3 +1017,18 @@ class TestOpenAIIncompleteResponse:
         mock_cls.return_value.responses.create.return_value = mock_response
         settings = _make_settings(Provider.OPENAI)
         assert _call_openai("sys", "usr", settings=settings)["groups"] == _SAMPLE_RAW_GROUPS
+
+
+class TestTruncationIsRetried:
+    @patch("pr_split.planner.client._call_llm")
+    def test_chunk_retry_recovers_from_truncated_first_attempt(self, mock_call: MagicMock) -> None:
+        mock_call.side_effect = [
+            LLMError(ErrorMsg.LLM_OUTPUT_TRUNCATED(detail="stop_reason=max_tokens")),
+            {"groups": _SAMPLE_RAW_GROUPS},
+        ]
+        settings = _make_settings(Provider.ANTHROPIC)
+        groups = _call_chunk_with_retry(
+            "sys", "usr", settings=settings, chunk_index=1, total_chunks=2
+        )
+        assert [g.id for g in groups] == [g["id"] for g in _SAMPLE_RAW_GROUPS]
+        assert mock_call.call_count == 2

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -641,7 +641,7 @@ class TestCallAnthropic:
             _call_anthropic("sys", "usr", settings=settings)
 
     @patch("pr_split.planner.client.anthropic.Anthropic")
-    def test_stop_reason_not_tool_use_still_succeeds(self, mock_cls: MagicMock) -> None:
+    def test_stop_reason_not_tool_use_raises(self, mock_cls: MagicMock) -> None:
         from anthropic.types.beta import BetaToolUseBlock
 
         tool_block = BetaToolUseBlock(
@@ -656,8 +656,8 @@ class TestCallAnthropic:
         )
         mock_cls.return_value.beta.messages.create.return_value = mock_response
         settings = _make_settings(Provider.ANTHROPIC)
-        result = _call_anthropic("sys", "usr", settings=settings)
-        assert result["groups"] == _SAMPLE_RAW_GROUPS
+        with pytest.raises(LLMError, match="cut off.*stop_reason=max_tokens"):
+            _call_anthropic("sys", "usr", settings=settings)
 
 
 # ---------------------------------------------------------------------------
@@ -986,3 +986,34 @@ class TestPlanSplitWithLlm:
         result = _plan_split_with_llm(parsed, settings)
         assert len(result) == 1
         mock_chunked.assert_called_once()
+
+
+class TestOpenAIIncompleteResponse:
+    @patch("pr_split.planner.client.openai.OpenAI")
+    def test_incomplete_status_raises(self, mock_cls: MagicMock) -> None:
+        item = SimpleNamespace(
+            type="function_call",
+            name=SPLIT_TOOL_NAME,
+            arguments=json.dumps({"groups": _SAMPLE_RAW_GROUPS}),
+        )
+        mock_response = SimpleNamespace(
+            status="incomplete",
+            incomplete_details=SimpleNamespace(reason="max_output_tokens"),
+            output=[item],
+        )
+        mock_cls.return_value.responses.create.return_value = mock_response
+        settings = _make_settings(Provider.OPENAI)
+        with pytest.raises(LLMError, match="cut off.*max_output_tokens"):
+            _call_openai("sys", "usr", settings=settings)
+
+    @patch("pr_split.planner.client.openai.OpenAI")
+    def test_completed_status_is_accepted(self, mock_cls: MagicMock) -> None:
+        item = SimpleNamespace(
+            type="function_call",
+            name=SPLIT_TOOL_NAME,
+            arguments=json.dumps({"groups": _SAMPLE_RAW_GROUPS}),
+        )
+        mock_response = SimpleNamespace(status="completed", output=[item])
+        mock_cls.return_value.responses.create.return_value = mock_response
+        settings = _make_settings(Provider.OPENAI)
+        assert _call_openai("sys", "usr", settings=settings)["groups"] == _SAMPLE_RAW_GROUPS


### PR DESCRIPTION
## Problem

`_call_anthropic` only *warned* when `stop_reason == "max_tokens"` and then returned whatever partial tool input had parsed. `_call_openai` never looked at `response.status == "incomplete"` at all. A plan cut off mid-generation is syntactically valid, so:

- in chunked mode, `assign_uncovered_hunks` silently dumped the missing hunks into an existing group and the truncated plan passed validation;
- in single-shot mode the user got a plan with groups missing and no indication anything was wrong.

## Fix

- `_call_anthropic`: `stop_reason == "max_tokens"` → `LLMError(ErrorMsg.LLM_OUTPUT_TRUNCATED)` (other non-`tool_use` stop reasons keep the existing warning + "no tool_use block" handling).
- `_call_openai`: `status == "incomplete"` → same error, with `incomplete_details.reason` in the message.

`LLMError` is what `_call_chunk_with_retry` already retries, so a truncated chunk gets another attempt; refinement keeps the prior plan; single-shot planning fails with a one-line message.

## Tests

- Anthropic `max_tokens` with a tool block raises; `end_turn` with a tool block still returns the plan.
- OpenAI `incomplete` raises (reason in message); `completed` is accepted.
- Retry loop: truncated first attempt then a valid one succeeds on attempt 2.

3 tests fail on base. Local review: 5/5. 447 tests pass, ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Incomplete or truncated AI-generated plans are now clearly identified instead of being processed as valid responses.
  * Improved error messages explain when output was cut off and why the partial plan cannot be trusted.
  * Truncated responses are automatically retried when appropriate.
  * Added clearer reporting for incomplete responses, including their status and reason.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->