### PR TITLE
fix: keep split --dry-run non-destructive and report a typo'd branch as not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Available placeholders: `{description}`, `{files}`, `{added}`, `{removed}`, `{lo
 
 ### Re-split with different parameters
 
-Running `split` again when a plan already exists will prompt you to clean up existing branches and PRs before re-planning. Dry-run plans are silently overwritten.
+Running `split` again when a plan already exists will prompt you to clean up existing branches and PRs before re-planning. Dry-run plans are silently overwritten. With `--dry-run`, `split` never closes PRs or deletes branches: if the saved plan has already been executed it exits 1 and asks you to run `pr-split clean` first.
 
 ### Clean up
 

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -645,6 +645,11 @@ def _interactive_edit(groups: list[Group], parsed_diff: ParsedDiff) -> list[Grou
             )
 
 
+def _is_fork_ref(dev_branch: str) -> bool:
+    """True for the PR-number (`#42`) and `user:branch` argument forms."""
+    return dev_branch.lstrip("#").isdigit() or ":" in dev_branch
+
+
 def _resolve_fork_ref(dev_branch: str) -> ForkPRInfo | None:
     cleaned = dev_branch.lstrip("#")
     if cleaned.isdigit():
@@ -726,6 +731,12 @@ def split(
     fork_info: ForkPRInfo | None = None
 
     if not branch_exists(dev_branch):
+        # Only a PR number or user:branch can be fetched from GitHub; a plain
+        # branch name that does not exist is just a typo, so say so before
+        # touching gh (which --dry-run must not require).
+        if not _is_fork_ref(dev_branch):
+            console.print(f"[red]{ErrorMsg.BRANCH_NOT_FOUND(branch=dev_branch)}[/red]")
+            raise typer.Exit(1)
         if not check_gh_auth():
             console.print(f"[red]{ErrorMsg.GH_AUTH_FAILED()}[/red]")
             raise typer.Exit(1)
@@ -745,6 +756,16 @@ def split(
     if plan_exists():
         existing = load_plan()
         has_git_state = existing.git_state.branches or existing.git_state.prs
+        if has_git_state and dry_run:
+            # A preview must never close PRs or delete branches, and saving
+            # the new plan would drop the record of the existing ones.
+            console.print("[yellow]An existing split plan with branches/PRs was found.[/yellow]")
+            console.print(
+                "[red]--dry-run would overwrite the record of those branches/PRs without "
+                "cleaning them up. Run 'pr-split clean' first, or run 'pr-split split' "
+                "without --dry-run to clean up and re-split.[/red]"
+            )
+            raise typer.Exit(1)
         if has_git_state:
             console.print("[yellow]An existing split plan with branches/PRs was found.[/yellow]")
             console.print(

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -478,6 +478,92 @@ class TestSplitCommandValidation:
         result = runner.invoke(app, ["split", "unknown-ref", "--dry-run"])
         assert result.exit_code != 0
 
+    @patch("pr_split.cli._resolve_fork_ref")
+    @patch("pr_split.cli.is_worktree_clean", return_value=True)
+    @patch("pr_split.cli.check_gh_auth", return_value=False)
+    @patch("pr_split.cli.branch_exists", return_value=False)
+    def test_split_missing_plain_branch_reports_branch_not_found(
+        self,
+        mock_be: MagicMock,
+        mock_auth: MagicMock,
+        mock_clean: MagicMock,
+        mock_resolve: MagicMock,
+    ) -> None:
+        result = runner.invoke(app, ["split", "nosuchbranch", "--dry-run"])
+        assert result.exit_code == 1
+        assert "Branch 'nosuchbranch' does not exist" in result.output
+        assert "GitHub CLI authentication failed" not in result.output
+        mock_auth.assert_not_called()
+        mock_resolve.assert_not_called()
+
+    @patch("pr_split.cli.check_gh_auth", return_value=False)
+    @patch("pr_split.cli.branch_exists", return_value=False)
+    def test_split_fork_shaped_ref_still_checks_gh_auth(
+        self,
+        mock_be: MagicMock,
+        mock_auth: MagicMock,
+    ) -> None:
+        result = runner.invoke(app, ["split", "someone:feature", "--dry-run"])
+        assert result.exit_code == 1
+        assert "GitHub CLI authentication failed" in result.output
+        mock_auth.assert_called_once()
+
+
+class TestSplitDryRunWithExecutedPlan:
+    @patch("pr_split.cli._cleanup_git_state")
+    @patch("pr_split.cli.typer.confirm")
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_dry_run_refuses_instead_of_offering_cleanup(
+        self,
+        mock_be: MagicMock,
+        mock_validate: MagicMock,
+        mock_pe: MagicMock,
+        mock_load: MagicMock,
+        mock_confirm: MagicMock,
+        mock_cleanup: MagicMock,
+    ) -> None:
+        existing = MagicMock()
+        existing.git_state.branches = []
+        existing.git_state.prs = [MagicMock()]
+        mock_load.return_value = existing
+
+        result = runner.invoke(app, ["split", "feature", "--dry-run"])
+
+        assert result.exit_code == 1
+        assert "Run 'pr-split clean' first" in result.output
+        mock_confirm.assert_not_called()
+        mock_cleanup.assert_not_called()
+
+    @patch("pr_split.cli.extract_diff", side_effect=PRSplitError("stop here"))
+    @patch("pr_split.cli._cleanup_git_state", return_value=(1, 1))
+    @patch("pr_split.cli.typer.confirm", return_value=True)
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_real_split_still_offers_cleanup(
+        self,
+        mock_be: MagicMock,
+        mock_validate: MagicMock,
+        mock_pe: MagicMock,
+        mock_load: MagicMock,
+        mock_confirm: MagicMock,
+        mock_cleanup: MagicMock,
+        mock_extract: MagicMock,
+    ) -> None:
+        existing = MagicMock()
+        existing.git_state.branches = []
+        existing.git_state.prs = [MagicMock()]
+        mock_load.return_value = existing
+
+        runner.invoke(app, ["split", "feature"], env={"ANTHROPIC_API_KEY": "sk-test"})
+
+        mock_confirm.assert_called_once()
+        mock_cleanup.assert_called_once_with(existing.git_state)
+
 
 # ---------------------------------------------------------------------------
 # execute command


### PR DESCRIPTION
## Summary

Two problems in the `split` preamble, both hit by `--dry-run`:

1. **Typo'd branch reported as an auth failure.** When `dev_branch` did not exist locally, `split` called `check_gh_auth()` before checking whether the argument was even fork-shaped, so `pr-split split nosuchbranch --dry-run` with gh unauthenticated printed "GitHub CLI authentication failed" instead of "Branch 'nosuchbranch' does not exist" — even though `--dry-run` is documented not to need gh. A new `_is_fork_ref` (PR number `#42` / `user:branch`) now gates the gh call; plain names fail with `BRANCH_NOT_FOUND` first.
2. **A preview could close PRs and delete branches.** `split --dry-run` ("Preview plan without creating branches or PRs") reached the existing-plan cleanup prompt; answering `y` ran `gh pr close` / `git push --delete`, and answering `n` refused the preview. With an executed plan on disk, `--dry-run` now exits 1 pointing at `pr-split clean` and never prompts (saving the preview would also have dropped the record of those branches/PRs). The non-dry-run flow is unchanged. README's re-split paragraph updated.

## Test plan

- `test_split_missing_plain_branch_reports_branch_not_found`, `test_split_fork_shaped_ref_still_checks_gh_auth`, `TestSplitDryRunWithExecutedPlan` (refusal without prompt; real split still offers cleanup) — the two behaviour-changing tests fail on main
- 448 tests pass, ruff clean
- Local review: 5/5
