### PR TITLE
docs: pin the README action example to a release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: vitali87/pr-split@main
+      - uses: vitali87/pr-split@v1.0.0
         with:
           max-loc: "400"
           partition-strategy: "graph"


### PR DESCRIPTION
## Change

The README's GitHub Action example used `vitali87/pr-split@main` while the repo's own `.github/workflows/split-score.yml` pins `@v1.0.0`. A floating ref means downstream repos silently pick up unreleased action changes; match the shipped workflow.

Verified: `v1.0.0` exists on origin, `action.yml` at the tag is byte-identical to `main`, and every input/output the README documents is present there. Docs only. Local review: 5/5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the GitHub Action usage example to reference the stable `v1.0.0` release instead of the `main` branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->