### PR TITLE
fix: refresh a stale score comment when the PR shrinks below the threshold

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,11 +72,17 @@ runs:
       run: python "${{ github.action_path }}/scripts/score_pr.py"
 
     - name: Post comment
-      if: inputs.post-comment == 'true' && steps.score.outputs.should_split == 'true'
+      if: inputs.post-comment == 'true' && steps.score.outputs.comment_path != ''
       uses: actions/github-script@v7
+      env:
+        SHOULD_SPLIT: ${{ steps.score.outputs.should_split }}
       with:
         script: |
           const fs = require('fs');
+          if (!context.payload.pull_request) {
+            core.info('Not a pull_request event; no comment to post.');
+            return;
+          }
           const body = fs.readFileSync('${{ steps.score.outputs.comment_path }}', 'utf8');
           const { data: comments } = await github.rest.issues.listComments({
             owner: context.repo.owner,
@@ -85,13 +91,15 @@ runs:
           });
           const existing = comments.find(c => c.body.includes('<!-- pr-split-score -->'));
           if (existing) {
+            // Always refresh an existing comment so a PR that shrank below
+            // the threshold no longer shows a stale split plan.
             await github.rest.issues.updateComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               comment_id: existing.id,
               body,
             });
-          } else {
+          } else if (process.env.SHOULD_SPLIT === 'true') {
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/scripts/score_pr.py
+++ b/scripts/score_pr.py
@@ -24,11 +24,28 @@ def _set_output(name: str, value: str) -> None:
         f.write(f"{name}={value}\n")
 
 
+COMMENT_MARKER = "<!-- pr-split-score -->"
+
+
+def _write_comment(body: str) -> None:
+    tmp_dir = os.environ.get("RUNNER_TEMP", tempfile.gettempdir())
+    comment_path = Path(tmp_dir) / "pr-split-comment.md"
+    comment_path.write_text(body)
+    _set_output("comment_path", str(comment_path))
+
+
 def _skip(reason: str) -> None:
     print(reason)
     _set_output("total_groups", "1")
     _set_output("objective", "0")
     _set_output("should_split", "false")
+    # Still emit a comment body so an earlier "please split" comment on this
+    # PR is updated (the action only ever updates an existing marker comment
+    # when should_split is false; it never creates one).
+    _write_comment(
+        f"{COMMENT_MARKER}\n## pr-split analysis\n\n{reason}\n\n"
+        "This PR is within acceptable size limits."
+    )
 
 
 def _md_escape(s: str) -> str:
@@ -146,7 +163,7 @@ def main() -> None:
 
     # Generate markdown comment
     lines = [
-        "<!-- pr-split-score -->",
+        COMMENT_MARKER,
         "## pr-split analysis",
         "",
         "| Metric | Value |",
@@ -183,11 +200,7 @@ def main() -> None:
     else:
         lines.append("This PR is within acceptable size limits.")
 
-    comment = "\n".join(lines)
-    tmp_dir = os.environ.get("RUNNER_TEMP", tempfile.gettempdir())
-    comment_path = Path(tmp_dir) / "pr-split-comment.md"
-    comment_path.write_text(comment)
-    _set_output("comment_path", str(comment_path))
+    _write_comment("\n".join(lines))
 
 
 if __name__ == "__main__":

--- a/scripts/score_pr.py
+++ b/scripts/score_pr.py
@@ -34,18 +34,21 @@ def _write_comment(body: str) -> None:
     _set_output("comment_path", str(comment_path))
 
 
-def _skip(reason: str) -> None:
+def _skip(reason: str, *, within_limits: bool = False) -> None:
     print(reason)
     _set_output("total_groups", "1")
     _set_output("objective", "0")
     _set_output("should_split", "false")
-    # Still emit a comment body so an earlier "please split" comment on this
-    # PR is updated (the action only ever updates an existing marker comment
-    # when should_split is false; it never creates one).
-    _write_comment(
-        f"{COMMENT_MARKER}\n## pr-split analysis\n\n{reason}\n\n"
-        "This PR is within acceptable size limits."
-    )
+    if within_limits:
+        # Emit a comment body so an earlier "please split" comment on this
+        # PR is refreshed once it shrinks under the threshold (the action
+        # only updates an existing marker comment when should_split is
+        # false; it never creates one). Failure paths deliberately write no
+        # body so a transient error cannot overwrite a valid plan comment.
+        _write_comment(
+            f"{COMMENT_MARKER}\n## pr-split analysis\n\n{reason}\n\n"
+            "This PR is within acceptable size limits."
+        )
 
 
 def _md_escape(s: str) -> str:
@@ -100,7 +103,10 @@ def main() -> None:
     _set_output("total_loc", str(total_loc))
 
     if total_loc <= max_loc:
-        _skip(f"PR has {total_loc} LOC — under the {max_loc} threshold, no split needed.")
+        _skip(
+            f"PR has {total_loc} LOC — under the {max_loc} threshold, no split needed.",
+            within_limits=True,
+        )
         return
 
     # Create local branch refs for pr-split

--- a/tests/test_score_pr_comment.py
+++ b/tests/test_score_pr_comment.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "score_pr.py"
+
+
+def _load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("score_pr_comment", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["score_pr_comment"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _outputs(path: Path) -> dict[str, str]:
+    return dict(line.split("=", 1) for line in path.read_text().splitlines() if line)
+
+
+class TestSkipWritesRefreshableComment:
+    def test_skip_writes_marker_comment_and_path_output(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        output_file = tmp_path / "output.txt"
+        output_file.touch()
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+        monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
+        module = _load_script()
+
+        module._skip("PR has 12 LOC — under the 400 threshold, no split needed.")
+
+        outputs = _outputs(output_file)
+        assert outputs["should_split"] == "false"
+        body = Path(outputs["comment_path"]).read_text()
+        assert body.startswith(module.COMMENT_MARKER)
+        assert "within acceptable size limits" in body
+        assert "under the 400 threshold" in body
+
+    def test_split_comment_uses_same_marker(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        output_file = tmp_path / "output.txt"
+        output_file.touch()
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+        monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
+        module = _load_script()
+
+        module._write_comment(f"{module.COMMENT_MARKER}\n## pr-split analysis\n")
+
+        body = Path(_outputs(output_file)["comment_path"]).read_text()
+        assert body.startswith("<!-- pr-split-score -->")

--- a/tests/test_score_pr_comment.py
+++ b/tests/test_score_pr_comment.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType
+from unittest.mock import patch
 
 import pytest
 
@@ -24,16 +27,19 @@ def _outputs(path: Path) -> dict[str, str]:
 
 
 class TestSkipWritesRefreshableComment:
-    def test_skip_writes_marker_comment_and_path_output(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def _prepare(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[ModuleType, Path]:
         output_file = tmp_path / "output.txt"
         output_file.touch()
         monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
         monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
-        module = _load_script()
+        return _load_script(), output_file
 
-        module._skip("PR has 12 LOC — under the 400 threshold, no split needed.")
+    def test_under_threshold_skip_writes_marker_comment(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        module, output_file = self._prepare(tmp_path, monkeypatch)
+
+        module._skip("PR has 12 LOC — under the 400 threshold.", within_limits=True)
 
         outputs = _outputs(output_file)
         assert outputs["should_split"] == "false"
@@ -42,16 +48,83 @@ class TestSkipWritesRefreshableComment:
         assert "within acceptable size limits" in body
         assert "under the 400 threshold" in body
 
-    def test_split_comment_uses_same_marker(
+    def test_failure_skip_writes_no_comment(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        output_file = tmp_path / "output.txt"
-        output_file.touch()
-        monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
-        monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
-        module = _load_script()
+        module, output_file = self._prepare(tmp_path, monkeypatch)
 
-        module._write_comment(f"{module.COMMENT_MARKER}\n## pr-split analysis\n")
+        module._skip("pr-split failed to generate a plan.")
 
-        body = Path(_outputs(output_file)["comment_path"]).read_text()
-        assert body.startswith("<!-- pr-split-score -->")
+        outputs = _outputs(output_file)
+        assert outputs["should_split"] == "false"
+        assert "comment_path" not in outputs
+
+    def test_main_failure_path_leaves_existing_comment_alone(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        module, output_file = self._prepare(tmp_path, monkeypatch)
+        monkeypatch.setenv("BASE_BRANCH", "main")
+        monkeypatch.setenv("HEAD_BRANCH", "feature")
+        monkeypatch.setenv("MAX_LOC", "10")
+
+        def fake_run(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
+            stdout = "400\t100\ta.py\n" if cmd[:2] == ["git", "diff"] else ""
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        def failing_pr_split(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="boom")
+
+        with (
+            patch.object(module, "_run", side_effect=fake_run),
+            patch.object(module.subprocess, "run", side_effect=failing_pr_split),
+        ):
+            module.main()
+
+        outputs = _outputs(output_file)
+        assert outputs["total_loc"] == "500"
+        assert outputs["should_split"] == "false"
+        assert "comment_path" not in outputs
+
+    def test_main_split_path_comment_starts_with_marker(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        module, output_file = self._prepare(tmp_path, monkeypatch)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("BASE_BRANCH", "main")
+        monkeypatch.setenv("HEAD_BRANCH", "feature")
+        monkeypatch.setenv("MAX_LOC", "10")
+        monkeypatch.setenv("THRESHOLD_GROUPS", "2")
+
+        def fake_run(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
+            stdout = "400\t100\ta.py\n" if cmd[:2] == ["git", "diff"] else ""
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        def stub_pr_split(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            plan_dir = tmp_path / ".pr-split"
+            plan_dir.mkdir(exist_ok=True)
+            groups = [
+                {
+                    "id": f"pr-{i}",
+                    "title": f"t{i}",
+                    "depends_on": [],
+                    "estimated_loc": 5,
+                    "estimated_added": 5,
+                    "estimated_removed": 0,
+                    "assignments": [{"file_path": "a.py"}],
+                }
+                for i in (1, 2)
+            ]
+            (plan_dir / "plan.json").write_text(json.dumps({"groups": groups}))
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with (
+            patch.object(module, "_run", side_effect=fake_run),
+            patch.object(module.subprocess, "run", side_effect=stub_pr_split),
+        ):
+            module.main()
+
+        outputs = _outputs(output_file)
+        assert outputs["should_split"] == "true"
+        body = Path(outputs["comment_path"]).read_text()
+        assert body.startswith(module.COMMENT_MARKER)
+        assert "| pr-1 |" in body and "| pr-2 |" in body


### PR DESCRIPTION
## Problem

`action.yml` ran the "Post comment" step only when `should_split == 'true'`. Once a PR had been flagged and the author pushed it back under `max-loc`, the script took the `_skip` path, wrote no comment body, and the old `<!-- pr-split-score -->` comment with the now-wrong split plan stayed on the PR forever.

## Fix

- `scripts/score_pr.py`: comment writing is factored into `_write_comment`; the under-threshold `_skip(..., within_limits=True)` writes a short "within acceptable size limits" body carrying the marker. The two failure-path skips (`pr-split` error, missing plan) deliberately write **no** body, so a transient failure can never overwrite a valid plan comment.
- `action.yml`: the step runs whenever `comment_path` is set, returns early on non-PR payloads, **updates** an existing marker comment regardless of `should_split`, and only **creates** one when `SHOULD_SPLIT == 'true'` (so small PRs that were never flagged stay quiet).

## Tests

- under-threshold skip writes a marker body and `comment_path`
- failure skip writes no `comment_path`
- `main()` with a failing stub `pr-split` on a 500-LOC diff writes no `comment_path`
- `main()` with a stub that writes a 2-group plan produces a marker-prefixed body with the group table

Local review: 5/5 (the github-script branching was simulated for all five cases). 448 tests pass, ruff clean.