### PR TITLE
fix: report a PR closed during the auto-merge wait and fail the run

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -1071,6 +1071,7 @@ def _poll_for_merged(
     group_ids: list[str],
     pr_map: dict[str, PRRecord],
     fetch_errors: list[str] | None = None,
+    closed: list[str] | None = None,
 ) -> set[str]:
     pending = set(group_ids)
     actually_merged: set[str] = set()
@@ -1092,6 +1093,8 @@ def _poll_for_merged(
                 )
                 if state == "" and fetch_errors is not None:
                     fetch_errors.append(gid)
+                if state == "CLOSED" and closed is not None:
+                    closed.append(gid)
                 pending.discard(gid)
     if pending:
         remaining = ", ".join(pending)
@@ -1225,12 +1228,18 @@ def merge_all(
             if queued:
                 logger.info(f"Waiting for auto-merge to complete: {', '.join(queued)}")
                 poll_fetch_errors: list[str] = []
-                actually_merged = _poll_for_merged(queued, pr_map, poll_fetch_errors)
+                poll_closed: list[str] = []
+                actually_merged = _poll_for_merged(queued, pr_map, poll_fetch_errors, poll_closed)
                 merged.extend(actually_merged)
                 for gid in poll_fetch_errors:
                     fetch_errors.append(gid)
                     skipped_ids.add(gid)
                     skipped.append(f"{gid} (fetch error)")
+                for gid in poll_closed:
+                    # Closed while we waited: report it like a closed PR found
+                    # up front instead of an anonymous incomplete batch.
+                    skipped_ids.add(gid)
+                    skipped.append(f"{gid} (CLOSED)")
 
         if stopped or any(gid not in merged and gid not in skipped_ids for gid in batch):
             if not stopped:

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -1149,6 +1149,7 @@ def merge_all(
     skipped_ids: set[str] = set()
     blocked: list[str] = []
     fetch_errors: list[str] = []
+    closed_while_waiting: list[str] = []
     failed: list[str] = []
 
     stopped = False
@@ -1236,8 +1237,10 @@ def merge_all(
                     skipped_ids.add(gid)
                     skipped.append(f"{gid} (fetch error)")
                 for gid in poll_closed:
-                    # Closed while we waited: report it like a closed PR found
-                    # up front instead of an anonymous incomplete batch.
+                    # Closed while we waited: name it like a closed PR found up
+                    # front, but keep it a failure -- we queued it for merging
+                    # and it never merged.
+                    closed_while_waiting.append(gid)
                     skipped_ids.add(gid)
                     skipped.append(f"{gid} (CLOSED)")
 
@@ -1272,6 +1275,11 @@ def merge_all(
             f"[red]Could not fetch PR state for ({len(fetch_errors)}): "
             f"{', '.join(fetch_errors)}. Check 'gh auth status' and re-run.[/red]"
         )
+    if closed_while_waiting:
+        console.print(
+            f"[red]Closed before auto-merge completed ({len(closed_while_waiting)}): "
+            f"{', '.join(closed_while_waiting)}. Reopen or recreate them and re-run.[/red]"
+        )
     if notify:
         exit_reason = (
             "merge_error"
@@ -1280,6 +1288,8 @@ def merge_all(
             if exited_early
             else "fetch_error"
             if fetch_errors
+            else "pr_closed"
+            if closed_while_waiting
             else "unmerged_dependency"
             if blocked
             else "success"
@@ -1292,11 +1302,18 @@ def merge_all(
                 "merged": merged,
                 "skipped": skipped_structured,
                 "failed": failed,
-                "success": not (failed or stopped or exited_early or blocked or fetch_errors),
+                "success": not (
+                    failed
+                    or stopped
+                    or exited_early
+                    or blocked
+                    or fetch_errors
+                    or closed_while_waiting
+                ),
                 "exit_reason": exit_reason,
             },
         )
 
-    if failed or stopped or exited_early or blocked or fetch_errors:
+    if failed or stopped or exited_early or blocked or fetch_errors or closed_while_waiting:
         raise typer.Exit(1)
     logger.success(f"Merge complete: {len(merged)} PRs merged")

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -610,4 +610,38 @@ class TestMergeClosedWhilePolling:
         assert "pr-2 (dependency pr-1 not merged)" in result.output
         payload = mock_webhook.call_args[0][1]
         assert [s["id"] for s in payload["skipped"]] == ["pr-1", "pr-2"]
-        assert payload["exit_reason"] == "unmerged_dependency"
+        assert payload["exit_reason"] == "pr_closed"
+        assert payload["success"] is False
+
+    @patch("pr_split.cli.time.sleep")
+    @patch("pr_split.cli._send_webhook")
+    @patch("pr_split.cli.merge_pr")
+    @patch("pr_split.cli.get_pr_state")
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_closed_leaf_during_auto_wait_exits_nonzero(
+        self,
+        mock_exists: MagicMock,
+        mock_load: MagicMock,
+        mock_state: MagicMock,
+        mock_merge: MagicMock,
+        mock_webhook: MagicMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        groups = [_group("pr-1", "closed later", files=["a.py"])]
+        mock_load.return_value = _plan_with_prs(groups)
+        open_state = {"state": "OPEN", "isDraft": False, "reviewDecision": None}
+        mock_state.side_effect = [open_state, {"state": "CLOSED"}]
+
+        result = runner.invoke(
+            app, ["merge", "--auto", "--notify", "https://example.invalid/hook"]
+        )
+
+        assert result.exit_code == 1
+        assert "pr-1 (CLOSED)" in result.output
+        assert "Closed before auto-merge completed (1): pr-1" in result.output
+        assert "Merge complete" not in result.output
+        payload = mock_webhook.call_args[0][1]
+        assert payload["exit_reason"] == "pr_closed"
+        assert payload["success"] is False
+        assert payload["merged"] == []

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -575,3 +575,39 @@ class TestMergeFetchErrors:
         payload = mock_webhook.call_args[0][1]
         assert payload["exit_reason"] == "fetch_error"
         assert [s["id"] for s in payload["skipped"]] == ["pr-1"]
+
+
+class TestMergeClosedWhilePolling:
+    @patch("pr_split.cli.time.sleep")
+    @patch("pr_split.cli._send_webhook")
+    @patch("pr_split.cli.merge_pr")
+    @patch("pr_split.cli.get_pr_state")
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_closed_during_auto_wait_is_listed_as_skipped(
+        self,
+        mock_exists: MagicMock,
+        mock_load: MagicMock,
+        mock_state: MagicMock,
+        mock_merge: MagicMock,
+        mock_webhook: MagicMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        groups = [
+            _group("pr-1", "closed later", files=["a.py"]),
+            _group("pr-2", "child", depends_on=["pr-1"], files=["b.py"]),
+        ]
+        mock_load.return_value = _plan_with_prs(groups)
+        open_state = {"state": "OPEN", "isDraft": False, "reviewDecision": None}
+        mock_state.side_effect = [open_state, {"state": "CLOSED"}, open_state]
+
+        result = runner.invoke(
+            app, ["merge", "--auto", "--notify", "https://example.invalid/hook"]
+        )
+
+        assert result.exit_code == 1
+        assert "pr-1 (CLOSED)" in result.output
+        assert "pr-2 (dependency pr-1 not merged)" in result.output
+        payload = mock_webhook.call_args[0][1]
+        assert [s["id"] for s in payload["skipped"]] == ["pr-1", "pr-2"]
+        assert payload["exit_reason"] == "unmerged_dependency"


### PR DESCRIPTION
## Summary

When a PR that `merge --auto` had queued was closed on GitHub before it merged, the run ended with the anonymous "Some PRs in this batch were not merged" message (or, for a leaf PR, nothing at all) and the webhook payload named no cause.

Now `_poll_for_merged` reports PRs that flip to `CLOSED` while waiting:

- listed as `<id> (CLOSED)` in the Skipped line and the webhook `skipped` list, so dependants show `(dependency <id> not merged)` instead of a generic incomplete batch
- a red `Closed before auto-merge completed (N): …` summary line
- the run exits 1 with `success: false` and `exit_reason="pr_closed"` (ranked between `fetch_error` and `unmerged_dependency`)

Stacked on #98 (`fix/merge-fetch-error-exit`).

## Test plan

- `test_closed_during_auto_wait_is_listed_as_skipped` (parent closed, child blocked) and `test_closed_leaf_during_auto_wait_exits_nonzero` — both fail on the base, pass here
- 454 tests pass, ruff clean
- Local review: 5/5
