### PR TITLE
fix: report branch-creation failures and an unknown merge base as errors instead of tracebacks

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -59,7 +59,7 @@ from .git_ops import (
     push_branch,
     remove_worktree,
 )
-from .git_ops.branches import run_git
+from .git_ops.branches import commit_exists, run_git
 from .git_ops.prs import close_pr, create_pr, get_pr_state, link_stack, merge_pr
 from .graph import PlanDAG
 from .plan_store import load_plan, plan_exists, save_plan
@@ -847,9 +847,13 @@ def split(
     typer.confirm("Proceed with creating branches and PRs?", abort=True)
 
     namespace = derive_split_namespace(dev_branch_arg)
-    branch_records = _create_branches_and_commits(
-        groups, parsed_diff, base, merge_base_ref, namespace, author=author, stacked=stack
-    )
+    try:
+        branch_records = _create_branches_and_commits(
+            groups, parsed_diff, base, merge_base_ref, namespace, author=author, stacked=stack
+        )
+    except PRSplitError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
     try:
         pr_records = _push_and_create_prs(groups, branch_records, draft=draft)
     except PRCreationError as exc:
@@ -1009,6 +1013,13 @@ def execute(
             " Re-run 'pr-split split --dry-run' to regenerate.[/red]"
         )
         raise typer.Exit(1)
+    if not commit_exists(plan.merge_base_sha):
+        console.print(
+            f"[red]Plan's merge base {plan.merge_base_sha} is not in this repository "
+            "(plan copied from another checkout, or history rewritten). "
+            "Fetch it or re-run 'pr-split split --dry-run' to regenerate.[/red]"
+        )
+        raise typer.Exit(1)
 
     if not branch_exists(plan.base_branch):
         console.print(f"[red]{ErrorMsg.BRANCH_NOT_FOUND(branch=plan.base_branch)}[/red]")
@@ -1032,15 +1043,19 @@ def execute(
     typer.confirm("Proceed with creating branches and PRs?", abort=True)
 
     namespace = derive_split_namespace(plan.dev_branch_arg or plan.dev_branch)
-    branch_records = _create_branches_and_commits(
-        plan.groups,
-        parsed_diff,
-        plan.base_branch,
-        plan.merge_base_sha,
-        namespace,
-        author=plan.author,
-        stacked=plan.stacked,
-    )
+    try:
+        branch_records = _create_branches_and_commits(
+            plan.groups,
+            parsed_diff,
+            plan.base_branch,
+            plan.merge_base_sha,
+            namespace,
+            author=plan.author,
+            stacked=plan.stacked,
+        )
+    except PRSplitError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
     try:
         pr_records = _push_and_create_prs(plan.groups, branch_records, draft=plan.draft)
     except PRCreationError as exc:

--- a/pr_split/git_ops/branches.py
+++ b/pr_split/git_ops/branches.py
@@ -33,6 +33,15 @@ def run_git_in_dir(cwd: str, *args: str) -> str:
     return result.stdout.strip()
 
 
+def commit_exists(ref: str) -> bool:
+    """True if ``ref`` resolves to a commit object in this repository."""
+    try:
+        run_git("cat-file", "-e", f"{ref}^{{commit}}")
+    except GitOperationError:
+        return False
+    return True
+
+
 def branch_exists(branch: str) -> bool:
     try:
         run_git("rev-parse", "--verify", branch)

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -509,6 +509,66 @@ class TestExecuteCommand:
         result = runner.invoke(app, ["execute"])
         assert result.exit_code != 0
 
+    @patch("pr_split.cli.commit_exists", return_value=False)
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_execute_unknown_merge_base_sha_is_a_clean_error(
+        self, mock_pe: MagicMock, mock_load: MagicMock, mock_commit: MagicMock
+    ) -> None:
+        mock_plan_file = MagicMock()
+        mock_plan_file.git_state.branches = []
+        mock_plan_file.git_state.prs = []
+        mock_plan_file.plan.raw_diff = "some diff"
+        mock_plan_file.plan.merge_base_sha = "0123456789abcdef"
+        mock_load.return_value = mock_plan_file
+        result = runner.invoke(app, ["execute"])
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "merge base 0123456789abcdef is not in this repository" in result.output
+        mock_commit.assert_called_once_with("0123456789abcdef")
+
+    @patch(
+        "pr_split.cli._create_branches_and_commits",
+        side_effect=PRSplitError("3 branch(es) failed"),
+    )
+    @patch("pr_split.cli.typer.confirm", return_value=True)
+    @patch("pr_split.cli.validate_coverage")
+    @patch("pr_split.cli.parse_diff")
+    @patch("pr_split.cli.commit_exists", return_value=True)
+    @patch("pr_split.cli.check_gh_auth", return_value=True)
+    @patch("pr_split.cli.is_worktree_clean", return_value=True)
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_execute_branch_creation_failure_is_a_clean_error(
+        self,
+        mock_pe: MagicMock,
+        mock_load: MagicMock,
+        mock_be: MagicMock,
+        mock_clean: MagicMock,
+        mock_auth: MagicMock,
+        mock_commit: MagicMock,
+        mock_parse: MagicMock,
+        mock_validate: MagicMock,
+        mock_confirm: MagicMock,
+        mock_create: MagicMock,
+    ) -> None:
+        mock_plan_file = MagicMock()
+        mock_plan_file.git_state.branches = []
+        mock_plan_file.git_state.prs = []
+        mock_plan_file.plan.raw_diff = "some diff"
+        mock_plan_file.plan.merge_base_sha = "abc123"
+        mock_plan_file.plan.stacked = False
+        mock_plan_file.plan.dev_branch_arg = "feature"
+        mock_plan_file.plan.dev_branch = "feature"
+        mock_plan_file.plan.base_branch = "main"
+        mock_plan_file.plan.groups = [_group("pr-1", "t", files=["a.py"])]
+        mock_load.return_value = mock_plan_file
+        result = runner.invoke(app, ["execute"])
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "3 branch(es) failed" in result.output
+
     @patch("pr_split.cli.load_plan")
     @patch("pr_split.cli.plan_exists", return_value=True)
     def test_execute_missing_merge_base_sha(

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -231,6 +231,61 @@ class TestHandleLocBoundWarnings:
         mock_warning.assert_not_called()
 
 
+class TestSplitBranchCreationFailure:
+    @patch("pr_split.cli.save_plan")
+    @patch(
+        "pr_split.cli._create_branches_and_commits",
+        side_effect=PRSplitError("2 branch(es) failed"),
+    )
+    @patch("pr_split.cli.typer.confirm", return_value=True)
+    @patch("pr_split.cli.plan_exists", return_value=False)
+    @patch("pr_split.cli.merge_base", return_value="abc123")
+    @patch("pr_split.cli._interactive_edit")
+    @patch("pr_split.cli._present_plan")
+    @patch("pr_split.cli.validate_plan", return_value=[])
+    @patch("pr_split.cli.plan_split")
+    @patch("pr_split.cli.parse_diff")
+    @patch("pr_split.cli.extract_diff", return_value="diff --git a/a.py b/a.py\n")
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_split_reports_branch_creation_failure_cleanly(
+        self,
+        mock_branch_exists: MagicMock,
+        mock_validate_inputs: MagicMock,
+        mock_extract_diff: MagicMock,
+        mock_parse_diff: MagicMock,
+        mock_plan_split: MagicMock,
+        mock_validate_plan: MagicMock,
+        mock_present_plan: MagicMock,
+        mock_interactive_edit: MagicMock,
+        mock_merge_base: MagicMock,
+        mock_plan_exists: MagicMock,
+        mock_confirm: MagicMock,
+        mock_create: MagicMock,
+        mock_save_plan: MagicMock,
+    ) -> None:
+        parsed_diff = MagicMock()
+        parsed_diff.stats = {
+            "total_files": 1,
+            "total_added": 1,
+            "total_removed": 0,
+            "total_loc": 1,
+        }
+        group = _group("pr-1", "t", files=["a.py"])
+        mock_parse_diff.return_value = parsed_diff
+        mock_plan_split.return_value = [group]
+        mock_interactive_edit.return_value = [group]
+
+        result = runner.invoke(
+            app, ["split", "feature-branch"], env={"ANTHROPIC_API_KEY": "sk-test"}
+        )
+
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "2 branch(es) failed" in result.output
+        mock_save_plan.assert_not_called()
+
+
 class TestSplitCliEnvVars:
     @patch("pr_split.cli.save_plan")
     @patch("pr_split.cli.merge_base", return_value="abc123")

--- a/tests/test_git_branches.py
+++ b/tests/test_git_branches.py
@@ -11,6 +11,7 @@ from pr_split.git_ops.branches import (
     branch_exists,
     checkout_branch,
     checkout_new_branch,
+    commit_exists,
     commit_files,
     commit_files_in_dir,
     create_group_branch,
@@ -314,3 +315,16 @@ class TestCommitFilesInDir:
     def test_empty_file_paths_raises(self) -> None:
         with pytest.raises(GitOperationError, match="no file paths"):
             commit_files_in_dir("/tmp/wt", [], "msg")
+
+
+class TestCommitExists:
+    @patch("pr_split.git_ops.branches.run_git", return_value="")
+    def test_true_when_object_resolves(self, mock_git: MagicMock) -> None:
+        assert commit_exists("abc123") is True
+        mock_git.assert_called_once_with("cat-file", "-e", "abc123^{commit}")
+
+    @patch(
+        "pr_split.git_ops.branches.run_git", side_effect=GitOperationError("Not a valid object")
+    )
+    def test_false_when_missing(self, mock_git: MagicMock) -> None:
+        assert commit_exists("0123456789abcdef") is False


### PR DESCRIPTION
## Summary

`_create_branches_and_commits` raises `PRSplitError` ("N branch(es) failed: …") when a group cannot be materialised or committed. Neither `split` nor `execute` caught it, so the user got a full Rich traceback. The most common trigger for `execute` is a plan whose `merge_base_sha` is unknown to the clone — `plan.json` copied from another checkout, or history rewritten — which failed with `fatal: invalid reference: …` for every group.

Now:

- both call sites wrap the call in `try/except PRSplitError` → red one-liner, exit 1 (partial branches were already cleaned up by `_create_branches_and_commits` itself)
- `execute` checks the saved merge base with a new `git_ops.branches.commit_exists(sha)` (`git cat-file -e <sha>^{commit}`) after the cheap plan checks and before any worktree or the confirm prompt, and explains how to recover

## Test plan

- `TestCommitExists`; `execute` with an unknown merge base (clean message, nothing created) and with a branch-creation failure; `split` with a branch-creation failure (no plan saved) — all fail on main
- Review verified `commit_exists` against a real repo (full/abbreviated SHAs and refs accepted; trees, missing objects, option-like strings rejected; list args, no shell) and the hunt's bogus-merge-base e2e fixture now exits 1 with zero branches created
- 449 tests pass, ruff clean
- Local review: 5/5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for split and execute operations, displaying clear messages instead of unhandled failures.
  * Execute now detects when a saved plan references a merge base that is unavailable locally and stops with an actionable error.

* **Tests**
  * Added coverage for missing merge bases and branch creation failures.
  * Added validation for commit availability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->