### PR TITLE
fix: count every hunk of a WHOLE_FILE assignment in LOC estimates

### DIFF
--- a/pr_split/planner/chunker.py
+++ b/pr_split/planner/chunker.py
@@ -204,7 +204,14 @@ def recompute_estimated_loc(groups: list[Group], parsed_diff: ParsedDiff) -> Non
         removed = 0
         for assignment in group.assignments:
             max_idx = file_hunk_counts.get(assignment.file_path, 0)
-            for idx in assignment.hunk_indices:
+            # A WHOLE_FILE assignment covers every hunk of the file whatever
+            # its hunk_indices list says (empty or partial); count it the way
+            # validate_coverage and the reconstructor do.
+            if assignment.assignment_type is AssignmentType.WHOLE_FILE:
+                indices: list[int] | range = range(max_idx)
+            else:
+                indices = assignment.hunk_indices
+            for idx in indices:
                 if idx >= max_idx:
                     logger.warning(
                         logs.INVALID_HUNK_INDEX.format(

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -239,6 +239,47 @@ class TestRecomputeEstimatedLoc:
         assert groups[0].estimated_loc == 3
         assert groups[1].estimated_loc == 4
 
+    def test_whole_file_with_empty_indices_counts_every_hunk(self) -> None:
+        parsed = parse_diff(TWO_HUNK_DIFF)
+        whole = GroupAssignment(
+            file_path="c.py", assignment_type=AssignmentType.WHOLE_FILE, hunk_indices=[]
+        )
+        groups = [_group("g1", [whole])]
+        recompute_estimated_loc(groups, parsed)
+        assert groups[0].estimated_loc == 2
+        assert groups[0].estimated_added == 2
+        assert groups[0].estimated_removed == 0
+        assert whole.hunk_indices == []
+
+    def test_whole_file_with_partial_indices_counts_every_hunk(self) -> None:
+        parsed = parse_diff(TWO_HUNK_DIFF)
+        whole = GroupAssignment(
+            file_path="c.py", assignment_type=AssignmentType.WHOLE_FILE, hunk_indices=[0]
+        )
+        groups = [_group("g1", [whole])]
+        recompute_estimated_loc(groups, parsed)
+        assert groups[0].estimated_loc == 2
+        assert whole.hunk_indices == [0]
+
+    def test_whole_file_with_full_indices_matches_partial_hunks(self) -> None:
+        parsed = parse_diff(TWO_HUNK_DIFF)
+        whole = GroupAssignment(
+            file_path="c.py", assignment_type=AssignmentType.WHOLE_FILE, hunk_indices=[0, 1]
+        )
+        partial = _ga("c.py", [0, 1])
+        groups = [_group("g1", [whole]), _group("g2", [partial])]
+        recompute_estimated_loc(groups, parsed)
+        assert groups[0].estimated_loc == groups[1].estimated_loc == 2
+
+    def test_whole_file_for_unknown_path_is_zero(self) -> None:
+        parsed = parse_diff(TWO_HUNK_DIFF)
+        whole = GroupAssignment(
+            file_path="missing.py", assignment_type=AssignmentType.WHOLE_FILE, hunk_indices=[]
+        )
+        groups = [_group("g1", [whole])]
+        recompute_estimated_loc(groups, parsed)
+        assert groups[0].estimated_loc == 0
+
 
 class TestAssignUncoveredHunks:
     def test_all_covered_returns_zero(self) -> None:


### PR DESCRIPTION
## Summary

`recompute_estimated_loc` summed only `assignment.hunk_indices`, while `validate_coverage` and the reconstructor treat a `WHOLE_FILE` assignment as covering every hunk of the file whatever its list says. The LLM path can emit `WHOLE_FILE` with an empty or partial list, so such a plan passed coverage but got a too-small `estimated_loc` and then failed `validate_loc` with `LOC_MISMATCH`.

`recompute_estimated_loc` now counts `range(hunk_count)` for every `WHOLE_FILE` assignment (the list itself is left untouched); `PARTIAL_HUNKS` is unchanged.

Stacked on #108 (`fix/move-assignment-recompute-loc`).

## Test plan

- `test_chunker.py`: WHOLE_FILE with `[]` and `[0]` on a two-hunk file now estimate 2 lines (both fail on the base with 0 / 1), full list matches an equivalent PARTIAL_HUNKS group, unknown path stays 0
- 450 tests pass, ruff clean
- Local review: 5/5

Follow-up noted by the review (not in this PR): `assign_uncovered_hunks` and `validate_no_conflicts` still read only `hunk_indices`.
