### PR TITLE
fix: tell the LLM planner about --min-loc instead of only checking it afterwards

### DIFF
--- a/pr_split/planner/client.py
+++ b/pr_split/planner/client.py
@@ -395,7 +395,7 @@ def _plan_split_with_llm(
 ) -> list[Group]:
     diff_stats = parsed_diff.stats
 
-    system = build_system_prompt(settings.priority, settings.max_loc)
+    system = build_system_prompt(settings.priority, settings.max_loc, settings.min_loc)
     user = build_user_prompt(diff_stats, parsed_diff.labeled_diff)
 
     logger.info(logs.COUNTING_TOKENS.format(model=settings.model))

--- a/pr_split/planner/prompts.py
+++ b/pr_split/planner/prompts.py
@@ -77,7 +77,7 @@ left unassigned and no hunk may appear in multiple groups.
 No cycles are allowed.
 3. Each group should stay within approximately {max_loc} lines of code \
 (added + removed). Exceeding this is acceptable only when a logical unit cannot \
-be split further.
+be split further.{min_loc_rule}
 4. Use the propose_split_plan tool to return your plan.
 5. PR titles MUST follow conventional commits format: \
 type(optional-scope): description. Allowed types: feat, fix, refactor, test, \
@@ -228,9 +228,20 @@ _PRIORITY_MAP = {
 }
 
 
-def build_system_prompt(priority: Priority, max_loc: int) -> str:
+_MIN_LOC_RULE = (
+    " Groups should also not be smaller than about {min_loc} lines: merge "
+    "closely related small changes rather than creating tiny groups, unless "
+    "a change genuinely stands alone."
+)
+
+
+def build_system_prompt(priority: Priority, max_loc: int, min_loc: int | None = None) -> str:
+    # --min-loc was documented as applying to every backend, but the LLM only
+    # ever heard about it via the (off by default) refinement prompt.
+    min_loc_rule = _MIN_LOC_RULE.format(min_loc=min_loc) if min_loc else ""
     return _SYSTEM_PROMPT_TEMPLATE.format(
         max_loc=max_loc,
+        min_loc_rule=min_loc_rule,
         priority_instructions=_PRIORITY_MAP[priority],
     )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -969,6 +969,29 @@ class TestPlanSplitWithLlm:
         mock_llm.assert_called_once()
 
     @patch("pr_split.planner.client._refine_plan_with_llm")
+    @patch("pr_split.planner.client.recompute_estimated_loc")
+    @patch("pr_split.planner.client._call_llm")
+    @patch("pr_split.planner.client._count_tokens", return_value=100)
+    def test_min_loc_reaches_the_system_prompt(
+        self,
+        mock_count: MagicMock,
+        mock_llm: MagicMock,
+        mock_recompute: MagicMock,
+        mock_refine: MagicMock,
+    ) -> None:
+        parsed = parse_diff(_TWO_FILE_DIFF)
+        settings = _make_settings(
+            Provider.ANTHROPIC, partition_strategy=PartitionStrategy.LLM, min_loc=50, max_loc=400
+        )
+        mock_llm.return_value = RawToolOutput(groups=_SAMPLE_RAW_GROUPS)
+        mock_refine.side_effect = lambda groups, *a, **kw: groups
+
+        _plan_split_with_llm(parsed, settings)
+
+        system = mock_llm.call_args.kwargs["system"]
+        assert "not be smaller than about 50 lines" in system
+
+    @patch("pr_split.planner.client._refine_plan_with_llm")
     @patch("pr_split.planner.client._plan_split_chunked")
     @patch("pr_split.planner.client._count_tokens", return_value=999_999_999)
     def test_large_diff_uses_chunking(

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -60,6 +60,17 @@ class TestBuildSystemPrompt:
         assert "LOGICAL" in result
         assert "200" in result
 
+    def test_min_loc_adds_a_size_floor_rule(self) -> None:
+        result = build_system_prompt(Priority.ORTHOGONAL, 400, min_loc=100)
+        assert "not be smaller than about 100 lines" in result
+        assert "within approximately 400 lines" in result
+
+    def test_no_min_loc_keeps_the_prompt_unchanged(self) -> None:
+        assert build_system_prompt(Priority.ORTHOGONAL, 400) == build_system_prompt(
+            Priority.ORTHOGONAL, 400, min_loc=None
+        )
+        assert "smaller than" not in build_system_prompt(Priority.ORTHOGONAL, 400)
+
 
 class TestBuildUserPrompt:
     def test_contains_file_summary(self) -> None:


### PR DESCRIPTION
## Summary

README says `--min-loc` controls sub-PR size "across all three backends (LLM, graph, CP-SAT)", but the LLM system prompt only ever mentioned `max_loc`. The minimum reached the model solely through the refinement prompt, which runs only with `--max-refinement-iterations > 0` (default `0`) — so with default settings `--min-loc N` produced post-hoc warnings (or a `--strict-loc-bounds` failure) and never influenced planning.

`build_system_prompt(priority, max_loc, min_loc=None)` now appends a size-floor sentence to rule 3 when a minimum is set, and `_plan_split_with_llm` passes `settings.min_loc`. The same system string already flows into the chunked path and refinement, so all LLM calls see it.

## Test plan

- `test_min_loc_adds_a_size_floor_rule`, `test_no_min_loc_keeps_the_prompt_unchanged` (prompts), `test_min_loc_reaches_the_system_prompt` (client) — the new-signature tests fail on main
- 447 tests pass, ruff clean
- Local review: 5/5
