### PR TITLE
fix: report malformed LLM tool output as an LLMError so chunk calls retry

### DIFF
--- a/pr_split/logs.py
+++ b/pr_split/logs.py
@@ -59,6 +59,10 @@ REFINEMENT_RESOLVED = (
 REFINEMENT_EXHAUSTED = (
     "Refinement iteration limit reached ({iterations}), {remaining} violation(s) remain"
 )
+REFINEMENT_FAILED = (
+    "Refinement iteration {iteration} failed ({error}); keeping the current plan, "
+    "{remaining} violation(s) remain"
+)
 STACK_LINKED = "Linked stack for PRs {prs}"
 STACK_LINK_FAILED = "Could not link stack for PRs {prs}: {detail}"
 MERGE_NODE_NOT_STACKED = (

--- a/pr_split/planner/client.py
+++ b/pr_split/planner/client.py
@@ -8,6 +8,7 @@ import openai
 import tiktoken
 from anthropic.types.beta import BetaToolUseBlock
 from loguru import logger
+from pydantic import ValidationError
 
 from .. import logs
 from ..config import Settings
@@ -204,6 +205,17 @@ def _call_chunk_with_retry(
 
 
 def _parse_groups(raw: RawToolOutput) -> list[Group]:
+    # Anything malformed in the tool output (missing key, bad enum value,
+    # wrong field type) is an LLMError so the chunk retry loop gets another
+    # attempt and the CLI reports it instead of a traceback.
+    try:
+        return _parse_groups_strict(raw)
+    except (KeyError, TypeError, ValueError, ValidationError) as exc:
+        detail = f"missing field {exc}" if isinstance(exc, KeyError) else str(exc)
+        raise LLMError(ErrorMsg.LLM_PARSE_ERROR(detail=detail)) from exc
+
+
+def _parse_groups_strict(raw: RawToolOutput) -> list[Group]:
     groups: list[Group] = []
     for entry in raw["groups"]:
         assignments = [
@@ -370,9 +382,11 @@ def _refine_plan_with_llm(
             refined = _parse_groups(raw)
             recompute_estimated_loc(refined, parsed_diff)
             groups = refined
-        except LLMError:
+        except LLMError as exc:
             logger.warning(
-                logs.REFINEMENT_EXHAUSTED.format(iterations=iteration, remaining=len(violations))
+                logs.REFINEMENT_FAILED.format(
+                    iteration=iteration, error=exc, remaining=len(violations)
+                )
             )
             return groups
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -460,9 +460,37 @@ class TestRefinePlanWithLlm:
         mock_call_llm.side_effect = LLMError("API failure")
 
         groups = _undersized_groups()
-        result = _refine_plan_with_llm(groups, parsed, settings, system="system")
+        with patch("pr_split.planner.client.logger") as mock_logger:
+            result = _refine_plan_with_llm(groups, parsed, settings, system="system")
         assert len(result) == 2
         mock_call_llm.assert_called_once()
+        warning = mock_logger.warning.call_args[0][0]
+        assert "Refinement iteration 1 failed (API failure)" in warning
+        assert "iteration limit" not in warning
+
+    @patch("pr_split.planner.client._call_llm")
+    def test_malformed_refinement_output_keeps_plan_and_logs_cause(
+        self, mock_call_llm: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        parsed = parse_diff(_TWO_FILE_DIFF)
+        settings = Settings(
+            partition_strategy=PartitionStrategy.GRAPH,
+            min_loc=5,
+            max_loc=10,
+            max_refinement_iterations=2,
+        )
+        mock_call_llm.return_value = RawToolOutput(groups=[{"id": "g", "title": "t"}])  # type: ignore[typeddict-item]
+
+        groups = _undersized_groups()
+        with patch("pr_split.planner.client.logger") as mock_logger:
+            result = _refine_plan_with_llm(groups, parsed, settings, system="system")
+        assert result == groups
+        mock_call_llm.assert_called_once()
+        warning = mock_logger.warning.call_args[0][0]
+        assert "missing field 'assignments'" in warning
+        assert "keeping the current plan" in warning
 
     def test_no_refinement_when_min_loc_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
@@ -986,3 +1014,57 @@ class TestPlanSplitWithLlm:
         result = _plan_split_with_llm(parsed, settings)
         assert len(result) == 1
         mock_chunked.assert_called_once()
+
+
+class TestParseGroupsMalformedOutput:
+    def _entry(self, **overrides: object) -> dict[str, object]:
+        entry: dict[str, object] = {
+            "id": "pr-1",
+            "title": "t",
+            "description": "d",
+            "depends_on": [],
+            "assignments": [
+                {"file_path": "a.py", "assignment_type": "whole_file", "hunk_indices": [0]}
+            ],
+            "estimated_loc": 1,
+        }
+        entry.update(overrides)
+        return entry
+
+    def test_missing_key_is_an_llm_error(self) -> None:
+        entry = self._entry()
+        del entry["depends_on"]
+        with pytest.raises(
+            LLMError, match="Failed to parse LLM response: missing field 'depends_on'"
+        ):
+            _parse_groups(RawToolOutput(groups=[entry]))  # type: ignore[typeddict-item]
+
+    def test_bad_assignment_type_is_an_llm_error(self) -> None:
+        entry = self._entry(
+            assignments=[{"file_path": "a.py", "assignment_type": "whole", "hunk_indices": [0]}]
+        )
+        with pytest.raises(LLMError, match="not a valid AssignmentType"):
+            _parse_groups(RawToolOutput(groups=[entry]))  # type: ignore[typeddict-item]
+
+    def test_wrong_field_type_is_an_llm_error(self) -> None:
+        entry = self._entry(
+            assignments=[
+                {"file_path": "a.py", "assignment_type": "whole_file", "hunk_indices": "0"}
+            ]
+        )
+        with pytest.raises(LLMError, match="Failed to parse LLM response"):
+            _parse_groups(RawToolOutput(groups=[entry]))  # type: ignore[typeddict-item]
+
+    @patch("pr_split.planner.client._call_llm")
+    def test_malformed_chunk_output_is_retried(self, mock_call: MagicMock) -> None:
+        bad = self._entry()
+        del bad["title"]
+        mock_call.side_effect = [
+            RawToolOutput(groups=[bad]),  # type: ignore[typeddict-item]
+            RawToolOutput(groups=[self._entry()]),  # type: ignore[typeddict-item]
+        ]
+        groups = _call_chunk_with_retry(
+            "sys", "user", settings=_make_settings(), chunk_index=1, total_chunks=1
+        )
+        assert [g.id for g in groups] == ["pr-1"]
+        assert mock_call.call_count == 2


### PR DESCRIPTION
## Summary

`_parse_groups` indexed the LLM tool output directly, so a missing key, an invalid `assignment_type` value, or a wrong field type raised `KeyError` / `ValueError` / pydantic `ValidationError`. None of those is an `LLMError`, so `_call_chunk_with_retry`'s `except LLMError` never retried and the CLI died with a traceback after a single malformed response.

Now `_parse_groups` converts those into `LLMError(Failed to parse LLM response: …)` (a missing key renders as `missing field 'depends_on'`), so chunked calls retry and the CLI's `PRSplitError` handlers print the message. The refinement loop, which already caught `LLMError`, no longer hides the cause behind "iteration limit reached": it logs a new `Refinement iteration N failed (<error>); keeping the current plan` warning.

## Test plan

- `TestParseGroupsMalformedOutput`: missing key, bad enum, wrong field type each raise `LLMError`; a bad-then-good chunk response is retried (2 calls)
- refinement: existing LLM-error test now asserts the new warning; new test for malformed refinement output keeps the plan and logs the cause
- six tests fail on main
- 449 tests pass, ruff clean
- Local review: 5/5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed planning and refinement responses.
  * Preserves the current plan when a refinement response cannot be processed.
  * Reports the specific refinement iteration, error details, and remaining issues in warning messages.
  * Automatically retries certain incomplete responses before reporting failure.
* **Reliability**
  * Invalid planning data now produces clearer, actionable errors instead of ambiguous failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->