### PR TITLE
fix: count a dependency listed twice as one edge in the plan objective

### DIFF
--- a/pr_split/planner/scoring.py
+++ b/pr_split/planner/scoring.py
@@ -39,7 +39,8 @@ def score_plan(groups: list[Group], max_loc: int, min_loc: int | None = None) ->
         else 0
     )
     loc_overflow = sum(max(0, group.estimated_loc - max_loc) for group in groups)
-    dependency_edges = sum(len(group.depends_on) for group in groups)
+    # Count edges as the DAG sees them (a dependency listed twice is one edge).
+    dependency_edges = sum(len(dag.parents(group.id)) for group in groups)
     dag_width = max((len(batch) for batch in dag.iter_ready()), default=0)
     dag_depth = _dag_depth(dag)
 

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -66,3 +66,18 @@ class TestScorePlan:
         metrics = score_plan(groups, 100, min_loc=50)
         assert metrics.loc_underflow == 30
         assert metrics.undersized_groups == 1
+
+
+class TestDependencyEdgesAreDeduped:
+    def test_duplicate_dependency_counts_once(self) -> None:
+        groups = [
+            _group("pr-1", "a.py", [0], 10),
+            _group("pr-2", "b.py", [0], 10, depends_on=["pr-1", "pr-1"]),
+        ]
+        metrics = score_plan(groups, max_loc=100)
+        assert metrics.dependency_edges == 1
+        clean = [
+            _group("pr-1", "a.py", [0], 10),
+            _group("pr-2", "b.py", [0], 10, depends_on=["pr-1"]),
+        ]
+        assert metrics.objective == score_plan(clean, max_loc=100).objective


### PR DESCRIPTION
## Summary

Follow-up to #139: `score_plan` computed `dependency_edges` as `sum(len(group.depends_on))`, so a dependency listed twice still inflated the objective (`dependency_edges=2`, objective 70 instead of 50) even though the DAG now treats it as one edge. It uses `len(dag.parents(group.id))` now, matching `_dag_depth`.

Stacked on #139 (stack #135 = #48→#134→#139→this).

## Test plan

- `TestDependencyEdgesAreDeduped`: edges == 1 and objective parity with the clean plan — fails on the base (edges 2, objective 70)
- 456 tests pass, ruff clean
- Local review: 5/5
