### PR TITLE
fix: treat a dependency listed twice as one edge so stacked children are not demoted to merge nodes

### DIFF
--- a/pr_split/graph.py
+++ b/pr_split/graph.py
@@ -18,9 +18,14 @@ class PlanDAG:
                 raise PlanValidationError(ErrorMsg.DUPLICATE_GROUP_ID(group=g.id))
             self._groups[g.id] = g
         self._children: dict[str, list[str]] = {g.id: [] for g in groups}
-        self._parents: dict[str, list[str]] = {g.id: list(g.depends_on) for g in groups}
+        # A dependency listed twice ("pr-1", "pr-1") is one edge: keeping the
+        # duplicate would make the group look like a merge node, so a stacked
+        # child would be built from the merge base and left out of the stack.
+        self._parents: dict[str, list[str]] = {
+            g.id: list(dict.fromkeys(g.depends_on)) for g in groups
+        }
         for g in groups:
-            for dep in g.depends_on:
+            for dep in self._parents[g.id]:
                 if dep not in self._groups:
                     raise PlanValidationError(ErrorMsg.UNKNOWN_DEPENDENCY(group=g.id, dep=dep))
                 self._children[dep].append(g.id)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -151,3 +151,16 @@ class TestPlanDAGRejectsDuplicateIds:
     def test_distinct_ids_are_fine(self) -> None:
         dag = PlanDAG([_group("pr-1"), _group("pr-2", ["pr-1"])])
         assert dag.parents("pr-2") == ["pr-1"]
+
+
+class TestPlanDAGDedupesDependencies:
+    def test_duplicate_dependency_is_a_single_edge(self) -> None:
+        dag = PlanDAG([_group("pr-1"), _group("pr-2", ["pr-1", "pr-1"])])
+        assert dag.parents("pr-2") == ["pr-1"]
+        assert dag.children("pr-1") == ["pr-2"]
+        assert dag.is_merge_node("pr-2") is False
+        assert dag.linear_chains() == [["pr-1", "pr-2"]]
+
+    def test_duplicate_dependency_does_not_break_batching(self) -> None:
+        dag = PlanDAG([_group("pr-1"), _group("pr-2", ["pr-1", "pr-1"])])
+        assert list(dag.iter_ready()) == [["pr-1"], ["pr-2"]]


### PR DESCRIPTION
## Summary

`PlanDAG` built its parent/child maps from `depends_on` verbatim. A plan with `depends_on: ["pr-1", "pr-1"]` — an LLM slip or a hand edit that passes validation — therefore looked like a two-parent merge node: `is_merge_node` was true, `linear_chains` split the chain, and in `--stack` mode the child was built from the merge base, its PR targeted the base branch instead of `pr-1`'s branch, it was left out of `gh stack link`, and the "merge node not stacked" warning fired.

A dependency listed twice is now one edge (`dict.fromkeys`), so the child stays a linear descendant. The review reproduced the stacked path before/after: base `('pr-2', 'main', <merge-base>)` + warning → branch `('pr-2', <pr-1 branch>, <pr-1 branch>)` and `link_stack([1, 2])`.

Stacked on #134 (`fix/plan-dag-duplicate-ids-and-merge-guard`, stack #135 = #48→#134→this).

## Test plan

- `TestPlanDAGDedupesDependencies`: single edge, not a merge node, one linear chain (fails on the base), batching unaffected
- 455 tests pass, ruff clean
- Local review: 5/5

Noted, not in this PR: `score_plan.dependency_edges` still counts the duplicate (only feeds a log line).
