### PR TITLE
fix: escape plan text in the plan table, dependency tree and editor messages

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -91,11 +91,13 @@ def _render_dag(groups: list[Group]) -> str:
         children = [g for g in groups if parent_id in g.depends_on]
         for child in children:
             deps_label = ", ".join(child.depends_on)
-            branch = parent_tree.add(f"{child.id}: {child.title} (depends on: {deps_label})")
+            branch = parent_tree.add(
+                escape(f"{child.id}: {child.title} (depends on: {deps_label})")
+            )
             _add_children(branch, child.id)
 
     for root in roots:
-        root_branch = tree.add(f"{root.id}: {root.title}")
+        root_branch = tree.add(escape(f"{root.id}: {root.title}"))
         _add_children(root_branch, root.id)
 
     with console.capture() as capture:
@@ -164,12 +166,13 @@ def _present_plan(groups: list[Group]) -> None:
         files = ", ".join(a.file_path for a in group.assignments)
         deps = ", ".join(group.depends_on) if group.depends_on else ""
         diff_str = f"+{group.estimated_added}/-{group.estimated_removed}"
+        # Plan text is LLM/user-written; "[...]" in it is Rich markup unless escaped.
         table.add_row(
-            group.id,
-            group.title,
+            escape(group.id),
+            escape(group.title),
             diff_str,
-            deps,
-            files,
+            escape(deps),
+            escape(files),
         )
 
     console.print(table)
@@ -515,7 +518,7 @@ def _move_assignment(
     src = group_map.get(from_id)
     dst = group_map.get(to_id)
     if not src or not dst:
-        console.print(f"[red]Group '{from_id}' or '{to_id}' not found.[/red]")
+        console.print(f"[red]Group '{escape(from_id)}' or '{escape(to_id)}' not found.[/red]")
         return False
 
     pf_map = {pf.path: pf for pf in parsed_diff.patch_set}
@@ -542,7 +545,9 @@ def _move_assignment(
             break
 
     if not found:
-        console.print(f"[red]Hunk {file_path}:{hunk_index} not found in {from_id}.[/red]")
+        console.print(
+            f"[red]Hunk {escape(file_path)}:{hunk_index} not found in {escape(from_id)}.[/red]"
+        )
         return False
 
     dst_assignment = next((a for a in dst.assignments if a.file_path == file_path), None)
@@ -564,7 +569,10 @@ def _move_assignment(
             )
         )
 
-    console.print(f"[green]Moved {file_path}:{hunk_index} from {from_id} to {to_id}[/green]")
+    console.print(
+        f"[green]Moved {escape(file_path)}:{hunk_index} from {escape(from_id)} "
+        f"to {escape(to_id)}[/green]"
+    )
     return True
 
 
@@ -572,7 +580,7 @@ def _show_group_detail(groups: list[Group], group_id: str) -> None:
     group_map = {g.id: g for g in groups}
     group = group_map.get(group_id)
     if not group:
-        console.print(f"[red]Group '{group_id}' not found.[/red]")
+        console.print(f"[red]Group '{escape(group_id)}' not found.[/red]")
         return
     # Titles, descriptions and paths come from the plan (LLM-written); any
     # "[...]" in them would be swallowed as Rich markup unless escaped.

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -557,3 +557,47 @@ class TestStatusCommand:
     def test_clean_no_plan(self, mock_pe: MagicMock) -> None:
         result = runner.invoke(app, ["clean"])
         assert result.exit_code == 0
+
+
+class TestRichEscapingOfPlanText:
+    def test_present_plan_keeps_brackets_in_title_and_paths(self) -> None:
+        from pr_split.cli import _present_plan, console
+
+        g = _group("pr-1", "Add [core] typing", files=["src/[id].py"])
+        # _render_dag captures on the same console, which would reset an
+        # enclosing capture; it has its own test below.
+        with patch("pr_split.cli._render_dag", return_value=""), console.capture() as capture:
+            _present_plan([g])
+        out = capture.get()
+        assert "Add [core] typing" in out
+        assert "src/[id].py" in out
+
+    def test_render_dag_keeps_brackets(self) -> None:
+        from pr_split.cli import _render_dag
+
+        root = _group("pr-1", "Root [v2]")
+        child = _group("pr-2", "Child [x]", depends_on=["pr-1"])
+        out = _render_dag([root, child])
+        assert "pr-1: Root [v2]" in out
+        assert "pr-2: Child [x] (depends on: pr-1)" in out
+
+    def test_move_messages_keep_bracketed_paths(self) -> None:
+        from pr_split.cli import console
+
+        g1 = _group("pr-1", "src", files=["src/[id].py"])
+        g2 = _group("pr-2", "dst")
+        pf = MagicMock()
+        pf.path = "src/[id].py"
+        pf.__len__ = MagicMock(return_value=2)
+        parsed = MagicMock()
+        parsed.patch_set = [pf]
+        with console.capture() as capture:
+            assert _move_assignment([g1, g2], parsed, "src/[id].py", 1, "pr-1", "pr-2")
+            assert not _move_assignment([g1, g2], parsed, "src/[id].py", 9, "pr-1", "pr-2")
+            assert not _move_assignment([g1, g2], parsed, "a.py", 0, "[pr-1]", "pr-2")
+            _show_group_detail([g1], "[pr-9]")
+        out = capture.get()
+        assert "Moved src/[id].py:1 from pr-1 to pr-2" in out
+        assert "Hunk src/[id].py:9 not found in pr-1." in out
+        assert "Group '[pr-1]' or 'pr-2' not found." in out
+        assert "Group '[pr-9]' not found." in out


### PR DESCRIPTION
## Summary

Follow-up to #124: the remaining Rich outputs that print plan or user text unescaped — the `Split Plan` table cells, the dependency-tree labels, and the editor's `Moved …` / `Hunk … not found` / `Group '…' not found` messages — now go through `rich.markup.escape`. A title such as `Add [core] typing` or a path like `src/[id].py` is printed as written instead of losing the bracketed part as a style tag. The markdown dependency graph in PR bodies is plain text and untouched.

Stacked on #124 (`fix/show-assignment-type-markup`).

Still unescaped, noted for a later PR: the `status` table, merge summary lines, `Edited plan is invalid: {exc}`-style error echoes, and LOC-bound warnings.

## Test plan

- `TestRichEscapingOfPlanText`: table, tree, and editor messages keep bracketed text — all three fail on the base
- 448 tests pass, ruff clean
- Local review: 5/5
