### PR TITLE
fix: expand WHOLE_FILE assignments consistently in coverage, conflict and auto-assign checks

### DIFF
--- a/pr_split/planner/chunker.py
+++ b/pr_split/planner/chunker.py
@@ -204,14 +204,7 @@ def recompute_estimated_loc(groups: list[Group], parsed_diff: ParsedDiff) -> Non
         removed = 0
         for assignment in group.assignments:
             max_idx = file_hunk_counts.get(assignment.file_path, 0)
-            # A WHOLE_FILE assignment covers every hunk of the file whatever
-            # its hunk_indices list says (empty or partial); count it the way
-            # validate_coverage and the reconstructor do.
-            if assignment.assignment_type is AssignmentType.WHOLE_FILE:
-                indices: list[int] | range = range(max_idx)
-            else:
-                indices = assignment.hunk_indices
-            for idx in indices:
+            for idx in assignment.covered_hunks(max_idx):
                 if idx >= max_idx:
                     logger.warning(
                         logs.INVALID_HUNK_INDEX.format(
@@ -231,11 +224,15 @@ def recompute_estimated_loc(groups: list[Group], parsed_diff: ParsedDiff) -> Non
 
 
 def assign_uncovered_hunks(groups: list[Group], parsed_diff: ParsedDiff) -> int:
+    hunk_counts = {pf.path: len(pf) for pf in parsed_diff.patch_set}
     assigned = {
-        (a.file_path, idx) for g in groups for a in g.assignments for idx in a.hunk_indices
+        (a.file_path, idx)
+        for g in groups
+        for a in g.assignments
+        for idx in a.covered_hunks(hunk_counts.get(a.file_path, 0))
     }
 
-    all_hunks = {(pf.path, i) for pf in parsed_diff.patch_set for i in range(len(pf))}
+    all_hunks = {(path, i) for path, count in hunk_counts.items() for i in range(count)}
     unassigned = sorted(all_hunks - assigned)
     if not unassigned:
         return 0

--- a/pr_split/planner/validator.py
+++ b/pr_split/planner/validator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from .. import logs
-from ..constants import AssignmentType, LocViolationType
+from ..constants import LocViolationType
 from ..diff_ops import ParsedDiff
 from ..exceptions import ErrorMsg, PlanValidationError
 from ..graph import PlanDAG
@@ -14,13 +14,7 @@ def validate_coverage(groups: list[Group], parsed_diff: ParsedDiff) -> None:
     assigned: dict[tuple[str, int], list[str]] = {}
     for group in groups:
         for assignment in group.assignments:
-            # A WHOLE_FILE assignment claims every hunk of the file even when
-            # its hunk_indices list was left empty.
-            if assignment.assignment_type is AssignmentType.WHOLE_FILE:
-                indices = range(hunk_counts.get(assignment.file_path, 0))
-            else:
-                indices = assignment.hunk_indices
-            for idx in indices:
+            for idx in assignment.covered_hunks(hunk_counts.get(assignment.file_path, 0)):
                 key = (assignment.file_path, idx)
                 assigned.setdefault(key, []).append(group.id)
 
@@ -46,12 +40,22 @@ def validate_loc(groups: list[Group], parsed_diff: ParsedDiff) -> None:
         )
 
 
-def validate_no_conflicts(groups: list[Group], dag: PlanDAG) -> None:
+def validate_no_conflicts(
+    groups: list[Group], dag: PlanDAG, parsed_diff: ParsedDiff | None = None
+) -> None:
+    # A WHOLE_FILE assignment can only be expanded to every hunk when the
+    # diff is known; validate_plan always passes it so this agrees with
+    # validate_coverage. Without it, fall back to the assignment's own list.
+    hunk_counts = {pf.path: len(pf) for pf in parsed_diff.patch_set} if parsed_diff else {}
     group_files: dict[str, dict[str, set[int]]] = {}
     for group in groups:
         file_hunks: dict[str, set[int]] = {}
         for assignment in group.assignments:
-            file_hunks.setdefault(assignment.file_path, set()).update(assignment.hunk_indices)
+            count = hunk_counts.get(assignment.file_path)
+            covered = (
+                assignment.covered_hunks(count) if count is not None else assignment.hunk_indices
+            )
+            file_hunks.setdefault(assignment.file_path, set()).update(covered)
         group_files[group.id] = file_hunks
 
     group_ids = [g.id for g in groups]
@@ -140,5 +144,5 @@ def validate_plan(
     dag.validate_acyclic()
     validate_coverage(groups, parsed_diff)
     validate_loc(groups, parsed_diff)
-    validate_no_conflicts(groups, dag)
+    validate_no_conflicts(groups, dag, parsed_diff)
     return validate_loc_bounds(groups, max_loc, min_loc)

--- a/pr_split/schemas.py
+++ b/pr_split/schemas.py
@@ -12,6 +12,18 @@ class GroupAssignment(BaseModel):
     assignment_type: AssignmentType
     hunk_indices: list[int] = Field(default_factory=list)
 
+    def covered_hunks(self, hunk_count: int) -> list[int]:
+        """Hunk indices this assignment claims, given the file's hunk count.
+
+        A WHOLE_FILE assignment covers every hunk whatever its hunk_indices
+        list says (the LLM may leave it empty or partial); PARTIAL_HUNKS
+        covers exactly the listed indices. Every consumer that expands an
+        assignment into hunks must go through this so they cannot disagree.
+        """
+        if self.assignment_type is AssignmentType.WHOLE_FILE:
+            return list(range(hunk_count))
+        return list(self.hunk_indices)
+
 
 class Group(BaseModel):
     id: str

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -291,6 +291,26 @@ class TestAssignUncoveredHunks:
         count = assign_uncovered_hunks(groups, parsed)
         assert count == 0
 
+    def test_whole_file_with_empty_indices_is_already_covered(self) -> None:
+        parsed = parse_diff(TWO_HUNK_DIFF)
+        whole = GroupAssignment(
+            file_path="c.py", assignment_type=AssignmentType.WHOLE_FILE, hunk_indices=[]
+        )
+        groups = [_group("g1", [whole])]
+        count = assign_uncovered_hunks(groups, parsed)
+        assert count == 0
+        assert whole.hunk_indices == []
+        assert whole.assignment_type is AssignmentType.WHOLE_FILE
+
+    def test_whole_file_with_partial_indices_is_already_covered(self) -> None:
+        parsed = parse_diff(TWO_HUNK_DIFF)
+        whole = GroupAssignment(
+            file_path="c.py", assignment_type=AssignmentType.WHOLE_FILE, hunk_indices=[0]
+        )
+        groups = [_group("g1", [whole])]
+        assert assign_uncovered_hunks(groups, parsed) == 0
+        assert whole.hunk_indices == [0]
+
     def test_uncovered_assigned_to_file_group(self) -> None:
         parsed = parse_diff(SAMPLE_DIFF)
         groups = [_group("g1", [_ga("a.py", [0])])]

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -131,6 +131,24 @@ class TestValidateNoConflicts:
         with pytest.raises(PlanValidationError, match="overlapping"):
             validate_no_conflicts(groups, dag)
 
+    def test_whole_file_with_empty_indices_conflicts_with_partial(self) -> None:
+        parsed = parse_diff(SAMPLE_DIFF)
+        groups = [
+            _make_group("g1", [_ga("a.py", WHOLE, [])], 3),
+            _make_group("g2", [_ga("a.py", PARTIAL, [0])], 3),
+        ]
+        dag = PlanDAG(groups)
+        with pytest.raises(PlanValidationError, match="overlapping"):
+            validate_no_conflicts(groups, dag, parsed)
+
+    def test_whole_file_with_empty_indices_and_no_diff_uses_its_list(self) -> None:
+        groups = [
+            _make_group("g1", [_ga("a.py", WHOLE, [])], 3),
+            _make_group("g2", [_ga("a.py", PARTIAL, [0])], 3),
+        ]
+        dag = PlanDAG(groups)
+        validate_no_conflicts(groups, dag)
+
     def test_dependent_groups_skip_conflict_check(self) -> None:
         groups = [
             _make_group("g1", [_ga("a.py", PARTIAL, [0])], 3),
@@ -195,3 +213,17 @@ class TestValidateCoverageWholeFileExpansion:
         ]
         with pytest.raises(PlanValidationError, match="multiple groups"):
             validate_coverage(groups, parsed)
+
+
+class TestCoveredHunks:
+    def test_whole_file_ignores_its_list(self) -> None:
+        assert _ga("a.py", WHOLE, []).covered_hunks(3) == [0, 1, 2]
+        assert _ga("a.py", WHOLE, [1]).covered_hunks(3) == [0, 1, 2]
+        assert _ga("a.py", WHOLE, []).covered_hunks(0) == []
+
+    def test_partial_returns_its_list(self) -> None:
+        assignment = _ga("a.py", PARTIAL, [2, 0])
+        covered = assignment.covered_hunks(3)
+        assert covered == [2, 0]
+        covered.append(9)
+        assert assignment.hunk_indices == [2, 0]


### PR DESCRIPTION
## Summary

Four places expand a `GroupAssignment` into hunks, and they disagreed on `WHOLE_FILE` assignments whose `hunk_indices` list is empty or partial (which the LLM path can produce): `validate_coverage` (and, after #109, `recompute_estimated_loc`) count every hunk of the file, but `assign_uncovered_hunks` and `validate_no_conflicts` read only the list. So such an assignment was "auto-assigned" hunk by hunk (a warning per hunk and a rewritten list) and an independent group touching the same file was never reported as a merge conflict.

This adds `GroupAssignment.covered_hunks(hunk_count)` as the single source of truth and routes all four sites through it. `validate_no_conflicts` gains an optional `parsed_diff` (always passed by `validate_plan`; without it, an assignment's own list is used).

Stacked on #109 (`fix/recompute-loc-whole-file`).

## Test plan

- `test_chunker.py`: WHOLE_FILE with `[]`/`[0]` is already covered (0 auto-assigned, list untouched)
- `test_validator.py`: WHOLE_FILE `[]` vs PARTIAL `[0]` in independent groups now raises "overlapping regions"; no-diff fallback; `covered_hunks` unit tests
- five of the new tests fail on the base
- 456 tests pass, ruff clean
- Local review: 5/5
