### PR TITLE
fix: refuse to split an empty diff and to execute a plan with no changes

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -763,6 +763,11 @@ def split(
 
     raw_diff = extract_diff(dev_branch, base)
     parsed_diff = parse_diff(raw_diff)
+    if not parsed_diff.patch_set:
+        # Planning an empty diff "succeeds" with zero groups and then
+        # execute rejects the plan as missing its diff; stop here instead.
+        console.print(f"[red]{ErrorMsg.NO_CHANGES(base=base, dev=dev_branch_arg)}[/red]")
+        raise typer.Exit(1)
     stats = parsed_diff.stats
     logger.info(
         logs.DIFF_STATS.format(
@@ -996,11 +1001,15 @@ def execute(
         console.print("[red]This plan already has branches/PRs. Use 'pr-split clean' first.[/red]")
         raise typer.Exit(1)
 
-    if not plan.raw_diff:
+    if plan.raw_diff is None:
         console.print(
             "[red]Plan is missing saved diff data."
             " Re-run 'pr-split split --dry-run' to regenerate.[/red]"
         )
+        raise typer.Exit(1)
+    if not plan.raw_diff.strip() or not plan.groups:
+        # A plan saved by an older version from an empty diff.
+        console.print(f"[red]{ErrorMsg.PLAN_HAS_NO_CHANGES()}[/red]")
         raise typer.Exit(1)
 
     if not plan.merge_base_sha:

--- a/pr_split/exceptions.py
+++ b/pr_split/exceptions.py
@@ -17,6 +17,8 @@ class ErrorMsg(StrEnum):
     LOC_MISMATCH = "Total LOC {actual} does not match diff LOC {expected}"
     MERGE_CONFLICT = "Groups '{a}' and '{b}' modify overlapping regions in '{file}'"
     NO_PLAN = "No split plan found; run 'pr-split split' first"
+    NO_CHANGES = "No changes between '{base}' and '{dev}'; nothing to split"
+    PLAN_HAS_NO_CHANGES = "Saved plan has an empty diff; nothing to execute"
     LLM_PARSE_ERROR = "Failed to parse LLM response: {detail}"
     BRANCH_CREATE_FAILED = "Failed to create branch '{branch}': {detail}"
     PR_CREATE_FAILED = "Failed to create PR for group '{group}': {detail}"

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -504,10 +504,27 @@ class TestExecuteCommand:
         mock_plan_file = MagicMock()
         mock_plan_file.git_state.branches = []
         mock_plan_file.git_state.prs = []
-        mock_plan_file.plan.raw_diff = ""
+        mock_plan_file.plan.raw_diff = None
         mock_load.return_value = mock_plan_file
         result = runner.invoke(app, ["execute"])
         assert result.exit_code != 0
+        assert "missing saved diff data" in result.output
+
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_execute_empty_saved_diff_is_refused(
+        self, mock_pe: MagicMock, mock_load: MagicMock
+    ) -> None:
+        mock_plan_file = MagicMock()
+        mock_plan_file.git_state.branches = []
+        mock_plan_file.git_state.prs = []
+        mock_plan_file.plan.raw_diff = ""
+        mock_plan_file.plan.groups = []
+        mock_plan_file.plan.merge_base_sha = "abc123"
+        mock_load.return_value = mock_plan_file
+        result = runner.invoke(app, ["execute"])
+        assert result.exit_code == 1
+        assert "Saved plan has an empty diff; nothing to execute" in result.output
 
     @patch("pr_split.cli.load_plan")
     @patch("pr_split.cli.plan_exists", return_value=True)

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -231,6 +231,31 @@ class TestHandleLocBoundWarnings:
         mock_warning.assert_not_called()
 
 
+class TestSplitEmptyDiff:
+    @patch("pr_split.cli.save_plan")
+    @patch("pr_split.cli.plan_split")
+    @patch("pr_split.cli.extract_diff", return_value="")
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_no_changes_is_refused_before_planning(
+        self,
+        mock_branch_exists: MagicMock,
+        mock_validate_inputs: MagicMock,
+        mock_extract_diff: MagicMock,
+        mock_plan_split: MagicMock,
+        mock_save_plan: MagicMock,
+    ) -> None:
+        result = runner.invoke(
+            app,
+            ["split", "feature-branch", "--base", "main", "--dry-run"],
+            env={"ANTHROPIC_API_KEY": "sk-test"},
+        )
+        assert result.exit_code == 1
+        assert "No changes between 'main' and 'feature-branch'; nothing to split" in result.output
+        mock_plan_split.assert_not_called()
+        mock_save_plan.assert_not_called()
+
+
 class TestSplitCliEnvVars:
     @patch("pr_split.cli.save_plan")
     @patch("pr_split.cli.merge_base", return_value="abc123")


### PR DESCRIPTION
## Summary

`pr-split split` on a branch with no changes against its base "succeeded" with a zero-group plan: `--dry-run` reported "Dry run complete: plan with 0 groups saved", the live path asked to proceed and then reported "Split complete: 0 PRs created", and `execute` on that plan complained that it was "missing saved diff data" because `raw_diff == ""` is falsy.

Now `split` stops right after parsing with `No changes between 'main' and 'feature'; nothing to split` (exit 1, nothing written), and `execute` distinguishes a plan with no saved diff (`raw_diff is None`) from one whose diff is empty (`Saved plan has an empty diff; nothing to execute`).

## Test plan

- `TestSplitEmptyDiff`: `extract_diff` returns `""` → exit 1 with the message, `plan_split`/`save_plan` never called
- `test_execute_empty_saved_diff_is_refused`; existing missing-diff test now uses `None`
- Review probed binary-only, mode-only and rename diffs (all parse to ≥1 file, so they are not misreported) and the fork-PR argument forms
- 446 tests pass, ruff clean
- Local review: 5/5
