### PR TITLE
fix: write a file truncated to empty instead of deleting it

### DIFF
--- a/pr_split/diff_ops/reconstructor.py
+++ b/pr_split/diff_ops/reconstructor.py
@@ -111,7 +111,10 @@ def materialize_group_files(
         patch_file = pf_map.get(file_path)
         if patch_file is None:
             continue
-        if patch_file.is_removed_file:
+        # unidiff's is_removed_file is a heuristic that is also true for a
+        # file truncated to empty (single hunk with target length 0); only a
+        # /dev/null target is a real deletion.
+        if patch_file.target_file == "/dev/null":
             result[file_path] = None
             continue
         indices = _assigned_hunk_indices(patch_file, assignments)

--- a/tests/test_reconstructor.py
+++ b/tests/test_reconstructor.py
@@ -439,3 +439,45 @@ class TestMaterializeDuplicateAssignments:
             ],
         )
         assert materialize_group_files(parsed, group, "main")["n.py"] == "one\ntwo\nten\n"
+
+
+class TestTruncatedFileIsNotDeleted:
+    @patch("pr_split.diff_ops.reconstructor._get_base_file_content", return_value="x\ny\n")
+    def test_file_emptied_on_dev_is_written_empty(self, mock_base: MagicMock) -> None:
+        parsed = parse_diff(
+            "diff --git a/a.txt b/a.txt\nindex 1111111..e69de29 100644\n"
+            "--- a/a.txt\n+++ b/a.txt\n@@ -1,2 +0,0 @@\n-x\n-y\n"
+        )
+        assert parsed.patch_set[0].is_removed_file  # the heuristic that misled us
+        group = Group(
+            id="pr-1",
+            title="t",
+            description="d",
+            assignments=[
+                GroupAssignment(
+                    file_path="a.txt",
+                    assignment_type=AssignmentType.WHOLE_FILE,
+                    hunk_indices=[0],
+                )
+            ],
+        )
+        assert materialize_group_files(parsed, group, "main") == {"a.txt": ""}
+
+    def test_real_deletion_still_removes(self) -> None:
+        parsed = parse_diff(
+            "diff --git a/a.txt b/a.txt\ndeleted file mode 100644\nindex 1111111..0000000\n"
+            "--- a/a.txt\n+++ /dev/null\n@@ -1,2 +0,0 @@\n-x\n-y\n"
+        )
+        group = Group(
+            id="pr-1",
+            title="t",
+            description="d",
+            assignments=[
+                GroupAssignment(
+                    file_path="a.txt",
+                    assignment_type=AssignmentType.WHOLE_FILE,
+                    hunk_indices=[0],
+                )
+            ],
+        )
+        assert materialize_group_files(parsed, group, "main") == {"a.txt": None}


### PR DESCRIPTION
## Problem

`materialize_group_files` used unidiff's `is_removed_file` to decide whether to delete a path. That property is a heuristic: it is also true for any single hunk whose target length is 0 — i.e. a file that `dev` truncated to empty (`@@ -1,20 +0,0 @@`, target still `b/a.txt`). The sub-PR therefore **deleted** the file: its tree differed from `dev` (`a.txt | 0`) and merging the sub-PR back conflicted (modify/delete). Found by the end-to-end hunt.

## Fix

Treat a path as deleted only when `patch_file.target_file == "/dev/null"` (the first clause of unidiff's own check). Verified in a real repo with a file emptied, a file deleted, an empty file filled, and an ordinary edit: the sub-PR `git ls-tree -r` now equals `dev`; on base the emptied file is missing.

## Tests

Emptied file materialises as `""` (fails on base); real `/dev/null` deletion still yields `None`.

Local review: 5/5. 452 tests pass, ruff clean. Stacked on #68 (same function). Follow-up: #90's `target_file_modes` uses the same heuristic and will get the same one-line change.