### PR TITLE
fix: report a hunk listed twice in one group as a duplicate, not an overlap

### DIFF
--- a/pr_split/exceptions.py
+++ b/pr_split/exceptions.py
@@ -14,6 +14,7 @@ class ErrorMsg(StrEnum):
     CYCLE_DETECTED = "Dependency cycle detected in split plan"
     COVERAGE_GAP = "Hunk {file}[{index}] not assigned to any group"
     COVERAGE_OVERLAP = "Hunk {file}[{index}] assigned to multiple groups: {groups}"
+    COVERAGE_DUPLICATE = "Hunk {file}[{index}] listed more than once in group '{group}'"
     LOC_MISMATCH = "Total LOC {actual} does not match diff LOC {expected}"
     MERGE_CONFLICT = "Groups '{a}' and '{b}' modify overlapping regions in '{file}'"
     NO_PLAN = "No split plan found; run 'pr-split split' first"

--- a/pr_split/planner/validator.py
+++ b/pr_split/planner/validator.py
@@ -22,7 +22,14 @@ def validate_coverage(groups: list[Group], parsed_diff: ParsedDiff) -> None:
                 indices = assignment.hunk_indices
             for idx in indices:
                 key = (assignment.file_path, idx)
-                assigned.setdefault(key, []).append(group.id)
+                owners = assigned.setdefault(key, [])
+                if group.id in owners:
+                    # The same group claiming a hunk twice is a malformed
+                    # plan, not an overlap between groups.
+                    raise PlanValidationError(
+                        ErrorMsg.COVERAGE_DUPLICATE(file=key[0], index=key[1], group=group.id)
+                    )
+                owners.append(group.id)
 
     all_hunks = {(pf.path, i) for pf in parsed_diff.patch_set for i in range(len(pf))}
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -34,6 +34,10 @@ class TestErrorMsg:
         assert "bar.py" in result
         assert "g1, g2" in result
 
+    def test_coverage_duplicate(self) -> None:
+        result = ErrorMsg.COVERAGE_DUPLICATE(file="bar.py", index=1, group="g1")
+        assert result == "Hunk bar.py[1] listed more than once in group 'g1'"
+
     def test_loc_mismatch(self) -> None:
         result = ErrorMsg.LOC_MISMATCH(actual=10, expected=20)
         assert "10" in result

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -90,7 +90,31 @@ class TestValidateCoverage:
                 7,
             ),
         ]
-        with pytest.raises(PlanValidationError, match="multiple groups"):
+        with pytest.raises(PlanValidationError, match="multiple groups: g1, g2"):
+            validate_coverage(groups, parsed)
+
+    def test_same_group_listing_hunk_twice_is_reported_as_duplicate(self) -> None:
+        parsed = parse_diff(SAMPLE_DIFF)
+        groups = [
+            _make_group(
+                "g1",
+                [_ga("a.py", PARTIAL, [0]), _ga("a.py", WHOLE, [])],
+                3,
+            ),
+            _make_group("g2", [_ga("b.py", WHOLE, [0])], 4),
+        ]
+        with pytest.raises(PlanValidationError) as exc_info:
+            validate_coverage(groups, parsed)
+        assert str(exc_info.value) == "Hunk a.py[0] listed more than once in group 'g1'"
+        assert "multiple groups" not in str(exc_info.value)
+
+    def test_repeated_index_in_one_assignment_is_reported_as_duplicate(self) -> None:
+        parsed = parse_diff(SAMPLE_DIFF)
+        groups = [
+            _make_group("g1", [_ga("a.py", PARTIAL, [0, 0])], 3),
+            _make_group("g2", [_ga("b.py", WHOLE, [0])], 4),
+        ]
+        with pytest.raises(PlanValidationError, match=r"more than once in group 'g1'"):
             validate_coverage(groups, parsed)
 
 


### PR DESCRIPTION
## Summary

When a single group listed the same hunk twice — a repeated index in `hunk_indices`, or two assignments for the same file in one group — `validate_coverage` reported it as `Hunk a.py[0] assigned to multiple groups: pr-1, pr-1`, which sends the user looking for a second group that does not exist.

Now that case raises a new `ErrorMsg.COVERAGE_DUPLICATE`: `Hunk a.py[0] listed more than once in group 'pr-1'`. Genuine cross-group overlaps keep the existing message.

## Test plan

- `test_same_group_listing_hunk_twice_is_reported_as_duplicate` and `test_repeated_index_in_one_assignment_is_reported_as_duplicate` (both fail on main with `multiple groups: g1, g1`), plus an `ErrorMsg` formatting test
- 447 tests pass, ruff clean
- Local review: 5/5
