### PR TITLE
fix: validate split settings before the existing-plan cleanup closes PRs and deletes branches

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -753,6 +753,24 @@ def split(
 
     _validate_inputs(dev_branch, base, dry_run=dry_run)
 
+    # Validate settings before anything destructive: the existing-plan
+    # cleanup below closes PRs and deletes branches, and a bad --min-loc or
+    # a missing API key must not be discovered only after that.
+    try:
+        settings = Settings(
+            min_loc=min_loc,
+            max_loc=max_loc,
+            strict_loc_bounds=strict_loc_bounds,
+            max_refinement_iterations=max_refinement_iterations,
+            cp_sat_timeout=cp_sat_timeout,
+            priority=priority,
+            chunk_strategy=chunk_strategy,
+            partition_strategy=partition_strategy,
+        )
+    except (ValidationError, ValueError) as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
+
     if plan_exists():
         existing = load_plan()
         has_git_state = existing.git_state.branches or existing.git_state.prs
@@ -794,20 +812,6 @@ def split(
         )
     )
 
-    try:
-        settings = Settings(
-            min_loc=min_loc,
-            max_loc=max_loc,
-            strict_loc_bounds=strict_loc_bounds,
-            max_refinement_iterations=max_refinement_iterations,
-            cp_sat_timeout=cp_sat_timeout,
-            priority=priority,
-            chunk_strategy=chunk_strategy,
-            partition_strategy=partition_strategy,
-        )
-    except (ValidationError, ValueError) as exc:
-        console.print(f"[red]{exc}[/red]")
-        raise typer.Exit(1) from exc
     groups = plan_split(parsed_diff, settings)
 
     logger.info(logs.VALIDATING_PLAN)

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -509,6 +509,42 @@ class TestSplitCommandValidation:
         mock_auth.assert_called_once()
 
 
+class TestSplitValidatesSettingsBeforeCleanup:
+    @patch("pr_split.cli.extract_diff")
+    @patch("pr_split.cli._cleanup_git_state")
+    @patch("pr_split.cli.typer.confirm", return_value=True)
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_bad_settings_never_reach_the_destructive_cleanup(
+        self,
+        mock_be: MagicMock,
+        mock_validate: MagicMock,
+        mock_pe: MagicMock,
+        mock_load: MagicMock,
+        mock_confirm: MagicMock,
+        mock_cleanup: MagicMock,
+        mock_extract: MagicMock,
+    ) -> None:
+        existing = MagicMock()
+        existing.git_state.branches = [MagicMock()]
+        existing.git_state.prs = [MagicMock()]
+        mock_load.return_value = existing
+
+        result = runner.invoke(
+            app,
+            ["split", "feature", "--min-loc", "500", "--max-loc", "400"],
+            env={"ANTHROPIC_API_KEY": "sk-test"},
+        )
+
+        assert result.exit_code == 1
+        assert "min_loc 500 must be less than max_loc 400" in " ".join(result.output.split())
+        mock_confirm.assert_not_called()
+        mock_cleanup.assert_not_called()
+        mock_extract.assert_not_called()
+
+
 class TestSplitDryRunWithExecutedPlan:
     @patch("pr_split.cli._cleanup_git_state")
     @patch("pr_split.cli.typer.confirm")
@@ -530,7 +566,9 @@ class TestSplitDryRunWithExecutedPlan:
         existing.git_state.prs = [MagicMock()]
         mock_load.return_value = existing
 
-        result = runner.invoke(app, ["split", "feature", "--dry-run"])
+        result = runner.invoke(
+            app, ["split", "feature", "--dry-run"], env={"ANTHROPIC_API_KEY": "sk-test"}
+        )
 
         assert result.exit_code == 1
         assert "Run 'pr-split clean' first" in result.output


### PR DESCRIPTION
## Summary

In `split`, the "Clean up and proceed with re-splitting?" step — which closes the existing sub-PRs, deletes their remote branches and removes the plan — ran **before** `Settings(...)` was constructed. An invalid option pair (`--min-loc 500 --max-loc 400`), a missing `ANTHROPIC_API_KEY`, or a negative `--max-refinement-iterations` was therefore only reported after the user's live PRs had already been destroyed, with nothing re-created.

`Settings` depends only on CLI options and the environment, so its construction (and the existing clean error handling) now happens right after `_validate_inputs`, before anything destructive.

Stacked on #111 (`fix/split-dry-run-preamble`), which owns the surrounding cleanup block.

## Test plan

- `test_bad_settings_never_reach_the_destructive_cleanup`: with an executed plan on disk and `--min-loc 500 --max-loc 400`, exit 1 with the settings error and neither the confirm prompt, `_cleanup_git_state`, nor `extract_diff` is reached — fails on the base
- the dry-run refusal test now supplies an API key since settings validate first
- Review confirmed `--dry-run --partition-strategy graph` without an API key still works, and `execute` has no equivalent hazard
- 449 tests pass, ruff clean
- Local review: 5/5
