### PR TITLE
fix: carry every ancestor's hunks into a stacked child that touches the same file

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -243,7 +243,14 @@ def _stacked_batch_args(
             group = groups_by_id[gid]
             parents = dag.parents(gid)
             if len(parents) == 1:
-                merged = merge_chain_assignments(group, [effective[parents[0]]], hunk_counts)
+                # Merge against every ancestor, not just the parent: the
+                # branch starts from the parent, but a file this group touches
+                # is rebuilt from the merge base with its own hunks, so hunks a
+                # grandparent added to that same file must be applied too or
+                # the child's commit would revert them.
+                merged = merge_chain_assignments(
+                    group, [effective[a] for a in sorted(dag.ancestors(gid))], hunk_counts
+                )
                 start_point = branch_names[parents[0]]
                 group_base = branch_names[parents[0]]
             elif len(parents) > 1:

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -443,6 +443,46 @@ class TestStackedBatchArgsMergeNode:
         _, base, start = self._merge_node_args()
         assert (base, start) == ("main", "base_sha")
 
+    def _chain_with_shared_file(self) -> list[Group]:
+        def partial(path: str, indices: list[int]) -> GroupAssignment:
+            return GroupAssignment(
+                file_path=path,
+                assignment_type=AssignmentType.PARTIAL_HUNKS,
+                hunk_indices=indices,
+            )
+
+        top = _group("pr-1", "top")
+        top.assignments = [partial("f.py", [0])]
+        middle = _group("pr-2", "middle", ["pr-1"])
+        middle.assignments = [partial("g.py", [0])]
+        bottom = _group("pr-3", "bottom", ["pr-2"])
+        bottom.assignments = [partial("f.py", [1])]
+        return [top, middle, bottom]
+
+    def _chain_args(self) -> dict[str, tuple[Group, str, str]]:
+        groups = self._chain_with_shared_file()
+        batches = _stacked_batch_args(
+            PlanDAG(groups),
+            {g.id: g for g in groups},
+            {g.id: f"pr-split/ns/{g.id}" for g in groups},
+            "main",
+            "base_sha",
+            {"f.py": 2, "g.py": 1},
+        )
+        return {
+            merged.id: (merged, base, start) for batch in batches for merged, base, start in batch
+        }
+
+    def test_grandchild_carries_grandparent_hunks_of_shared_file(self) -> None:
+        merged, base, start = self._chain_args()["pr-3"]
+        by_file = {a.file_path: a.hunk_indices for a in merged.assignments}
+        assert by_file == {"f.py": [0, 1]}
+        assert (base, start) == ("pr-split/ns/pr-2", "pr-split/ns/pr-2")
+
+    def test_middle_of_chain_does_not_gain_files_it_never_touched(self) -> None:
+        merged, _, _ = self._chain_args()["pr-2"]
+        assert [a.file_path for a in merged.assignments] == ["g.py"]
+
 
 class TestPushFailureGating:
     @patch("pr_split.cli.create_pr", return_value=(1, "https://github.com/pr/1"))


### PR DESCRIPTION
## Summary

**Stacked branches could silently revert a grandparent's changes.** In `_stacked_batch_args`, a single-parent group was merged only against `effective[parent]`, which holds just the parent's own files. When a grandparent had edited a file the parent did not touch, and the child edits that file again, `materialize_group_files` rebuilt it from the merge base with the child's hunks only and wrote it into a worktree started from the parent branch — dropping the grandparent's hunks from the child's commit (and from every PR above it).

Repro shape (exactly what the graph backend produces after transitive reduction): `pr-1 = f.py[0]` → `pr-2 = g.py` → `pr-3 = f.py[1]`. `git diff dev pr-3` showed `1 deletion` on the base; the leaf now matches `dev`.

Fix: merge a single-parent group against `[effective[a] for a in dag.ancestors(gid)]`. `carry_ancestor_files` stays `False`, so files the child does not touch still come from the parent branch unchanged; the merge-node path already used all ancestors.

## Test plan

- `test_grandchild_carries_grandparent_hunks_of_shared_file` (fails on main: pr-3 gets `f.py [1]` instead of `[0, 1]`) and `test_middle_of_chain_does_not_gain_files_it_never_touched`
- Review verified with real git repos: original repro, 4-deep chain (two shapes), parent-already-carried, and diamond-above-chain — the first two go from mismatch to byte-identical with `dev`, the rest are unchanged
- 446 tests pass, ruff clean
- Local review: 5/5
