### PR TITLE
fix: surface a failed OpenAI response with its error message

### DIFF
--- a/pr_split/planner/client.py
+++ b/pr_split/planner/client.py
@@ -166,7 +166,7 @@ def _call_openai(system: str, user: str, *, settings: Settings) -> RawToolOutput
     status = getattr(response, "status", None)
     if status == "failed":
         error = getattr(response, "error", None)
-        detail = getattr(error, "message", None) or str(error) or "unknown error"
+        detail = getattr(error, "message", None) or getattr(error, "code", None) or "unknown error"
         raise LLMError(ErrorMsg.LLM_PARSE_ERROR(detail=f"response failed: {detail}"))
     if status == "incomplete":
         details = getattr(response, "incomplete_details", None)

--- a/pr_split/planner/client.py
+++ b/pr_split/planner/client.py
@@ -164,6 +164,10 @@ def _call_openai(system: str, user: str, *, settings: Settings) -> RawToolOutput
     except openai.APIError as exc:
         raise LLMError(ErrorMsg.LLM_PARSE_ERROR(detail=str(exc))) from exc
     status = getattr(response, "status", None)
+    if status == "failed":
+        error = getattr(response, "error", None)
+        detail = getattr(error, "message", None) or str(error) or "unknown error"
+        raise LLMError(ErrorMsg.LLM_PARSE_ERROR(detail=f"response failed: {detail}"))
     if status == "incomplete":
         details = getattr(response, "incomplete_details", None)
         reason = getattr(details, "reason", None) or "unknown"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1054,3 +1054,13 @@ class TestOpenAIFailedResponse:
         )
         with pytest.raises(LLMError, match="response failed: unknown error"):
             _call_openai("sys", "usr", settings=_make_settings(Provider.OPENAI))
+
+    @patch("pr_split.planner.client.openai.OpenAI")
+    def test_failed_status_falls_back_to_error_code(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value.responses.create.return_value = SimpleNamespace(
+            status="failed",
+            error=SimpleNamespace(code="rate_limit_exceeded", message=None),
+            output=[],
+        )
+        with pytest.raises(LLMError, match="response failed: rate_limit_exceeded"):
+            _call_openai("sys", "usr", settings=_make_settings(Provider.OPENAI))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1032,3 +1032,17 @@ class TestTruncationIsRetried:
         )
         assert [g.id for g in groups] == [g["id"] for g in _SAMPLE_RAW_GROUPS]
         assert mock_call.call_count == 2
+
+
+class TestOpenAIFailedResponse:
+    @patch("pr_split.planner.client.openai.OpenAI")
+    def test_failed_status_raises_with_error_message(self, mock_cls: MagicMock) -> None:
+        mock_response = SimpleNamespace(
+            status="failed",
+            error=SimpleNamespace(code="server_error", message="upstream exploded"),
+            output=[],
+        )
+        mock_cls.return_value.responses.create.return_value = mock_response
+        settings = _make_settings(Provider.OPENAI)
+        with pytest.raises(LLMError, match="response failed: upstream exploded"):
+            _call_openai("sys", "usr", settings=settings)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1046,3 +1046,11 @@ class TestOpenAIFailedResponse:
         settings = _make_settings(Provider.OPENAI)
         with pytest.raises(LLMError, match="response failed: upstream exploded"):
             _call_openai("sys", "usr", settings=settings)
+
+    @patch("pr_split.planner.client.openai.OpenAI")
+    def test_failed_status_without_error_object(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value.responses.create.return_value = SimpleNamespace(
+            status="failed", error=None, output=[]
+        )
+        with pytest.raises(LLMError, match="response failed: unknown error"):
+            _call_openai("sys", "usr", settings=_make_settings(Provider.OPENAI))


### PR DESCRIPTION
## Problem

An OpenAI Responses API result with `status == "failed"` carries no `function_call` item, so `_call_openai` reported it as `no function_call in response output` and the actual reason (`response.error.message` — rate limit, server error, …) was lost.

## Fix

Check `status == "failed"` before the `incomplete` check and the output scan, and raise `LLMError` with `error.message`, falling back to `error.code`, then `"unknown error"` (`error` can be `None`). It is a plain `LLMError`, so the chunk retry loop retries it like any other provider error.

## Tests

`message` present; `error=None` → "unknown error"; `message=None, code=…` → the code. All fail on base (generic "no function_call" message).

Local review: 5/5. 450 tests pass, ruff clean. Stacked on #86.