### PR TITLE
fix: reject out-of-range hunk indices and unknown files during plan validation

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -795,8 +795,14 @@ def split(
     groups = plan_split(parsed_diff, settings)
 
     logger.info(logs.VALIDATING_PLAN)
-    dag = PlanDAG(groups)
-    warnings = validate_plan(groups, parsed_diff, dag, settings.max_loc, min_loc=settings.min_loc)
+    try:
+        dag = PlanDAG(groups)
+        warnings = validate_plan(
+            groups, parsed_diff, dag, settings.max_loc, min_loc=settings.min_loc
+        )
+    except PRSplitError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
     _handle_loc_bound_warnings(warnings, strict_loc_bounds=settings.strict_loc_bounds)
     logger.success(logs.VALIDATION_PASSED)
 

--- a/pr_split/exceptions.py
+++ b/pr_split/exceptions.py
@@ -14,6 +14,10 @@ class ErrorMsg(StrEnum):
     CYCLE_DETECTED = "Dependency cycle detected in split plan"
     COVERAGE_GAP = "Hunk {file}[{index}] not assigned to any group"
     COVERAGE_OVERLAP = "Hunk {file}[{index}] assigned to multiple groups: {groups}"
+    UNKNOWN_FILE = "Group '{group}' references '{file}', which is not in the diff"
+    HUNK_INDEX_OUT_OF_RANGE = (
+        "Hunk {file}[{index}] in group '{group}' does not exist (file has {count} hunks)"
+    )
     LOC_MISMATCH = "Total LOC {actual} does not match diff LOC {expected}"
     MERGE_CONFLICT = "Groups '{a}' and '{b}' modify overlapping regions in '{file}'"
     NO_PLAN = "No split plan found; run 'pr-split split' first"

--- a/pr_split/planner/validator.py
+++ b/pr_split/planner/validator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from .. import logs
-from ..constants import AssignmentType, LocViolationType
+from ..constants import LocViolationType
 from ..diff_ops import ParsedDiff
 from ..exceptions import ErrorMsg, PlanValidationError
 from ..graph import PlanDAG
@@ -14,13 +14,21 @@ def validate_coverage(groups: list[Group], parsed_diff: ParsedDiff) -> None:
     assigned: dict[tuple[str, int], list[str]] = {}
     for group in groups:
         for assignment in group.assignments:
-            # A WHOLE_FILE assignment claims every hunk of the file even when
-            # its hunk_indices list was left empty.
-            if assignment.assignment_type is AssignmentType.WHOLE_FILE:
-                indices = range(hunk_counts.get(assignment.file_path, 0))
-            else:
-                indices = assignment.hunk_indices
-            for idx in indices:
+            count = hunk_counts.get(assignment.file_path)
+            if count is None:
+                raise PlanValidationError(
+                    ErrorMsg.UNKNOWN_FILE(group=group.id, file=assignment.file_path)
+                )
+            # Reject stale or invented indices here; the reconstructor would
+            # otherwise fail with an IndexError while materializing.
+            for idx in assignment.hunk_indices:
+                if idx < 0 or idx >= count:
+                    raise PlanValidationError(
+                        ErrorMsg.HUNK_INDEX_OUT_OF_RANGE(
+                            file=assignment.file_path, index=idx, group=group.id, count=count
+                        )
+                    )
+            for idx in assignment.covered_indices(count):
                 key = (assignment.file_path, idx)
                 assigned.setdefault(key, []).append(group.id)
 

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -231,6 +231,50 @@ class TestHandleLocBoundWarnings:
         mock_warning.assert_not_called()
 
 
+class TestSplitRejectsInvalidLlmPlan:
+    @patch("pr_split.cli.save_plan")
+    @patch("pr_split.cli.merge_base", return_value="abc123")
+    @patch("pr_split.cli._interactive_edit")
+    @patch("pr_split.cli._present_plan")
+    @patch("pr_split.cli.plan_split")
+    @patch("pr_split.cli.extract_diff")
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_out_of_range_hunk_index_is_a_clean_error(
+        self,
+        mock_branch_exists: MagicMock,
+        mock_validate_inputs: MagicMock,
+        mock_extract_diff: MagicMock,
+        mock_plan_split: MagicMock,
+        mock_present_plan: MagicMock,
+        mock_interactive_edit: MagicMock,
+        mock_merge_base: MagicMock,
+        mock_save_plan: MagicMock,
+    ) -> None:
+        mock_extract_diff.return_value = (
+            "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n@@ -1 +1 @@\n-x\n+y\n"
+        )
+        bad = _group("pr-1", "t")
+        bad.assignments = [
+            GroupAssignment(
+                file_path="a.py",
+                assignment_type=AssignmentType.PARTIAL_HUNKS,
+                hunk_indices=[0, 9],
+            )
+        ]
+        mock_plan_split.return_value = [bad]
+
+        result = runner.invoke(
+            app, ["split", "feature-branch", "--dry-run"], env={"ANTHROPIC_API_KEY": "sk-test"}
+        )
+
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "Hunk a.py[9] in group 'pr-1' does not exist (file has 1 hunks)" in result.output
+        mock_present_plan.assert_not_called()
+        mock_save_plan.assert_not_called()
+
+
 class TestSplitCliEnvVars:
     @patch("pr_split.cli.save_plan")
     @patch("pr_split.cli.merge_base", return_value="abc123")

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -72,6 +72,46 @@ class TestValidateCoverage:
         ]
         validate_coverage(groups, parsed)
 
+    def test_partial_index_out_of_range_raises(self) -> None:
+        parsed = parse_diff(SAMPLE_DIFF)
+        groups = [
+            _make_group("g1", [_ga("a.py", PARTIAL, [0, 5])], 3),
+            _make_group("g2", [_ga("b.py", WHOLE, [0])], 4),
+        ]
+        with pytest.raises(PlanValidationError) as exc_info:
+            validate_coverage(groups, parsed)
+        assert str(exc_info.value) == (
+            "Hunk a.py[5] in group 'g1' does not exist (file has 1 hunks)"
+        )
+
+    def test_negative_index_raises(self) -> None:
+        parsed = parse_diff(SAMPLE_DIFF)
+        groups = [
+            _make_group("g1", [_ga("a.py", PARTIAL, [-1])], 3),
+            _make_group("g2", [_ga("b.py", WHOLE, [0])], 4),
+        ]
+        with pytest.raises(PlanValidationError, match=r"a\.py\[-1\] in group 'g1'"):
+            validate_coverage(groups, parsed)
+
+    def test_whole_file_with_stale_index_raises(self) -> None:
+        parsed = parse_diff(SAMPLE_DIFF)
+        groups = [
+            _make_group("g1", [_ga("a.py", WHOLE, [7])], 3),
+            _make_group("g2", [_ga("b.py", WHOLE, [0])], 4),
+        ]
+        with pytest.raises(PlanValidationError, match=r"a\.py\[7\]"):
+            validate_coverage(groups, parsed)
+
+    def test_file_not_in_diff_raises(self) -> None:
+        parsed = parse_diff(SAMPLE_DIFF)
+        groups = [
+            _make_group("g1", [_ga("a.py", WHOLE, [0]), _ga("ghost.py", WHOLE, [])], 3),
+            _make_group("g2", [_ga("b.py", WHOLE, [0])], 4),
+        ]
+        with pytest.raises(PlanValidationError) as exc_info:
+            validate_coverage(groups, parsed)
+        assert str(exc_info.value) == "Group 'g1' references 'ghost.py', which is not in the diff"
+
     def test_missing_hunk_raises(self) -> None:
         parsed = parse_diff(SAMPLE_DIFF)
         groups = [


### PR DESCRIPTION
## Summary

`validate_coverage` accepted hunk indices outside `0..count-1` (a negative index silently addressed the file from the end) and assignments for files that are not in the diff at all. Such plans — which the LLM path can produce, and which `recompute_estimated_loc` only warns about — passed validation and then failed with an `IndexError` or a git error while materialising branches.

Now they fail validation with a clear message:

- `Hunk a.py[9] in group 'pr-1' does not exist (file has 1 hunks)` (`ErrorMsg.HUNK_INDEX_OUT_OF_RANGE`; also checked on `WHOLE_FILE` lists, which the reconstructor unions into the covered set)
- `Group 'pr-1' references 'ghost.py', which is not in the diff` (`ErrorMsg.UNKNOWN_FILE`)

The first `validate_plan` call in `split` is now wrapped in the same `try/except PRSplitError` guard used after interactive editing, so an invalid LLM plan exits 1 with a red one-liner instead of a traceback (identical to the guard #63 adds; the merge is trivial either way).

Restacked after the local review confirmed the same behaviour on this base (465 tests pass).

Stacked on #60 (`fix/interactive-move-recompute-loc`, stack #74 = #58→#60→#114→#129); #58 provides `GroupAssignment.covered_indices`, which this PR uses.

## Test plan

- `test_validator.py`: out-of-range, negative, stale WHOLE_FILE index, unknown file (all fail on the base)
- `TestSplitRejectsInvalidLlmPlan`: `split --dry-run` with a plan containing `[0, 9]` exits 1 cleanly with the message, no unhandled exception, plan neither presented nor saved (fails on the base with an uncaught `PlanValidationError`)
- 461 tests pass, ruff clean
- Local review: 5/5

