### PR TITLE
fix: drop groups emptied in the interactive editor instead of aborting the session

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ edit> done               # proceed (default — just press Enter)
 edit> abort              # cancel
 ```
 
-The plan is re-validated after editing to catch empty groups or coverage gaps.
+Groups you empty are dropped (their dependants inherit their dependencies); the plan is then re-validated for coverage gaps and LOC bounds.
 
 ### Custom PR body templates
 

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -590,6 +590,43 @@ def _show_group_detail(groups: list[Group], group_id: str) -> None:
     console.print()
 
 
+def _drop_empty_groups(groups: list[Group]) -> list[Group]:
+    """Remove groups the user emptied in the editor and unlink them from the DAG.
+
+    Moving every hunk out of a group is a legitimate way to dissolve it;
+    aborting the session there would throw away all the other edits. A
+    dropped group's own dependencies are inherited by its dependants so
+    ordering is preserved.
+    """
+    dropped = {g.id: list(g.depends_on) for g in groups if not g.assignments}
+    if not dropped:
+        return groups
+
+    def _surviving(dep: str, seen: set[str]) -> list[str]:
+        # Walk through chains of dropped groups to the nearest kept ancestors.
+        if dep not in dropped:
+            return [dep]
+        out: list[str] = []
+        for parent in dropped[dep]:
+            if parent not in seen:
+                seen.add(parent)
+                out.extend(_surviving(parent, seen))
+        return out
+
+    kept: list[Group] = []
+    for group in groups:
+        if group.id in dropped:
+            continue
+        deps: list[str] = []
+        for dep in group.depends_on:
+            for candidate in _surviving(dep, set()):
+                if candidate not in deps and candidate != group.id:
+                    deps.append(candidate)
+        kept.append(group.model_copy(update={"depends_on": deps}))
+    console.print(f"[yellow]Dropped empty group(s) after editing: {', '.join(dropped)}[/yellow]")
+    return kept
+
+
 def _interactive_edit(groups: list[Group], parsed_diff: ParsedDiff) -> list[Group]:
     console.print(
         "\n[cyan]Interactive editor. Commands:[/cyan]\n"
@@ -806,10 +843,9 @@ def split(
     groups = _interactive_edit(groups, parsed_diff)
 
     # Re-validate after user edits
-    empty_groups = [g for g in groups if not g.assignments]
-    if empty_groups:
-        empty_ids = [g.id for g in empty_groups]
-        console.print(f"[red]Groups {empty_ids} are empty after editing.[/red]")
+    groups = _drop_empty_groups(groups)
+    if not groups:
+        console.print("[red]Every group is empty after editing; nothing to split.[/red]")
         raise typer.Exit(1)
     try:
         dag = PlanDAG(groups)

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -16,6 +16,7 @@ from typer.testing import CliRunner
 
 from pr_split.cli import (
     _build_pr_body,
+    _drop_empty_groups,
     _handle_loc_bound_warnings,
     _interactive_edit,
     _move_assignment,
@@ -611,3 +612,109 @@ class TestStatusCommand:
     def test_clean_no_plan(self, mock_pe: MagicMock) -> None:
         result = runner.invoke(app, ["clean"])
         assert result.exit_code == 0
+
+
+TWO_HUNK_DIFF = """\
+diff --git a/a.py b/a.py
+--- a/a.py
++++ b/a.py
+@@ -1,3 +1,4 @@
+ x
++one
+ y
+ z
+@@ -20,3 +21,5 @@
+ p
++two
++three
+ q
+ r
+"""
+
+
+class TestDropEmptyGroups:
+    def test_no_empty_groups_returns_same_list(self) -> None:
+        groups = [_group("pr-1", "a", files=["a.py"]), _group("pr-2", "b", files=["b.py"])]
+        assert _drop_empty_groups(groups) is groups
+
+    def test_empty_group_is_dropped_and_dependants_inherit_its_parents(self) -> None:
+        root = _group("pr-1", "root", files=["a.py"])
+        emptied = _group("pr-2", "emptied", depends_on=["pr-1"])
+        leaf = _group("pr-3", "leaf", depends_on=["pr-2"], files=["c.py"])
+        from pr_split.cli import console
+
+        with console.capture() as capture:
+            result = _drop_empty_groups([root, emptied, leaf])
+
+        assert [g.id for g in result] == ["pr-1", "pr-3"]
+        assert result[1].depends_on == ["pr-1"]
+        assert "Dropped empty group(s) after editing: pr-2" in capture.get()
+
+    def test_dropping_a_root_leaves_dependants_as_roots(self) -> None:
+        emptied = _group("pr-1", "emptied")
+        leaf = _group("pr-2", "leaf", depends_on=["pr-1"], files=["b.py"])
+        result = _drop_empty_groups([emptied, leaf])
+        assert [g.id for g in result] == ["pr-2"]
+        assert result[0].depends_on == []
+
+    def test_chain_of_empty_groups_collapses_transitively(self) -> None:
+        root = _group("pr-1", "root", files=["a.py"])
+        e1 = _group("pr-2", "e1", depends_on=["pr-1"])
+        e2 = _group("pr-3", "e2", depends_on=["pr-2"])
+        leaf = _group("pr-4", "leaf", depends_on=["pr-3"], files=["d.py"])
+        result = _drop_empty_groups([root, e1, e2, leaf])
+        assert [g.id for g in result] == ["pr-1", "pr-4"]
+        assert result[1].depends_on == ["pr-1"]
+
+    def test_chain_with_direct_edge_does_not_duplicate(self) -> None:
+        root = _group("pr-1", "root", files=["a.py"])
+        e1 = _group("pr-2", "e1", depends_on=["pr-1"])
+        e2 = _group("pr-3", "e2", depends_on=["pr-2"])
+        leaf = _group("pr-4", "leaf", depends_on=["pr-3", "pr-1"], files=["d.py"])
+        result = _drop_empty_groups([root, e1, e2, leaf])
+        assert result[1].depends_on == ["pr-1"]
+
+    def test_diamond_through_dropped_groups(self) -> None:
+        a = _group("pr-1", "a", files=["a.py"])
+        b = _group("pr-2", "b", files=["b.py"])
+        e1 = _group("pr-3", "e1", depends_on=["pr-1"])
+        e2 = _group("pr-4", "e2", depends_on=["pr-2"])
+        e3 = _group("pr-5", "e3", depends_on=["pr-3", "pr-4"])
+        leaf = _group("pr-6", "leaf", depends_on=["pr-5"], files=["f.py"])
+        result = _drop_empty_groups([a, b, e1, e2, e3, leaf])
+        assert [g.id for g in result] == ["pr-1", "pr-2", "pr-6"]
+        assert result[2].depends_on == ["pr-1", "pr-2"]
+
+
+class TestEditorEmptiedGroupEndToEnd:
+    @patch("pr_split.cli.typer.prompt")
+    def test_moving_the_last_hunk_out_yields_a_valid_one_group_plan(
+        self, mock_prompt: MagicMock
+    ) -> None:
+        from pr_split.cli import _drop_empty_groups, _interactive_edit
+        from pr_split.diff_ops.parser import parse_diff
+        from pr_split.graph import PlanDAG
+        from pr_split.planner.validator import validate_plan
+
+        parsed = parse_diff(TWO_HUNK_DIFF)
+        g1 = _group("pr-1", "first", added=1, removed=0)
+        g1.assignments = [
+            GroupAssignment(
+                file_path="a.py", assignment_type=AssignmentType.PARTIAL_HUNKS, hunk_indices=[0]
+            )
+        ]
+        g2 = _group("pr-2", "second", depends_on=["pr-1"], added=2, removed=0)
+        g2.assignments = [
+            GroupAssignment(
+                file_path="a.py", assignment_type=AssignmentType.PARTIAL_HUNKS, hunk_indices=[1]
+            )
+        ]
+        mock_prompt.side_effect = ["move a.py:1 pr-2 pr-1", "done"]
+
+        edited = _interactive_edit([g1, g2], parsed)
+        groups = _drop_empty_groups(edited)
+
+        assert [g.id for g in groups] == ["pr-1"]
+        assert groups[0].assignments[0].hunk_indices == [0, 1]
+        assert groups[0].estimated_loc == 3
+        assert validate_plan(groups, parsed, PlanDAG(groups), max_loc=400) == []

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -231,6 +231,97 @@ class TestHandleLocBoundWarnings:
         mock_warning.assert_not_called()
 
 
+class TestSplitEditorEmptiedGroup:
+    @patch("pr_split.cli.save_plan")
+    @patch("pr_split.cli.merge_base", return_value="abc123")
+    @patch("pr_split.cli._interactive_edit")
+    @patch("pr_split.cli._present_plan")
+    @patch("pr_split.cli.validate_plan", return_value=[])
+    @patch("pr_split.cli.plan_split")
+    @patch("pr_split.cli.parse_diff")
+    @patch("pr_split.cli.extract_diff", return_value="diff --git a/a.py b/a.py\n")
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_emptied_group_is_dropped_and_plan_saved(
+        self,
+        mock_branch_exists: MagicMock,
+        mock_validate_inputs: MagicMock,
+        mock_extract_diff: MagicMock,
+        mock_parse_diff: MagicMock,
+        mock_plan_split: MagicMock,
+        mock_validate_plan: MagicMock,
+        mock_present_plan: MagicMock,
+        mock_interactive_edit: MagicMock,
+        mock_merge_base: MagicMock,
+        mock_save_plan: MagicMock,
+    ) -> None:
+        parsed_diff = MagicMock()
+        parsed_diff.stats = {
+            "total_files": 1,
+            "total_added": 1,
+            "total_removed": 0,
+            "total_loc": 1,
+        }
+        mock_parse_diff.return_value = parsed_diff
+        first = _group("pr-1", "keeps a", files=["a.py"])
+        second = _group("pr-2", "emptied", depends_on=["pr-1"])
+        mock_plan_split.return_value = [first, second]
+        mock_interactive_edit.return_value = [first, second]
+
+        result = runner.invoke(
+            app, ["split", "feature-branch", "--dry-run"], env={"ANTHROPIC_API_KEY": "sk-test"}
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Dropped empty group(s) after editing: pr-2" in result.output
+        saved = mock_save_plan.call_args[0][0].plan
+        assert [g.id for g in saved.groups] == ["pr-1"]
+        validated = mock_validate_plan.call_args_list[-1].args[0]
+        assert [g.id for g in validated] == ["pr-1"]
+
+    @patch("pr_split.cli.save_plan")
+    @patch("pr_split.cli.merge_base", return_value="abc123")
+    @patch("pr_split.cli._interactive_edit")
+    @patch("pr_split.cli._present_plan")
+    @patch("pr_split.cli.validate_plan", return_value=[])
+    @patch("pr_split.cli.plan_split")
+    @patch("pr_split.cli.parse_diff")
+    @patch("pr_split.cli.extract_diff", return_value="diff --git a/a.py b/a.py\n")
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_all_groups_emptied_is_an_error(
+        self,
+        mock_branch_exists: MagicMock,
+        mock_validate_inputs: MagicMock,
+        mock_extract_diff: MagicMock,
+        mock_parse_diff: MagicMock,
+        mock_plan_split: MagicMock,
+        mock_validate_plan: MagicMock,
+        mock_present_plan: MagicMock,
+        mock_interactive_edit: MagicMock,
+        mock_merge_base: MagicMock,
+        mock_save_plan: MagicMock,
+    ) -> None:
+        parsed_diff = MagicMock()
+        parsed_diff.stats = {
+            "total_files": 1,
+            "total_added": 1,
+            "total_removed": 0,
+            "total_loc": 1,
+        }
+        mock_parse_diff.return_value = parsed_diff
+        mock_plan_split.return_value = [_group("pr-1", "a", files=["a.py"])]
+        mock_interactive_edit.return_value = [_group("pr-1", "emptied")]
+
+        result = runner.invoke(
+            app, ["split", "feature-branch", "--dry-run"], env={"ANTHROPIC_API_KEY": "sk-test"}
+        )
+
+        assert result.exit_code == 1
+        assert "Every group is empty after editing; nothing to split." in result.output
+        mock_save_plan.assert_not_called()
+
+
 class TestSplitCliEnvVars:
     @patch("pr_split.cli.save_plan")
     @patch("pr_split.cli.merge_base", return_value="abc123")


### PR DESCRIPTION
## Summary

Moving every hunk out of a group in the interactive editor ended the session with `Groups ['pr-2'] are empty after editing.` and exit 1 — all other edits were thrown away. Dissolving a group is a legitimate edit.

`split` now drops emptied groups (`Dropped empty group(s) after editing: pr-2`), rewires their dependants to the nearest kept ancestors (chains of emptied groups collapse transitively; a dropped root leaves its dependants as roots; diamonds keep both surviving parents), then re-validates the reduced plan. It only errors when every group is empty. README's editor paragraph now describes this.

Stacked on #60 (stack #74 = #58→#60→#129) because #60 recomputes LOC after each move — without it the dropped group's stale `estimated_loc` made `validate_loc` fail.

## Test plan

- `TestDropEmptyGroups`: no-op, single drop with inheritance, dropped root, transitive chain (unmasked), direct-edge dedup, diamond through dropped groups
- `TestEditorEmptiedGroupEndToEnd`: unmocked `_interactive_edit` → drop → real `validate_plan` returns `[]`
- `TestSplitEditorEmptiedGroup`: CLI saves the one-group plan; all-empty exits 1
- Review verified the e2e fixture (`move a.py:2 pr-2 pr-1`, `done`) now exits 0 with a valid one-group plan
- 470 tests pass, ruff clean
- Local review: 5/5 (after three fix→re-review rounds)


