### PR TITLE
fix: delete the group branch when materializing or committing it fails

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -197,6 +197,7 @@ def _create_single_branch_and_commit(
 
     with _worktree_ref_lock:
         add_worktree(worktree_path, branch_name, start_point or merge_base_ref)
+    failed = False
     try:
         materialized = materialize_group_files(parsed_diff, group, merge_base_ref)
         for file_path, content in materialized.items():
@@ -214,11 +215,22 @@ def _create_single_branch_and_commit(
             group.title,
             author=author,
         )
+    except BaseException:
+        failed = True
+        raise
     finally:
         try:
             remove_worktree(worktree_path)
         except PRSplitError as exc:
             logger.warning(f"Failed to remove worktree {worktree_path}: {exc}")
+        if failed:
+            # add_worktree created the branch; the caller only knows about
+            # branches that produced a BranchRecord, so drop this one here or
+            # it lingers (and blocks the next run's namespace).
+            try:
+                delete_branch(branch_name)
+            except PRSplitError as exc:
+                logger.warning(f"Could not clean up branch {branch_name}: {exc}")
 
     return BranchRecord(
         group_id=group.id,

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import contextlib
 import threading
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from pr_split.cli import (
     _create_branches_and_commits,
+    _create_single_branch_and_commit,
     _link_stacks,
     _push_and_create_prs,
     _render_dag,
@@ -236,6 +238,71 @@ class TestPushAndCreatePrs:
         assert mock_push.call_count == 6
         assert mock_create.call_count == 6
         assert max_concurrent_val >= 3
+
+
+class TestFailedBranchIsDeleted:
+    @patch("pr_split.cli.delete_branch")
+    @patch("pr_split.cli.commit_files_in_dir", return_value="sha1")
+    @patch("pr_split.cli.materialize_group_files", side_effect=PRSplitError("bad hunk"))
+    @patch("pr_split.cli.remove_worktree")
+    @patch("pr_split.cli.add_worktree")
+    def test_branch_deleted_when_materialization_fails(
+        self,
+        mock_add: MagicMock,
+        mock_remove: MagicMock,
+        mock_mat: MagicMock,
+        mock_commit: MagicMock,
+        mock_delete: MagicMock,
+    ) -> None:
+        order: list[str] = []
+        mock_remove.side_effect = lambda path: order.append("remove_worktree")
+        mock_delete.side_effect = lambda branch: order.append(f"delete:{branch}")
+
+        with pytest.raises(PRSplitError, match="bad hunk"):
+            _create_single_branch_and_commit(
+                _group("pr-1", "t"), MagicMock(), "main", "base_sha", "ns", Path("/wt")
+            )
+
+        assert order == ["remove_worktree", "delete:pr-split/ns/pr-1"]
+        mock_commit.assert_not_called()
+
+    @patch("pr_split.cli.delete_branch", side_effect=PRSplitError("branch busy"))
+    @patch("pr_split.cli.commit_files_in_dir", side_effect=GitOperationError("commit failed"))
+    @patch("pr_split.cli.materialize_group_files", return_value={})
+    @patch("pr_split.cli.remove_worktree")
+    @patch("pr_split.cli.add_worktree")
+    def test_original_error_wins_when_cleanup_also_fails(
+        self,
+        mock_add: MagicMock,
+        mock_remove: MagicMock,
+        mock_mat: MagicMock,
+        mock_commit: MagicMock,
+        mock_delete: MagicMock,
+    ) -> None:
+        with pytest.raises(GitOperationError, match="commit failed"):
+            _create_single_branch_and_commit(
+                _group("pr-1", "t"), MagicMock(), "main", "base_sha", "ns", Path("/wt")
+            )
+        mock_delete.assert_called_once_with("pr-split/ns/pr-1")
+
+    @patch("pr_split.cli.delete_branch")
+    @patch("pr_split.cli.commit_files_in_dir", return_value="sha1")
+    @patch("pr_split.cli.materialize_group_files", return_value={})
+    @patch("pr_split.cli.remove_worktree")
+    @patch("pr_split.cli.add_worktree")
+    def test_successful_branch_is_kept(
+        self,
+        mock_add: MagicMock,
+        mock_remove: MagicMock,
+        mock_mat: MagicMock,
+        mock_commit: MagicMock,
+        mock_delete: MagicMock,
+    ) -> None:
+        record = _create_single_branch_and_commit(
+            _group("pr-1", "t"), MagicMock(), "main", "base_sha", "ns", Path("/wt")
+        )
+        assert record.branch_name == "pr-split/ns/pr-1"
+        mock_delete.assert_not_called()
 
 
 class TestCreateBranchesAndCommitsStacked:


### PR DESCRIPTION
## Summary

`_create_single_branch_and_commit` creates the group branch with `git worktree add -b`. If `materialize_group_files` or the commit then failed, the worktree was removed but the branch stayed behind: the cleanup loop in `_create_branches_and_commits` only deletes branches that produced a `BranchRecord`, so a failed run left `pr-split/<ns>/<id>` in the repo (and in the way of the next run).

Now a failure is flagged and, in the `finally` after the worktree is removed (git refuses to delete a branch that is checked out), the branch is deleted; a failed delete only logs a warning so the original error still propagates.

## Test plan

- `TestFailedBranchIsDeleted`: materialisation failure → worktree removed then branch deleted, in that order; commit failure with a failing delete still raises the original error; success path never deletes — the first two fail on main
- Review verified with a real-git repro (base leaves `pr-split/ns/pr-2`, branch leaves nothing) and a 4-worker parallel run with 40 failing groups (0 leftovers)
- 447 tests pass, ruff clean
- Local review: 5/5
