### PR TITLE
fix: only warn about truncation when the stop reason is max_tokens

### DIFF
--- a/pr_split/logs.py
+++ b/pr_split/logs.py
@@ -41,6 +41,7 @@ LLM_OUTPUT_TRUNCATED = (
     "LLM output truncated (stop_reason: {stop_reason}), keys in partial output: {keys}"
 )
 LLM_OUTPUT_INCOMPLETE = "LLM output incomplete (status: {status}, reason: {reason})"
+LLM_UNEXPECTED_STOP = "LLM stopped with stop_reason={stop_reason} (keys in tool input: {keys})"
 CHUNK_RETRY = "Chunk {index}/{total} failed (attempt {attempt}), retrying: {error}"
 INVALID_HUNK_INDEX = (
     "Group '{group}': invalid hunk index {index} for {file} (max: {max}), skipping"

--- a/pr_split/planner/client.py
+++ b/pr_split/planner/client.py
@@ -142,9 +142,12 @@ def _call_anthropic(system: str, user: str, *, settings: Settings) -> RawToolOut
             if isinstance(block, BetaToolUseBlock) and isinstance(block.input, dict):
                 keys = list(block.input.keys())
                 break
-        logger.warning(logs.LLM_OUTPUT_TRUNCATED.format(stop_reason=stop_reason, keys=keys))
         if stop_reason == "max_tokens":
+            logger.warning(logs.LLM_OUTPUT_TRUNCATED.format(stop_reason=stop_reason, keys=keys))
             raise LLMError(ErrorMsg.LLM_OUTPUT_TRUNCATED(detail=f"stop_reason={stop_reason}"))
+        # Any other stop reason is not a truncation; if a tool block is
+        # present the plan is complete, otherwise the loop below reports it.
+        logger.debug(logs.LLM_UNEXPECTED_STOP.format(stop_reason=stop_reason, keys=keys))
     for block in response.content:
         if isinstance(block, BetaToolUseBlock) and block.name == SPLIT_TOOL_NAME:
             return RawToolOutput(groups=_extract_raw_output(block.input))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1064,3 +1064,22 @@ class TestOpenAIFailedResponse:
         )
         with pytest.raises(LLMError, match="response failed: rate_limit_exceeded"):
             _call_openai("sys", "usr", settings=_make_settings(Provider.OPENAI))
+
+
+class TestTruncationWarningScope:
+    @patch("pr_split.planner.client.logger")
+    @patch("pr_split.planner.client.anthropic.Anthropic")
+    def test_end_turn_with_tool_block_does_not_warn_truncated(
+        self, mock_cls: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        from anthropic.types.beta import BetaToolUseBlock
+
+        block = BetaToolUseBlock(
+            id="tu_1", type="tool_use", name=SPLIT_TOOL_NAME, input={"groups": _SAMPLE_RAW_GROUPS}
+        )
+        mock_cls.return_value.beta.messages.create.return_value = SimpleNamespace(
+            stop_reason="end_turn", content=[block]
+        )
+        result = _call_anthropic("sys", "usr", settings=_make_settings(Provider.ANTHROPIC))
+        assert result["groups"] == _SAMPLE_RAW_GROUPS
+        assert not any("truncated" in str(c.args[0]) for c in mock_logger.warning.call_args_list)


### PR DESCRIPTION
## Summary

`_call_anthropic` logged the `LLM_OUTPUT_TRUNCATED` warning for every stop reason other than `tool_use`, including `end_turn` and `stop_sequence`, so a plain "no tool_use block" failure was misreported as truncation. This narrows the warning to `stop_reason == "max_tokens"` and emits a debug-level `LLM_UNEXPECTED_STOP` line for the other stop reasons.

Stacked on #100 (`fix/openai-failed-status`).

## Test plan

- new `test_client.py` case: `end_turn` with no tool block raises the "no tool_use block" error and does not log the truncation warning (fails on base, passes here)
- 451 tests pass, ruff clean
- Local review: 5/5
