### PR TITLE
fix: clean deletes remote branches even when the local branch is gone and keeps the plan on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Running `split` again when a plan already exists will prompt you to clean up exi
 pr-split clean
 ```
 
-Closes all split PRs, deletes their branches (local and remote), and removes the plan file.
+Closes all split PRs, deletes their branches (local and remote), and removes the plan file. A branch that is already gone locally or currently checked out is still removed from `origin`. If anything could not be closed or deleted, the plan file is kept and `clean` exits 1 so you can fix the cause and run it again.
 
 ## Configuration
 

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -9,7 +9,7 @@ from collections.abc import Generator
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from threading import Lock, Semaphore
-from typing import Annotated
+from typing import Annotated, NamedTuple
 
 import typer
 from loguru import logger
@@ -751,9 +751,16 @@ def split(
                 "[red]Warning: this will permanently close PRs and delete remote branches.[/red]"
             )
             if typer.confirm("Clean up and proceed with re-splitting?"):
-                closed_prs, deleted_branches = _cleanup_git_state(existing.git_state)
+                result = _cleanup_git_state(existing.git_state)
+                if not result.complete:
+                    # Re-splitting would overwrite the plan and lose the
+                    # record of what is still out there.
+                    _report_incomplete_cleanup(result)
+                    raise typer.Exit(1)
                 logger.success(
-                    logs.CLEAN_COMPLETE.format(branches=deleted_branches, prs=closed_prs)
+                    logs.CLEAN_COMPLETE.format(
+                        branches=result.deleted_branches, prs=result.closed_prs
+                    )
                 )
             else:
                 console.print("[red]Aborting. Run 'pr-split clean' manually first.[/red]")
@@ -920,14 +927,26 @@ def status() -> None:
     console.print(table)
 
 
-def _cleanup_git_state(git_state: GitState) -> tuple[int, int]:
+class CleanupResult(NamedTuple):
+    closed_prs: int
+    deleted_branches: int
+    failures: list[str]
+
+    @property
+    def complete(self) -> bool:
+        return not self.failures
+
+
+def _cleanup_git_state(git_state: GitState) -> CleanupResult:
+    failures: list[str] = []
     closed_prs = 0
     for pr_record in git_state.prs:
         try:
             close_pr(pr_record.pr_number)
             closed_prs += 1
-        except PRSplitError:
-            logger.warning(f"Could not close PR #{pr_record.pr_number}")
+        except PRSplitError as exc:
+            logger.warning(f"Could not close PR #{pr_record.pr_number}: {exc}")
+            failures.append(f"PR #{pr_record.pr_number}")
 
     logger.info(logs.CLEANING_BRANCHES)
     deleted_branches = 0
@@ -935,14 +954,27 @@ def _cleanup_git_state(git_state: GitState) -> tuple[int, int]:
         try:
             delete_branch(branch_record.branch_name, remote=True)
             deleted_branches += 1
-        except PRSplitError:
-            logger.warning(f"Could not delete branch {branch_record.branch_name}")
+        except PRSplitError as exc:
+            logger.warning(f"Could not delete branch {branch_record.branch_name}: {exc}")
+            failures.append(f"branch {branch_record.branch_name}")
 
-    plan_path = Path(PLAN_FILE)
-    if plan_path.exists():
-        plan_path.unlink()
+    # The plan is the only record of what was created; keep it while
+    # anything is still left so the user can re-run clean.
+    if not failures:
+        plan_path = Path(PLAN_FILE)
+        if plan_path.exists():
+            plan_path.unlink()
 
-    return closed_prs, deleted_branches
+    return CleanupResult(closed_prs, deleted_branches, failures)
+
+
+def _report_incomplete_cleanup(result: CleanupResult) -> None:
+    console.print(
+        f"[red]Cleanup incomplete ({result.closed_prs} PRs closed, "
+        f"{result.deleted_branches} branches deleted); still to clean "
+        f"({len(result.failures)}): {', '.join(result.failures)}. The plan file was kept; "
+        f"fix the cause and run 'pr-split clean' again.[/red]"
+    )
 
 
 @app.command(help="Close all split PRs and delete their branches.")
@@ -954,10 +986,19 @@ def clean() -> None:
     plan_file = load_plan()
     git_state = plan_file.git_state
 
+    if git_state.prs and not check_gh_auth():
+        console.print(f"[red]{ErrorMsg.GH_AUTH_FAILED()}[/red]")
+        raise typer.Exit(1)
+
     typer.confirm("Delete all pr-split branches and close PRs?", abort=True)
 
-    closed_prs, deleted_branches = _cleanup_git_state(git_state)
-    logger.success(logs.CLEAN_COMPLETE.format(branches=deleted_branches, prs=closed_prs))
+    result = _cleanup_git_state(git_state)
+    if not result.complete:
+        _report_incomplete_cleanup(result)
+        raise typer.Exit(1)
+    logger.success(
+        logs.CLEAN_COMPLETE.format(branches=result.deleted_branches, prs=result.closed_prs)
+    )
 
 
 @app.command(

--- a/pr_split/git_ops/branches.py
+++ b/pr_split/git_ops/branches.py
@@ -70,11 +70,33 @@ def push_branch(branch: str) -> None:
     run_git("push", "--force-with-lease", "-u", "origin", branch)
 
 
+_REMOTE_REF_MISSING = "remote ref does not exist"
+
+
 def delete_branch(branch: str, *, remote: bool = False) -> None:
-    run_git("branch", "-D", branch)
-    logger.info(logs.BRANCH_DELETED.format(branch=branch))
+    """Delete a branch locally and, with remote=True, on origin as well.
+
+    The two deletes are independent: a local branch that is already gone
+    (``gh pr merge --delete-branch``) or currently checked out must not
+    stop the remote branch from being removed, and a remote branch that no
+    longer exists counts as deleted.
+    """
+    try:
+        run_git("branch", "-D", branch)
+        logger.info(logs.BRANCH_DELETED.format(branch=branch))
+    except GitOperationError as exc:
+        if not remote:
+            raise
+        logger.warning(logs.LOCAL_BRANCH_NOT_DELETED.format(branch=branch, error=exc))
     if remote:
-        run_git("push", "origin", "--delete", branch)
+        try:
+            run_git("push", "origin", "--delete", branch)
+        except GitOperationError as exc:
+            if _REMOTE_REF_MISSING not in str(exc):
+                raise
+            logger.info(logs.REMOTE_BRANCH_ALREADY_GONE.format(branch=branch))
+        else:
+            logger.info(logs.REMOTE_BRANCH_DELETED.format(branch=branch))
 
 
 def merge_base(ref_a: str, ref_b: str) -> str:

--- a/pr_split/logs.py
+++ b/pr_split/logs.py
@@ -18,6 +18,11 @@ SAVING_PLAN = "Saving plan to {path}"
 PLAN_LOADED = "Loaded plan with {count} groups from {path}"
 CLEANING_BRANCHES = "Cleaning up pr-split branches"
 BRANCH_DELETED = "Deleted branch {branch}"
+LOCAL_BRANCH_NOT_DELETED = (
+    "Local branch {branch} not deleted ({error}); still removing it from origin"
+)
+REMOTE_BRANCH_DELETED = "Deleted origin/{branch}"
+REMOTE_BRANCH_ALREADY_GONE = "origin/{branch} was already gone"
 PR_CLOSED = "Closed PR #{number}"
 CLEAN_COMPLETE = "Cleanup complete: {branches} branches, {prs} PRs"
 FETCHING_FORK_PR = "Fetching PR #{number} from fork {fork}"

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -367,6 +367,45 @@ class TestMoveAssignment:
 # ---------------------------------------------------------------------------
 # split command argument validation
 # ---------------------------------------------------------------------------
+class TestSplitResplitStopsOnIncompleteCleanup:
+    @patch("pr_split.cli.extract_diff")
+    @patch("pr_split.cli._cleanup_git_state")
+    @patch("pr_split.cli.typer.confirm", return_value=True)
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_resplit_stops_when_cleanup_is_incomplete(
+        self,
+        mock_be: MagicMock,
+        mock_validate: MagicMock,
+        mock_pe: MagicMock,
+        mock_load: MagicMock,
+        mock_confirm: MagicMock,
+        mock_cleanup: MagicMock,
+        mock_extract: MagicMock,
+    ) -> None:
+        from pr_split.cli import CleanupResult
+        from pr_split.schemas import PRRecord
+
+        existing = MagicMock()
+        existing.git_state.branches = [MagicMock()]
+        existing.git_state.prs = [PRRecord(group_id="pr-1", pr_number=10, pr_url="u")]
+        mock_load.return_value = existing
+        mock_cleanup.return_value = CleanupResult(1, 0, ["branch b1"])
+
+        result = runner.invoke(
+            app, ["split", "feature-branch"], env={"ANTHROPIC_API_KEY": "sk-test"}
+        )
+
+        flat = " ".join(result.output.split())
+        assert result.exit_code == 1
+        assert "Cleanup incomplete (1 PRs closed, 0 branches deleted)" in flat
+        assert "still to clean (1): branch b1" in flat
+        assert "Cleanup complete" not in flat
+        mock_extract.assert_not_called()
+
+
 class TestSplitCommandValidation:
     @patch("pr_split.cli.parse_diff")
     @patch("pr_split.cli.extract_diff", return_value="diff --git a/a.py b/a.py\n")

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -144,9 +144,10 @@ class TestCleanupGitState:
                 PRRecord(group_id="pr-2", pr_number=11, pr_url="url2"),
             ],
         )
-        closed, deleted = _cleanup_git_state(git_state)
-        assert closed == 2
-        assert deleted == 2
+        result = _cleanup_git_state(git_state)
+        assert (result.closed_prs, result.deleted_branches) == (2, 2)
+        assert result.complete
+        mock_path.return_value.unlink.assert_called_once()
         mock_close.assert_any_call(10)
         mock_close.assert_any_call(11)
         mock_delete.assert_any_call("pr-split/ns/pr-1", remote=True)
@@ -176,9 +177,64 @@ class TestCleanupGitState:
                 PRRecord(group_id="pr-2", pr_number=11, pr_url="url2"),
             ],
         )
-        closed, deleted = _cleanup_git_state(git_state)
-        assert closed == 1
-        assert deleted == 1
+        result = _cleanup_git_state(git_state)
+        assert (result.closed_prs, result.deleted_branches) == (1, 1)
+        assert result.failures == ["PR #11", "branch b1"]
+        mock_path.return_value.unlink.assert_not_called()
+
+
+class TestCleanCommandKeepsPlanOnFailure:
+    @patch("pr_split.cli._cleanup_git_state")
+    @patch("pr_split.cli.typer.confirm", return_value=True)
+    @patch("pr_split.cli.check_gh_auth", return_value=True)
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_incomplete_cleanup_exits_nonzero(
+        self,
+        mock_exists: MagicMock,
+        mock_load: MagicMock,
+        mock_auth: MagicMock,
+        mock_confirm: MagicMock,
+        mock_cleanup: MagicMock,
+    ) -> None:
+        from pr_split.cli import CleanupResult
+
+        plan_file = MagicMock()
+        plan_file.git_state.prs = [PRRecord(group_id="pr-1", pr_number=10, pr_url="u")]
+        mock_load.return_value = plan_file
+        mock_cleanup.return_value = CleanupResult(0, 1, ["PR #10"])
+
+        result = runner.invoke(app, ["clean"])
+
+        assert result.exit_code == 1
+        flat = " ".join(result.output.split())
+        assert "Cleanup incomplete (0 PRs closed, 1 branches deleted)" in flat
+        assert "still to clean (1): PR #10" in flat
+        assert "plan file was kept" in flat
+        assert "Cleanup complete" not in flat
+
+    @patch("pr_split.cli._cleanup_git_state")
+    @patch("pr_split.cli.typer.confirm", return_value=True)
+    @patch("pr_split.cli.check_gh_auth", return_value=False)
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_requires_gh_auth_when_prs_exist(
+        self,
+        mock_exists: MagicMock,
+        mock_load: MagicMock,
+        mock_auth: MagicMock,
+        mock_confirm: MagicMock,
+        mock_cleanup: MagicMock,
+    ) -> None:
+        plan_file = MagicMock()
+        plan_file.git_state.prs = [PRRecord(group_id="pr-1", pr_number=10, pr_url="u")]
+        mock_load.return_value = plan_file
+
+        result = runner.invoke(app, ["clean"])
+
+        assert result.exit_code == 1
+        assert "GitHub CLI authentication failed" in result.output
+        mock_cleanup.assert_not_called()
 
 
 class TestGetPrState:

--- a/tests/test_git_branches.py
+++ b/tests/test_git_branches.py
@@ -130,6 +130,35 @@ class TestDeleteBranch:
         delete_branch("pr-split/pr-1", remote=True)
         assert mock_git.call_count == 2
 
+    @patch("pr_split.git_ops.branches.run_git")
+    def test_remote_is_deleted_even_when_local_branch_is_gone(self, mock_git: MagicMock) -> None:
+        mock_git.side_effect = [GitOperationError("error: branch 'pr-split/pr-1' not found."), ""]
+        delete_branch("pr-split/pr-1", remote=True)
+        assert mock_git.call_args_list[1].args == ("push", "origin", "--delete", "pr-split/pr-1")
+
+    @patch("pr_split.git_ops.branches.run_git")
+    def test_local_failure_still_raises_without_remote(self, mock_git: MagicMock) -> None:
+        mock_git.side_effect = GitOperationError("checked out")
+        with pytest.raises(GitOperationError, match="checked out"):
+            delete_branch("pr-split/pr-1")
+        assert mock_git.call_count == 1
+
+    @patch("pr_split.git_ops.branches.run_git")
+    def test_missing_remote_ref_counts_as_deleted(self, mock_git: MagicMock) -> None:
+        mock_git.side_effect = [
+            "",
+            GitOperationError(
+                "error: unable to delete 'pr-split/pr-1': remote ref does not exist"
+            ),
+        ]
+        delete_branch("pr-split/pr-1", remote=True)
+
+    @patch("pr_split.git_ops.branches.run_git")
+    def test_other_remote_failure_raises(self, mock_git: MagicMock) -> None:
+        mock_git.side_effect = ["", GitOperationError("fatal: could not read from remote")]
+        with pytest.raises(GitOperationError, match="could not read from remote"):
+            delete_branch("pr-split/pr-1", remote=True)
+
 
 class TestDeriveSplitNamespace:
     def test_simple_branch(self) -> None:


### PR DESCRIPTION
## Summary

`delete_branch(remote=True)` ran `git branch -D` first and only pushed the remote delete when that succeeded. Whenever the local branch was already gone (`pr-split merge` uses `gh pr merge --delete-branch`) or currently checked out (`gh pr checkout` to inspect a sub-PR), the local delete raised and the remote branch was never touched. `_cleanup_git_state` then unlinked `plan.json` unconditionally, so the only record of what still needed cleaning was lost.

Now:

- local and remote deletes are independent: a local failure with `remote=True` is a warning, "remote ref does not exist" counts as deleted, other remote failures still raise; `remote=False` (the materialise-failure rollback) keeps raising
- `_cleanup_git_state` returns `CleanupResult(closed_prs, deleted_branches, failures)` and keeps `plan.json` when anything failed
- `clean` requires gh auth when PRs are recorded and, on an incomplete run, prints `Cleanup incomplete (N PRs closed, M branches deleted); still to clean (…)…` and exits 1 — the success line is only logged when everything was cleaned; the `split` re-split path stops the same way instead of overwriting the plan
- README's Clean up paragraph documents this

## Test plan

- `TestDeleteBranch`: remote deleted when local is gone; missing remote ref accepted; other remote failures raise; `remote=False` still raises
- `TestCleanupGitState` (result/plan retention), `TestCleanCommandKeepsPlanOnFailure` (exit 1, gh-auth gate), `TestSplitResplitStopsOnIncompleteCleanup`
- Review verified against a real bare `origin`: checked-out branch, locally-missing branch, both-gone, unreachable remote
- 451 tests pass, ruff clean
- Local review: 5/5
