### PR TITLE
fix: report a CP-SAT time-out distinctly from an infeasible model

### DIFF
--- a/pr_split/exceptions.py
+++ b/pr_split/exceptions.py
@@ -27,6 +27,11 @@ class ErrorMsg(StrEnum):
     HUNK_TOO_LARGE = "Hunk {file}[{index}] has ~{tokens} estimated tokens, exceeds budget {budget}"
     MIN_LOC_GE_MAX_LOC = "min_loc {min_loc} must be less than max_loc {max_loc}"
     LOC_BOUNDS_STRICT_FAILED = "Plan violates configured LOC bounds"
+    CP_SAT_TIMED_OUT = (
+        "CP-SAT found no hunk assignment within {timeout:.1f}s ({units} units); "
+        "raise --cp-sat-timeout or use --partition-strategy graph"
+    )
+    CP_SAT_INFEASIBLE = "CP-SAT partitioning failed to find a feasible hunk assignment"
 
     def __call__(self, **kwargs: object) -> str:
         return self.value.format(**kwargs) if kwargs else self.value

--- a/pr_split/planner/partitioning.py
+++ b/pr_split/planner/partitioning.py
@@ -10,7 +10,7 @@ from loguru import logger
 
 from .. import logs
 from ..constants import AssignmentType, PartitionStrategy, Priority
-from ..exceptions import PRSplitError
+from ..exceptions import ErrorMsg, PRSplitError
 from ..schemas import Group, GroupAssignment
 from .chunker import recompute_estimated_loc
 
@@ -426,8 +426,14 @@ def _group_units_cp_sat(
     solver = cp_model.CpSolver()
     solver.parameters.max_time_in_seconds = settings.cp_sat_timeout
     status = solver.Solve(model)
+    if status == cp_model.UNKNOWN:
+        # The time limit expired before any solution was found; that is not
+        # infeasibility, and the fix (more time or another backend) differs.
+        raise PRSplitError(
+            ErrorMsg.CP_SAT_TIMED_OUT(timeout=settings.cp_sat_timeout, units=len(units))
+        )
     if status not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
-        raise PRSplitError("CP-SAT partitioning failed to find a feasible hunk assignment")
+        raise PRSplitError(ErrorMsg.CP_SAT_INFEASIBLE())
 
     assignments: dict[int, list[PartitionUnit]] = defaultdict(list)
     for unit_idx, unit in enumerate(units):

--- a/tests/test_partitioning.py
+++ b/tests/test_partitioning.py
@@ -141,6 +141,32 @@ class TestPartitionDiffCpSat:
         assert "0.5s limit" in warning
         assert "raise --cp-sat-timeout" in warning
 
+    @pytest.mark.parametrize(
+        ("status_name", "expected"),
+        [("UNKNOWN", "found no hunk assignment within 0.5s"), ("INFEASIBLE", "feasible hunk")],
+    )
+    def test_solver_status_is_reported_distinctly(
+        self, monkeypatch: pytest.MonkeyPatch, status_name: str, expected: str
+    ) -> None:
+        cp_model = pytest.importorskip("ortools.sat.python.cp_model")
+        from unittest.mock import patch
+
+        from pr_split.exceptions import PRSplitError
+
+        parsed = parse_diff(SAMPLE_DIFF)
+        settings = _settings(
+            monkeypatch,
+            max_loc=10,
+            partition_strategy=PartitionStrategy.CP_SAT,
+            cp_sat_timeout=0.5,
+        )
+        forced = getattr(cp_model, status_name)
+        with (
+            patch.object(cp_model.CpSolver, "Solve", lambda self, model: forced),
+            pytest.raises(PRSplitError, match=expected),
+        ):
+            partition_diff(parsed, settings)
+
     def test_optimal_solution_does_not_warn(self, monkeypatch: pytest.MonkeyPatch) -> None:
         pytest.importorskip("ortools.sat.python.cp_model")
         from unittest.mock import patch


### PR DESCRIPTION
## Summary

The CP-SAT backend raised "CP-SAT partitioning failed to find a feasible hunk assignment" for every status other than OPTIMAL/FEASIBLE — including `UNKNOWN`, which OR-tools returns when the time limit expires before *any* solution is found. A too-small `--cp-sat-timeout` on a larger diff therefore read as "your diff cannot be partitioned".

`UNKNOWN` now raises `CP-SAT found no hunk assignment within 15.0s (70 units); raise --cp-sat-timeout or use --partition-strategy graph`; the other statuses keep the previous text (moved to `ErrorMsg.CP_SAT_INFEASIBLE`).

Stacked on #130 (`fix/cp-sat-feasible-warning`), which owns the surrounding status handling.

## Test plan

- `test_solver_status_is_reported_distinctly` parametrised over `UNKNOWN` / `INFEASIBLE` (patches `CpSolver.Solve`) — the `UNKNOWN` case fails on the base
- 448 tests pass, ruff clean
- Local review: 5/5
