### PR TITLE
fix: reject duplicate group ids and unknown dependencies with a clear validation error

### DIFF
--- a/pr_split/exceptions.py
+++ b/pr_split/exceptions.py
@@ -12,6 +12,8 @@ class ErrorMsg(StrEnum):
     DIRTY_WORKTREE = "Working tree has uncommitted changes; commit or stash first"
     GH_AUTH_FAILED = "GitHub CLI authentication failed; run 'gh auth login'"
     CYCLE_DETECTED = "Dependency cycle detected in split plan"
+    DUPLICATE_GROUP_ID = "Group id '{group}' is used more than once"
+    UNKNOWN_DEPENDENCY = "Group '{group}' depends on '{dep}', which is not a group in the plan"
     COVERAGE_GAP = "Hunk {file}[{index}] not assigned to any group"
     COVERAGE_OVERLAP = "Hunk {file}[{index}] assigned to multiple groups: {groups}"
     LOC_MISMATCH = "Total LOC {actual} does not match diff LOC {expected}"

--- a/pr_split/graph.py
+++ b/pr_split/graph.py
@@ -10,11 +10,19 @@ from .schemas import Group
 
 class PlanDAG:
     def __init__(self, groups: list[Group]) -> None:
-        self._groups: dict[str, Group] = {g.id: g for g in groups}
+        self._groups: dict[str, Group] = {}
+        for g in groups:
+            # Silently collapsing duplicates would drop a group and later
+            # surface as a bogus merge conflict between a group and itself.
+            if g.id in self._groups:
+                raise PlanValidationError(ErrorMsg.DUPLICATE_GROUP_ID(group=g.id))
+            self._groups[g.id] = g
         self._children: dict[str, list[str]] = {g.id: [] for g in groups}
         self._parents: dict[str, list[str]] = {g.id: list(g.depends_on) for g in groups}
         for g in groups:
             for dep in g.depends_on:
+                if dep not in self._children:
+                    raise PlanValidationError(ErrorMsg.UNKNOWN_DEPENDENCY(group=g.id, dep=dep))
                 self._children[dep].append(g.id)
 
     def _build_sorter(self) -> TopologicalSorter[str]:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -137,3 +137,21 @@ class TestLinearChains:
         ]
         dag = PlanDAG(groups)
         assert sorted(dag.linear_chains()) == [["a"], ["b", "c"], ["d"]]
+
+
+class TestPlanDAGRejectsMalformedGroups:
+    def test_unknown_dependency_is_a_validation_error(self) -> None:
+        with pytest.raises(PlanValidationError) as exc_info:
+            PlanDAG([_group("pr-1"), _group("pr-2", ["pr-9"])])
+        assert str(exc_info.value) == (
+            "Group 'pr-2' depends on 'pr-9', which is not a group in the plan"
+        )
+
+    def test_duplicate_group_id_is_a_validation_error(self) -> None:
+        with pytest.raises(PlanValidationError, match="'pr-1' is used more than once"):
+            PlanDAG([_group("pr-1"), _group("pr-1")])
+
+    def test_self_dependency_still_reports_a_cycle(self) -> None:
+        dag = PlanDAG([_group("pr-1", ["pr-1"])])
+        with pytest.raises(PlanValidationError, match="cycle"):
+            dag.validate_acyclic()


### PR DESCRIPTION
## Summary

`PlanDAG.__init__` silently collapsed duplicate group ids (two `pr-1` groups later surfaced as a bogus "merge conflict between pr-1 and pr-1"), and a `depends_on` naming a group that does not exist — a realistic LLM typo — raised a raw `KeyError`, so `split --dry-run` ended in a traceback.

Both are now `PlanValidationError`s with dedicated messages:

- `Group id 'pr-1' is used more than once`
- `Group 'pr-2' depends on 'pr-9', which is not a group in the plan`

Stacked on #63, whose `try/except PRSplitError` around `score_plan`/`PlanDAG`/`validate_plan` in `split` turns them into a red one-liner and exit 1.

## Test plan

- `TestPlanDAGRejectsMalformedGroups` in `test_graph.py`: unknown dependency, duplicate id (both fail on the base with `KeyError` / no error), self-dependency still reported as a cycle
- 456 tests pass, ruff clean
- Local review: 5/5

Noted by the review, not in this PR: `execute --stack` and `merge` build a `PlanDAG` from a saved plan outside any guard (pre-existing; a hand-edited plan.json now gets a `PlanValidationError` traceback instead of a `KeyError` one).
