### PR TITLE
fix: stop the score action from clobbering the base ref

### DIFF
--- a/scripts/score_pr.py
+++ b/scripts/score_pr.py
@@ -86,17 +86,19 @@ def main() -> None:
         _skip(f"PR has {total_loc} LOC — under the {max_loc} threshold, no split needed.")
         return
 
-    # Create local branch refs for pr-split
-    _run(["git", "branch", "-f", base_branch, f"origin/{base_branch}"])
-    _run(["git", "branch", "-f", head_branch, local_head])
+    # Pass the fetched refs straight to pr-split. Materialising them as local
+    # branches named after the PR's branches is unsafe: a fork PR opened from
+    # the fork's "main" has head_branch == base_branch, so the second
+    # "git branch -f" clobbered the base ref and the diff came out empty.
+    base_ref = f"origin/{base_branch}"
 
     # Run pr-split in dry-run mode
     cmd = [
         "pr-split",
         "split",
-        head_branch,
+        local_head,
         "--base",
-        base_branch,
+        base_ref,
         "--partition-strategy",
         strategy,
         "--priority",

--- a/tests/test_score_pr_refs.py
+++ b/tests/test_score_pr_refs.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "score_pr.py"
+
+
+def _load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("score_pr_refs", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["score_pr_refs"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestScoreUsesFetchedRefsDirectly:
+    def test_head_named_like_base_does_not_clobber_base(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        output_file = tmp_path / "output.txt"
+        output_file.touch()
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+        monkeypatch.setenv("BASE_BRANCH", "main")
+        monkeypatch.setenv("HEAD_BRANCH", "main")  # fork PR opened from the fork's main
+        monkeypatch.setenv("PR_NUMBER", "7")
+        monkeypatch.setenv("MAX_LOC", "1")
+        module = _load_script()
+
+        git_calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
+            git_calls.append(cmd)
+            stdout = "5\t3\ta.py\n" if cmd[:2] == ["git", "diff"] else ""
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        split_cmds: list[list[str]] = []
+
+        def fake_subprocess_run(
+            cmd: list[str], **kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            split_cmds.append(cmd)
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="stub")
+
+        with (
+            patch.object(module, "_run", side_effect=fake_run),
+            patch.object(module.subprocess, "run", side_effect=fake_subprocess_run),
+        ):
+            module.main()
+
+        assert not any(c[:2] == ["git", "branch"] for c in git_calls)
+        assert len(split_cmds) == 1
+        split = split_cmds[0]
+        assert split[:3] == ["pr-split", "split", "pr-split/head-7"]
+        assert split[split.index("--base") + 1] == "origin/main"
+
+    def test_branch_event_without_pr_number_uses_origin_refs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        output_file = tmp_path / "output.txt"
+        output_file.touch()
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+        monkeypatch.setenv("BASE_BRANCH", "main")
+        monkeypatch.setenv("HEAD_BRANCH", "feature")
+        monkeypatch.delenv("PR_NUMBER", raising=False)
+        monkeypatch.setenv("MAX_LOC", "1")
+        module = _load_script()
+
+        def fake_run(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
+            stdout = "5\t3\ta.py\n" if cmd[:2] == ["git", "diff"] else ""
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        split_cmds: list[list[str]] = []
+
+        def fake_subprocess_run(
+            cmd: list[str], **kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            split_cmds.append(cmd)
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="stub")
+
+        with (
+            patch.object(module, "_run", side_effect=fake_run),
+            patch.object(module.subprocess, "run", side_effect=fake_subprocess_run),
+        ):
+            module.main()
+
+        split = split_cmds[0]
+        assert split[2] == "origin/feature"
+        assert split[split.index("--base") + 1] == "origin/main"


### PR DESCRIPTION
## Problem

`scripts/score_pr.py` turned the PR's base and head into local branches named after them:

```
git branch -f <base> origin/<base>
git branch -f <head> pr-split/head-<n>
```

A fork PR opened from the fork's own `main` (very common) has `HEAD_BRANCH == BASE_BRANCH == main`, so the second command re-pointed `main` at the PR head. `git diff main...main` is empty, `pr-split split` produced a 0-group plan, and the PR was reported as within limits. Verified in a scratch clone with a real `refs/pull/7/head`: the old script left `main == pr-split/head-7 != origin/main`.

## Fix

Don't materialise branches at all. Pass `origin/<base>` and the fetched head ref (`pr-split/head-<n>`, or `origin/<head>` when there is no PR number) straight to `pr-split split`; `branch_exists` uses `rev-parse --verify`, and `extract_diff`/`merge_base` accept any ref (verified end to end: 6 groups on a 240-LOC PR).

## Tests

- head named like base: no `git branch` calls, `split` invoked with `pr-split/head-7 --base origin/main`
- branch event without PR number: `origin/feature --base origin/main`

Both fail on base. Local review: 5/5. 446 tests pass, ruff clean.

Note: the action still reports 0 groups until #53 (plan-file key) merges; the two fixes are independent.