### PR TITLE
fix: warn when CP-SAT returns a feasible but unproven-optimal partition at the time limit

### DIFF
--- a/pr_split/logs.py
+++ b/pr_split/logs.py
@@ -75,6 +75,6 @@ PR_SKIPPED_BASE_NOT_PUSHED = (
     "Skipping PR for group '{group}': its base branch '{base}' was not pushed"
 )
 CP_SAT_NOT_OPTIMAL = (
-    "CP-SAT stopped at the {timeout:.1f}s limit with a feasible but unproven-optimal plan "
+    "CP-SAT stopped at the {timeout:g}s limit with a feasible but unproven-optimal plan "
     "({units} units, {groups} groups); raise --cp-sat-timeout for a better partition"
 )

--- a/pr_split/logs.py
+++ b/pr_split/logs.py
@@ -69,3 +69,7 @@ MERGE_NODE_NOT_STACKED = (
 PR_SKIPPED_BASE_NOT_PUSHED = (
     "Skipping PR for group '{group}': its base branch '{base}' was not pushed"
 )
+CP_SAT_NOT_OPTIMAL = (
+    "CP-SAT stopped at the {timeout:.1f}s limit with a feasible but unproven-optimal plan "
+    "({units} units, {groups} groups); raise --cp-sat-timeout for a better partition"
+)

--- a/pr_split/planner/partitioning.py
+++ b/pr_split/planner/partitioning.py
@@ -6,6 +6,9 @@ from itertools import pairwise
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 
+from loguru import logger
+
+from .. import logs
 from ..constants import AssignmentType, PartitionStrategy, Priority
 from ..exceptions import PRSplitError
 from ..schemas import Group, GroupAssignment
@@ -433,11 +436,21 @@ def _group_units_cp_sat(
                 assignments[group_idx].append(unit)
                 break
 
-    return [
+    grouped = [
         sorted(group_units, key=lambda unit: unit.position)
         for _, group_units in sorted(assignments.items())
         if group_units
     ]
+    if status == cp_model.FEASIBLE:
+        # The solver ran out of time before proving optimality; on larger
+        # diffs the plan it returns can be far from the best one (many
+        # singleton groups), so say so instead of presenting it as final.
+        logger.warning(
+            logs.CP_SAT_NOT_OPTIMAL.format(
+                timeout=settings.cp_sat_timeout, units=len(units), groups=len(grouped)
+            )
+        )
+    return grouped
 
 
 def _build_group_title(group_index: int, units: list[PartitionUnit]) -> str:

--- a/tests/test_partitioning.py
+++ b/tests/test_partitioning.py
@@ -149,6 +149,36 @@ class TestPartitionDiffCpSat:
         assert "0.5s limit" in warning
         assert "raise --cp-sat-timeout" in warning
 
+    def test_sub_decisecond_timeout_is_reported_exactly(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cp_model = pytest.importorskip("ortools.sat.python.cp_model")
+        from unittest.mock import patch
+
+        parsed = parse_diff(SAMPLE_DIFF)
+        settings = _settings(
+            monkeypatch,
+            max_loc=10,
+            partition_strategy=PartitionStrategy.CP_SAT,
+            cp_sat_timeout=0.04,
+        )
+        real_solve = cp_model.CpSolver.Solve
+
+        def solve_feasible(self: object, model: object) -> int:
+            real_solve(self, model)
+            return cp_model.FEASIBLE
+
+        with (
+            patch.object(cp_model.CpSolver, "Solve", solve_feasible),
+            patch("pr_split.planner.partitioning.logger") as mock_logger,
+        ):
+            partition_diff(parsed, settings)
+
+        warning = mock_logger.warning.call_args[0][0]
+        # A timeout below 0.1s must not be rounded away to "0.0s"; the warning
+        # tells the user which limit to raise, so it has to name the real value.
+        assert "0.04s limit" in warning
+
     def test_optimal_solution_does_not_warn(self, monkeypatch: pytest.MonkeyPatch) -> None:
         pytest.importorskip("ortools.sat.python.cp_model")
         from unittest.mock import patch

--- a/tests/test_partitioning.py
+++ b/tests/test_partitioning.py
@@ -50,12 +50,14 @@ def _settings(
     max_loc: int,
     partition_strategy: PartitionStrategy,
     priority: Priority = Priority.ORTHOGONAL,
+    **overrides: object,
 ) -> Settings:
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
     return Settings(
         max_loc=max_loc,
         partition_strategy=partition_strategy,
         priority=priority,
+        **overrides,
     )
 
 
@@ -109,3 +111,42 @@ class TestPartitionDiffCpSat:
         groups = partition_diff(parsed, settings)
         assert len(groups) == 2
         assert all(group.depends_on == [] for group in groups)
+
+    def test_feasible_but_not_optimal_is_warned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cp_model = pytest.importorskip("ortools.sat.python.cp_model")
+        from unittest.mock import patch
+
+        parsed = parse_diff(SAMPLE_DIFF)
+        settings = _settings(
+            monkeypatch,
+            max_loc=10,
+            partition_strategy=PartitionStrategy.CP_SAT,
+            cp_sat_timeout=0.5,
+        )
+        real_solve = cp_model.CpSolver.Solve
+
+        def solve_feasible(self: object, model: object) -> int:
+            real_solve(self, model)
+            return cp_model.FEASIBLE
+
+        with (
+            patch.object(cp_model.CpSolver, "Solve", solve_feasible),
+            patch("pr_split.planner.partitioning.logger") as mock_logger,
+        ):
+            groups = partition_diff(parsed, settings)
+
+        assert len(groups) == 2
+        warning = mock_logger.warning.call_args[0][0]
+        assert "feasible but unproven-optimal plan" in warning
+        assert "0.5s limit" in warning
+        assert "raise --cp-sat-timeout" in warning
+
+    def test_optimal_solution_does_not_warn(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pytest.importorskip("ortools.sat.python.cp_model")
+        from unittest.mock import patch
+
+        parsed = parse_diff(SAMPLE_DIFF)
+        settings = _settings(monkeypatch, max_loc=10, partition_strategy=PartitionStrategy.CP_SAT)
+        with patch("pr_split.planner.partitioning.logger") as mock_logger:
+            partition_diff(parsed, settings)
+        mock_logger.warning.assert_not_called()


### PR DESCRIPTION
## Summary

The CP-SAT partition backend accepted a `FEASIBLE` solver status silently. When the solver hits `--cp-sat-timeout` on a larger diff (the model has one boolean per unit×slot×pair, so ~70 units already exceed the default 15 s) it returns whatever feasible assignment it had — often dozens of singleton groups — and the user had no way to tell that from a proven-optimal plan.

A `FEASIBLE` result now logs a warning: `CP-SAT stopped at the 15.0s limit with a feasible but unproven-optimal plan (70 units, 37 groups); raise --cp-sat-timeout for a better partition`. `OPTIMAL` stays silent; `INFEASIBLE`/`UNKNOWN` still raise as before.

## Test plan

- `test_feasible_but_not_optimal_is_warned` (patches `CpSolver.Solve` to report FEASIBLE after a real solve) and `test_optimal_solution_does_not_warn` — both fail on main
- Review confirmed the warning reaches stderr on a real time-limited solve (30 units, 3 s)
- 446 tests pass, ruff clean
- Local review: 5/5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a warning when the planner finds a feasible solution but cannot prove it is optimal within the configured timeout.
  * Warning details include the timeout and guidance to increase the CP-SAT timeout for potentially better results.
  * Improved graph partitioning behavior for cyclic inputs, including safer grouping and minimum-size corrections.
  * Added validation to reject invalid cyclic partitioning results.

* **Tests**
  * Expanded coverage for solver warnings and graph partitioning edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->