### PR TITLE
fix: reject a non-positive --cp-sat-timeout instead of reporting an infeasible model

### DIFF
--- a/pr_split/config.py
+++ b/pr_split/config.py
@@ -39,7 +39,7 @@ class Settings(BaseSettings):
     max_loc: int = Field(default=DEFAULT_MAX_LOC, gt=0)
     strict_loc_bounds: bool = DEFAULT_STRICT_LOC_BOUNDS
     max_refinement_iterations: int = Field(default=DEFAULT_MAX_REFINEMENT_ITERATIONS, ge=0)
-    cp_sat_timeout: float = DEFAULT_CP_SAT_TIMEOUT_SECONDS
+    cp_sat_timeout: float = Field(default=DEFAULT_CP_SAT_TIMEOUT_SECONDS, gt=0)
     priority: Priority = Priority.ORTHOGONAL
     chunk_strategy: ChunkStrategy = DEFAULT_CHUNK_STRATEGY
     partition_strategy: PartitionStrategy = DEFAULT_PARTITION_STRATEGY

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -182,3 +182,18 @@ class TestSettingsEmptyKeyValidation:
         monkeypatch.setenv("OPENAI_API_KEY", "")
         with pytest.raises(ValidationError, match="OPENAI_API_KEY"):
             Settings(provider=Provider.OPENAI)
+
+
+class TestCpSatTimeoutBound:
+    @pytest.mark.parametrize("timeout", [0.0, -1.0, -5])
+    def test_non_positive_timeout_is_rejected(
+        self, monkeypatch: pytest.MonkeyPatch, timeout: float
+    ) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        with pytest.raises(ValidationError, match="cp_sat_timeout"):
+            Settings(partition_strategy=PartitionStrategy.CP_SAT, cp_sat_timeout=timeout)
+
+    def test_positive_timeout_is_accepted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        settings = Settings(partition_strategy=PartitionStrategy.CP_SAT, cp_sat_timeout=0.25)
+        assert settings.cp_sat_timeout == 0.25


### PR DESCRIPTION
## Summary

`Settings.cp_sat_timeout` had no bound, so `--cp-sat-timeout 0` or `-5` (and `PR_SPLIT_CP_SAT_TIMEOUT=0`) were accepted. OR-tools then returns `UNKNOWN` (0) or `MODEL_INVALID` (negative) and the CP-SAT backend reported "failed to find a feasible hunk assignment" — even for a trivially feasible single-unit problem.

The field is now `Field(default=15.0, gt=0)`; the CLI's existing `Settings` error handling prints `cp_sat_timeout: Input should be greater than 0` and exits 1 before any planning.

## Test plan

- `TestCpSatTimeoutBound`: `0.0`, `-1.0`, `-5` rejected; `0.25` accepted — the rejections fail on main
- Review confirmed the CLI message and the env-var path
- 448 tests pass, ruff clean
- Local review: 5/5

Noted by the review, not in this PR: a tiny positive timeout on a large model still surfaces as the generic "infeasible" message (a status-specific "solver timed out" message would be a separate small change).
