### PR TITLE
fix: validate a saved plan's dependency graph before execute and merge act on it

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -1032,7 +1032,12 @@ def execute(
 
     parsed_diff = parse_diff(plan.raw_diff)
 
+    # A saved plan may have been hand-edited; check the dependency graph as
+    # well as coverage before touching branches, so a bad plan is a message
+    # rather than a traceback halfway through creating branches.
     try:
+        dag = PlanDAG(plan.groups)
+        dag.validate_acyclic()
         validate_coverage(plan.groups, parsed_diff)
     except PlanValidationError as exc:
         console.print(f"[red]{exc}[/red]")
@@ -1062,7 +1067,7 @@ def execute(
         )
         raise
     if plan.stacked:
-        _link_stacks(PlanDAG(plan.groups), pr_records)
+        _link_stacks(dag, pr_records)
 
     save_plan(
         PlanFile(
@@ -1144,7 +1149,12 @@ def merge_all(
         console.print("[yellow]No PRs found in plan. Nothing to merge.[/yellow]")
         raise typer.Exit(0)
 
-    dag = PlanDAG(plan.groups)
+    try:
+        dag = PlanDAG(plan.groups)
+        dag.validate_acyclic()
+    except PlanValidationError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
     merged: list[str] = []
     skipped: list[str] = []
     skipped_ids: set[str] = set()

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -25,9 +25,9 @@ from pr_split.cli import (
     _validate_inputs,
     app,
 )
-from pr_split.constants import AssignmentType
+from pr_split.constants import AssignmentType, Priority
 from pr_split.exceptions import PRSplitError
-from pr_split.schemas import Group, GroupAssignment
+from pr_split.schemas import GitState, Group, GroupAssignment, PlanFile, PRRecord, SplitPlan
 from pr_split.types_defs import ForkPRInfo
 
 runner = CliRunner()
@@ -522,6 +522,64 @@ class TestExecuteCommand:
         mock_load.return_value = mock_plan_file
         result = runner.invoke(app, ["execute"])
         assert result.exit_code != 0
+
+
+class TestSavedPlanDagValidation:
+    RAW_DIFF = "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n@@ -1 +1 @@\n-x\n+y\n"
+
+    def _plan_file(self, *, prs: bool) -> PlanFile:
+        groups = [
+            _group("pr-1", "t", files=["a.py"]),
+            _group("pr-2", "u", depends_on=["pr-9"]),
+        ]
+        plan = SplitPlan(
+            dev_branch="feature",
+            base_branch="main",
+            max_loc=400,
+            priority=Priority.ORTHOGONAL,
+            groups=groups,
+            merge_base_sha="abc123",
+            raw_diff=self.RAW_DIFF,
+        )
+        git_state = GitState(
+            prs=[PRRecord(group_id="pr-1", pr_number=1, pr_url="u")] if prs else []
+        )
+        return PlanFile(plan=plan, git_state=git_state)
+
+    @patch("pr_split.cli._create_branches_and_commits")
+    @patch("pr_split.cli.check_gh_auth", return_value=True)
+    @patch("pr_split.cli.is_worktree_clean", return_value=True)
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_execute_rejects_unknown_dependency_before_creating_branches(
+        self,
+        mock_pe: MagicMock,
+        mock_load: MagicMock,
+        mock_be: MagicMock,
+        mock_clean: MagicMock,
+        mock_auth: MagicMock,
+        mock_create: MagicMock,
+    ) -> None:
+        mock_load.return_value = self._plan_file(prs=False)
+        result = runner.invoke(app, ["execute"])
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "depends on 'pr-9', which is not a group in the plan" in result.output
+        mock_create.assert_not_called()
+
+    @patch("pr_split.cli.get_pr_state")
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_merge_rejects_unknown_dependency_cleanly(
+        self, mock_pe: MagicMock, mock_load: MagicMock, mock_state: MagicMock
+    ) -> None:
+        mock_load.return_value = self._plan_file(prs=True)
+        result = runner.invoke(app, ["merge"])
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "depends on 'pr-9', which is not a group in the plan" in result.output
+        mock_state.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`execute` only ran `validate_coverage` on the saved plan; the dependency graph was first built unguarded inside `_create_branches_and_commits` (stacked) and `_link_stacks`. `merge` built `PlanDAG(plan.groups)` unguarded and `iter_ready` raised a raw `graphlib.CycleError` on a cyclic plan. A hand-edited `plan.json` with an unknown dependency or a cycle therefore ended in a traceback — in `execute`'s case after the confirm prompt, i.e. potentially with branches already created.

Now `execute` builds the DAG and calls `validate_acyclic()` inside the existing `PlanValidationError` guard together with `validate_coverage` (before the prompt and before any branch exists) and reuses that DAG for stack linking; `merge` gets the same guard. Both print the message in red and exit 1.

Stacked on #117 (`fix/plan-dag-id-validation`).

## Test plan

- `TestSavedPlanDagValidation`: `execute` with `depends_on: ["pr-9"]` exits 1 with the message and never calls `_create_branches_and_commits`; `merge` exits 1 the same way and never queries PR state — both fail on the base
- Review reproduced the cyclic case: base `execute` reached the confirm prompt and base `merge` raised `CycleError`; branch prints `Dependency cycle detected in split plan` for both
- 458 tests pass, ruff clean
- Local review: 5/5
