### PR TITLE
fix: reject duplicate group ids and guard merge against a malformed saved plan

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -1179,7 +1179,14 @@ def merge_all(
         console.print("[yellow]No PRs found in plan. Nothing to merge.[/yellow]")
         raise typer.Exit(0)
 
-    dag = PlanDAG(plan.groups)
+    # A hand-edited plan.json can carry unknown or cyclic dependencies;
+    # report that instead of a traceback from the DAG walk.
+    try:
+        dag = PlanDAG(plan.groups)
+        dag.validate_acyclic()
+    except PlanValidationError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
     merged: list[str] = []
     skipped: list[str] = []
     skipped_ids: set[str] = set()

--- a/pr_split/exceptions.py
+++ b/pr_split/exceptions.py
@@ -17,6 +17,7 @@ class ErrorMsg(StrEnum):
     UNKNOWN_HUNK = "Hunk {file}[{index}] assigned to group '{group}' does not exist in the diff"
     UNKNOWN_FILE = "File '{file}' assigned to group '{group}' does not exist in the diff"
     UNKNOWN_DEPENDENCY = "Group '{group}' depends on unknown group '{dep}'"
+    DUPLICATE_GROUP_ID = "Group id '{group}' is used more than once"
     LOC_MISMATCH = "Total LOC {actual} does not match diff LOC {expected}"
     MERGE_CONFLICT = "Groups '{a}' and '{b}' modify overlapping regions in '{file}'"
     NO_PLAN = "No split plan found; run 'pr-split split' first"

--- a/pr_split/graph.py
+++ b/pr_split/graph.py
@@ -10,7 +10,13 @@ from .schemas import Group
 
 class PlanDAG:
     def __init__(self, groups: list[Group]) -> None:
-        self._groups: dict[str, Group] = {g.id: g for g in groups}
+        self._groups: dict[str, Group] = {}
+        for g in groups:
+            # Silently collapsing duplicates would drop a group and later
+            # surface as a bogus merge conflict between a group and itself.
+            if g.id in self._groups:
+                raise PlanValidationError(ErrorMsg.DUPLICATE_GROUP_ID(group=g.id))
+            self._groups[g.id] = g
         self._children: dict[str, list[str]] = {g.id: [] for g in groups}
         self._parents: dict[str, list[str]] = {g.id: list(g.depends_on) for g in groups}
         for g in groups:

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -21,7 +21,9 @@ from pr_split.schemas import (
     GitState,
     Group,
     GroupAssignment,
+    PlanFile,
     PRRecord,
+    SplitPlan,
 )
 
 runner = CliRunner()
@@ -385,3 +387,51 @@ class TestSplitCliEnvVars:
         assert mock_validate_plan.call_args_list[0].kwargs["min_loc"] == 50
         assert mock_validate_plan.call_args_list[1].kwargs["min_loc"] == 50
         mock_save_plan.assert_not_called()
+
+
+class TestMergeRejectsMalformedSavedPlan:
+    def _plan_file(self, groups: list[Group]) -> PlanFile:
+        from pr_split.constants import Priority
+
+        plan = SplitPlan(
+            dev_branch="feature",
+            base_branch="main",
+            max_loc=400,
+            priority=Priority.ORTHOGONAL,
+            groups=groups,
+        )
+        prs = [PRRecord(group_id=g.id, pr_number=i + 1, pr_url="u") for i, g in enumerate(groups)]
+        return PlanFile(plan=plan, git_state=GitState(prs=prs))
+
+    @patch("pr_split.cli.get_pr_state")
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_unknown_dependency_is_a_clean_error(
+        self, mock_pe: MagicMock, mock_load: MagicMock, mock_state: MagicMock
+    ) -> None:
+        mock_load.return_value = self._plan_file(
+            [_group("pr-1", "a", files=["a.py"]), _group("pr-2", "b", depends_on=["pr-9"])]
+        )
+        result = runner.invoke(app, ["merge"])
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "depends on unknown group 'pr-9'" in result.output
+        mock_state.assert_not_called()
+
+    @patch("pr_split.cli.get_pr_state")
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_cycle_is_a_clean_error(
+        self, mock_pe: MagicMock, mock_load: MagicMock, mock_state: MagicMock
+    ) -> None:
+        mock_load.return_value = self._plan_file(
+            [
+                _group("pr-1", "a", depends_on=["pr-2"], files=["a.py"]),
+                _group("pr-2", "b", depends_on=["pr-1"], files=["b.py"]),
+            ]
+        )
+        result = runner.invoke(app, ["merge"])
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "Dependency cycle detected" in result.output
+        mock_state.assert_not_called()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -141,3 +141,13 @@ class TestLinearChains:
         ]
         dag = PlanDAG(groups)
         assert sorted(dag.linear_chains()) == [["a"], ["b", "c"], ["d"]]
+
+
+class TestPlanDAGRejectsDuplicateIds:
+    def test_duplicate_group_id_is_a_validation_error(self) -> None:
+        with pytest.raises(PlanValidationError, match="'pr-1' is used more than once"):
+            PlanDAG([_group("pr-1"), _group("pr-1")])
+
+    def test_distinct_ids_are_fine(self) -> None:
+        dag = PlanDAG([_group("pr-1"), _group("pr-2", ["pr-1"])])
+        assert dag.parents("pr-2") == ["pr-1"]


### PR DESCRIPTION
## Summary

Two small gaps left after #48:

- `PlanDAG.__init__` silently collapsed two groups with the same id (a dict keyed by id), which later surfaced as a bogus "merge conflict between pr-1 and pr-1" or, in `merge`, a silently skipped group. It now raises `Group id 'pr-1' is used more than once`.
- `merge` built the DAG unguarded and `iter_ready` raised a raw `graphlib.CycleError` / `KeyError` for a hand-edited `plan.json` with a cycle or an unknown dependency. It now wraps `PlanDAG` + `validate_acyclic()` and prints the message with exit 1 — the same guard #48 adds to `execute`.

Stacked on #48 (`fix/validate-plan-references`).

## Test plan

- `TestPlanDAGRejectsDuplicateIds` (`test_graph.py`), `TestMergeRejectsMalformedSavedPlan` (unknown dependency, cycle — `get_pr_state` never called) — all fail on the base
- 453 tests pass, ruff clean
- Local review: 5/5
