### PR TITLE
docs: describe the action's objective output as the simplified score

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ jobs:
 |--------|-------------|
 | `total-loc` | Total lines of code in the PR diff |
 | `total-groups` | Number of suggested groups |
-| `objective` | Plan objective score (lower is better) |
+| `objective` | Simplified plan score, `overflow × 1000 + file_scatter × 50 + groups` (lower is better; not the full `score_plan` objective described in METHODOLOGY.md) |
 | `should-split` | Whether the PR should be split (`true`/`false`) |
 
 ## Planning backends

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ outputs:
     description: "Number of suggested groups"
     value: ${{ steps.score.outputs.total_groups }}
   objective:
-    description: "Plan objective score (lower is better)"
+    description: "Simplified plan score: overflow*1000 + file_scatter*50 + groups (lower is better)"
     value: ${{ steps.score.outputs.objective }}
   should-split:
     description: "Whether the PR should be split (true/false)"


### PR DESCRIPTION
## Problem

README's action-output table and `action.yml` called `objective` the "Plan objective score (lower is better)", implying the `score_plan` objective from METHODOLOGY.md. `scripts/score_pr.py` actually computes `overflow × 1000 + file_scatter × 50 + groups` — no underflow, undersized/tiny-group, dependency-edge, or depth/width terms. Same 2-group plan: action `100052`, `score_plan` `100090`.

## Change

Docs only: both descriptions now state the simplified formula and that it is not the full `score_plan` objective. (Importing `score_plan` from the script would require the package in the action's Python; a separate change if wanted.)

Local review: 5/5.