### PR TITLE
fix: escape plan text in the editor's show output so brackets are not lost as Rich markup

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -15,6 +15,7 @@ import typer
 from loguru import logger
 from pydantic import ValidationError
 from rich.console import Console
+from rich.markup import escape
 from rich.panel import Panel
 from rich.table import Table
 from rich.tree import Tree
@@ -573,9 +574,11 @@ def _show_group_detail(groups: list[Group], group_id: str) -> None:
     if not group:
         console.print(f"[red]Group '{group_id}' not found.[/red]")
         return
-    console.print(f"\n[bold]{group.id}[/bold]: {group.title}")
-    console.print(f"  Description: {group.description}")
-    console.print(f"  Depends on: {', '.join(group.depends_on) or 'none'}")
+    # Titles, descriptions and paths come from the plan (LLM-written); any
+    # "[...]" in them would be swallowed as Rich markup unless escaped.
+    console.print(f"\n[bold]{escape(group.id)}[/bold]: {escape(group.title)}")
+    console.print(f"  Description: {escape(group.description)}")
+    console.print(f"  Depends on: {escape(', '.join(group.depends_on) or 'none')}")
     console.print(
         f"  Estimated: +{group.estimated_added}/-{group.estimated_removed}"
         f" ({group.estimated_loc} LOC)"
@@ -585,7 +588,9 @@ def _show_group_detail(groups: list[Group], group_id: str) -> None:
             hunks_str = "all"
         else:
             hunks_str = ", ".join(str(i) for i in a.hunk_indices)
-        console.print(f"  {a.file_path} [{a.assignment_type}] hunks: [{hunks_str}]")
+        # Square brackets are Rich markup; without escaping "[whole_file]"
+        # is treated as a style tag and silently dropped from the output.
+        console.print(escape(f"  {a.file_path} [{a.assignment_type.value}] hunks: [{hunks_str}]"))
     console.print()
 
 

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -244,6 +244,26 @@ class TestShowGroupDetail:
         g = _group("pr-1", "root", files=["a.py"], depends_on=["pr-0"])
         _show_group_detail([g], "pr-1")
 
+    def test_assignment_type_is_printed_not_eaten_as_markup(self) -> None:
+        from pr_split.cli import console
+
+        g = _group("pr-1", "Support list[str] [WIP]", files=["a.py"])
+        g.description = "uses the [red] tag literally"
+        g.assignments.append(
+            GroupAssignment(
+                file_path="src/[id].py",
+                assignment_type=AssignmentType.PARTIAL_HUNKS,
+                hunk_indices=[0, 2],
+            )
+        )
+        with console.capture() as capture:
+            _show_group_detail([g], "pr-1")
+        out = capture.get()
+        assert "pr-1: Support list[str] [WIP]" in out
+        assert "Description: uses the [red] tag literally" in out
+        assert "a.py [whole_file] hunks: [all]" in out
+        assert "src/[id].py [partial_hunks] hunks: [0, 2]" in out
+
     def test_partial_hunks_rendering(self) -> None:
         g = Group(
             id="pr-1",


### PR DESCRIPTION
## Summary

The interactive editor's `show <group>` printed plan text through Rich unescaped. Rich treats `[…]` as a style tag, so the assignment type — `[whole_file]` / `[partial_hunks]` — was silently dropped from every line (observed: `a.py  hunks: [0, 1]`), and a title like `Support list[str]`, a description containing `[red]`, or a path such as `src/[id].py` lost the bracketed text as well.

All plan-derived interpolations in `_show_group_detail` now go through `rich.markup.escape`.

Left for a follow-up (noted by the review): the same escaping is missing in `_move_assignment` messages, the `_present_plan` table and the `_render_dag` tree.

## Test plan

- `test_assignment_type_is_printed_not_eaten_as_markup`: captured `show` output contains `a.py [whole_file] hunks: [all]`, `src/[id].py [partial_hunks] hunks: [0, 2]`, a bracketed title and description — fails on main
- 445 tests pass, ruff clean
- Local review: 5/5
