### PR TITLE
fix: open PRs in base-chain order and skip children whose parent PR could not be opened

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -460,22 +460,53 @@ def _push_and_create_prs(
                 return False
             gid = owner
 
+    # Open PRs in base-chain order: a child's PR targets its parent's
+    # branch, so if the parent's PR could not be opened the child must be
+    # skipped too, or the saved plan ends up holding orphans whose stack
+    # root does not exist.
+    pending = [g for g in groups if g.id in pushed and _base_pushed(g)]
+    results: dict[str, PRRecord] = {}
+    failed_prs: set[str] = set()
     with ThreadPoolExecutor(max_workers=_PUSH_MAX_WORKERS) as executor:
-        future_to_group_id = {
-            executor.submit(
-                _create_single_pr, group, record_map[group.id], groups, draft=draft
-            ): group.id
-            for group in groups
-            if group.id in pushed and _base_pushed(group)
-        }
-        results: dict[str, PRRecord] = {}
-        for future in as_completed(future_to_group_id):
-            group_id = future_to_group_id[future]
-            try:
-                results[group_id] = future.result()
-            except Exception as exc:
-                logger.error(f"Failed to create PR for {group_id}: {exc}")
-                errors.append((group_id, exc))
+        while pending:
+            ready: list[Group] = []
+            for group in pending:
+                owner = branch_owner.get(record_map[group.id].base_branch)
+                if owner is None or owner in results:
+                    ready.append(group)
+                elif owner in failed_prs:
+                    logger.warning(
+                        logs.PR_SKIPPED_BASE_PR_FAILED.format(
+                            group=group.id, base=record_map[group.id].base_branch
+                        )
+                    )
+                    failed_prs.add(group.id)
+            pending = [g for g in pending if g not in ready and g.id not in failed_prs]
+            if not ready:
+                # Whatever is left descends (possibly several levels, and in
+                # any listing order) from a failed PR; say so for each one.
+                for group in pending:
+                    logger.warning(
+                        logs.PR_SKIPPED_BASE_PR_FAILED.format(
+                            group=group.id, base=record_map[group.id].base_branch
+                        )
+                    )
+                    failed_prs.add(group.id)
+                break
+            future_to_group_id = {
+                executor.submit(
+                    _create_single_pr, group, record_map[group.id], groups, draft=draft
+                ): group.id
+                for group in ready
+            }
+            for future in as_completed(future_to_group_id):
+                group_id = future_to_group_id[future]
+                try:
+                    results[group_id] = future.result()
+                except Exception as exc:
+                    logger.error(f"Failed to create PR for {group_id}: {exc}")
+                    errors.append((group_id, exc))
+                    failed_prs.add(group_id)
 
     if errors:
         error_details = "\n".join([f"- {gid}: {exc}" for gid, exc in errors])

--- a/pr_split/logs.py
+++ b/pr_split/logs.py
@@ -69,3 +69,6 @@ MERGE_NODE_NOT_STACKED = (
 PR_SKIPPED_BASE_NOT_PUSHED = (
     "Skipping PR for group '{group}': its base branch '{base}' was not pushed"
 )
+PR_SKIPPED_BASE_PR_FAILED = (
+    "Skipping PR for {group}: no PR could be opened for its base branch {base}"
+)

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -539,6 +539,131 @@ class TestStackedTransitiveChain:
         assert child_calls[0].args[1].assignments[0].hunk_indices == [0, 1, 2]
 
 
+class TestParentPrFailureGating:
+    def _chain(self) -> tuple[list[Group], list[BranchRecord]]:
+        groups = [
+            _group("pr-1", "feat: a"),
+            _group("pr-2", "feat: b", ["pr-1"]),
+            _group("pr-3", "feat: c", ["pr-2"]),
+        ]
+        records = [
+            _branch_record("pr-1", "pr-split/ns/pr-1"),
+            BranchRecord(
+                group_id="pr-2",
+                branch_name="pr-split/ns/pr-2",
+                base_branch="pr-split/ns/pr-1",
+                commit_sha="abc123",
+            ),
+            BranchRecord(
+                group_id="pr-3",
+                branch_name="pr-split/ns/pr-3",
+                base_branch="pr-split/ns/pr-2",
+                commit_sha="abc123",
+            ),
+        ]
+        return groups, records
+
+    @patch("pr_split.cli.create_pr")
+    @patch("pr_split.cli.push_branch")
+    def test_children_are_skipped_when_the_root_pr_fails(
+        self, mock_push: MagicMock, mock_create: MagicMock
+    ) -> None:
+        from pr_split.exceptions import PRCreationError
+
+        groups, records = self._chain()
+
+        def create(
+            *, head: str, base: str, title: str, body: str, draft: bool = False
+        ) -> tuple[int, str]:
+            if head == "pr-split/ns/pr-1":
+                raise GitOperationError("boom")
+            return (11, "https://github.com/pr/11")
+
+        mock_create.side_effect = create
+        with pytest.raises(PRCreationError) as excinfo:
+            _push_and_create_prs(groups, records)
+
+        assert excinfo.value.pr_records == []
+        assert [c.kwargs["head"] for c in mock_create.call_args_list] == ["pr-split/ns/pr-1"]
+
+    @patch("pr_split.cli.create_pr")
+    @patch("pr_split.cli.push_branch")
+    def test_every_descendant_is_warned_even_when_listed_before_its_parent(
+        self, mock_push: MagicMock, mock_create: MagicMock
+    ) -> None:
+        from pr_split.exceptions import PRCreationError
+
+        groups, records = self._chain()
+        groups.reverse()
+        records.reverse()
+
+        def create(
+            *, head: str, base: str, title: str, body: str, draft: bool = False
+        ) -> tuple[int, str]:
+            if head == "pr-split/ns/pr-1":
+                raise GitOperationError("boom")
+            return (11, "https://github.com/pr/11")
+
+        mock_create.side_effect = create
+        with patch("pr_split.cli.logger") as mock_logger, pytest.raises(PRCreationError):
+            _push_and_create_prs(groups, records)
+
+        warned = " ".join(str(c.args[0]) for c in mock_logger.warning.call_args_list)
+        assert "Skipping PR for pr-2" in warned
+        assert "Skipping PR for pr-3" in warned
+
+    @patch("pr_split.cli.create_pr")
+    @patch("pr_split.cli.push_branch")
+    def test_only_the_failed_subtree_is_skipped(
+        self, mock_push: MagicMock, mock_create: MagicMock
+    ) -> None:
+        from pr_split.exceptions import PRCreationError
+
+        groups, records = self._chain()
+        groups.append(_group("pr-4", "feat: d"))
+        records.append(_branch_record("pr-4", "pr-split/ns/pr-4"))
+        numbers = iter(range(20, 30))
+
+        def create(
+            *, head: str, base: str, title: str, body: str, draft: bool = False
+        ) -> tuple[int, str]:
+            if head == "pr-split/ns/pr-2":
+                raise GitOperationError("boom")
+            n = next(numbers)
+            return (n, f"https://github.com/pr/{n}")
+
+        mock_create.side_effect = create
+        with pytest.raises(PRCreationError) as excinfo:
+            _push_and_create_prs(groups, records)
+
+        created = sorted(r.group_id for r in excinfo.value.pr_records)
+        assert created == ["pr-1", "pr-4"]
+        heads = {c.kwargs["head"] for c in mock_create.call_args_list}
+        assert "pr-split/ns/pr-3" not in heads
+
+    @patch("pr_split.cli.create_pr")
+    @patch("pr_split.cli.push_branch")
+    def test_parent_pr_is_opened_before_its_child(
+        self, mock_push: MagicMock, mock_create: MagicMock
+    ) -> None:
+        groups, records = self._chain()
+        order: list[str] = []
+        numbers = iter(range(1, 10))
+
+        def create(
+            *, head: str, base: str, title: str, body: str, draft: bool = False
+        ) -> tuple[int, str]:
+            order.append(head)
+            n = next(numbers)
+            return (n, f"https://github.com/pr/{n}")
+
+        mock_create.side_effect = create
+        result = _push_and_create_prs(groups, records)
+
+        assert [r.group_id for r in result] == ["pr-1", "pr-2", "pr-3"]
+        assert order == ["pr-split/ns/pr-1", "pr-split/ns/pr-2", "pr-split/ns/pr-3"]
+
+
 class TestTransitivePushFailureGating:
     @patch("pr_split.cli.create_pr", return_value=(1, "https://github.com/pr/1"))
     @patch("pr_split.cli.push_branch")


### PR DESCRIPTION
## Summary

`_push_and_create_prs` submitted every PR creation to the thread pool at once. The only gate, `_base_pushed`, checks *pushes*, so when `gh pr create` failed for the root of a stack its children — whose PRs target the root's branch — were still opened. `PRCreationError.pr_records` (and therefore the saved plan) then held orphan PRs whose stack root has no PR, and `_link_stacks` never ran.

PRs are now opened in waves: a group is submitted only once the owner of its base branch has a PR (or the base is not owned by a group); descendants of a failed PR are skipped with `Skipping PR for pr-3: no PR could be opened for its base branch pr-split/ns/pr-2` — one warning per skipped group, in any plan listing order — while independent subtrees and merge nodes (which target the base branch) proceed. Concurrency within a wave is unchanged.

## Test plan

- `TestParentPrFailureGating`: root failure skips the whole chain (no records, only one `create_pr` call); a mid-chain failure skips only that subtree while a sibling root still opens; every descendant is warned even when listed before its parent; parent-before-child ordering — three of the four fail on main
- Review probed a fan-out DAG (root and mid-chain failures, both listing orders)
- 448 tests pass, ruff clean
- Local review: 5/5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Pull requests are now created in dependency order, ensuring parent branches are available before child pull requests are opened.
  - Descendant pull requests are skipped when a parent pull request fails, with clear warnings.
  - Independent pull request groups continue processing even when another group fails.
  - Partial results and errors are reported more accurately when creation issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->