### PR TITLE
fix: round-trip non-UTF-8 text files instead of crashing with UnicodeDecodeError

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -226,7 +226,7 @@ def _create_single_branch_and_commit(
             if content is not None:
                 p.parent.mkdir(parents=True, exist_ok=True)
                 # newline="" keeps CRLF from the reconstructed content intact.
-                p.write_text(content, encoding="utf-8", newline="")
+                p.write_text(content, encoding="utf-8", errors="surrogateescape", newline="")
             elif p.exists():
                 p.unlink()
 

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -225,7 +225,8 @@ def _create_single_branch_and_commit(
             p = Path(worktree_path) / file_path
             if content is not None:
                 p.parent.mkdir(parents=True, exist_ok=True)
-                p.write_text(content, encoding="utf-8")
+                # newline="" keeps CRLF from the reconstructed content intact.
+                p.write_text(content, encoding="utf-8", newline="")
             elif p.exists():
                 p.unlink()
 

--- a/pr_split/diff_ops/parser.py
+++ b/pr_split/diff_ops/parser.py
@@ -34,14 +34,16 @@ DIFF_ARGS: tuple[str, ...] = (
 
 def extract_diff(dev_branch: str, base_branch: str) -> str:
     logger.info(logs.EXTRACTING_DIFF.format(base=base_branch, dev=dev_branch))
+    # Capture bytes: text mode applies universal-newline translation, which
+    # turns CRLF into LF and would make every sub-PR rewrite the file's
+    # line endings.
     result = subprocess.run(
         ["git", "diff", *DIFF_ARGS, f"{base_branch}...{dev_branch}"],
         capture_output=True,
-        text=True,
     )
     if result.returncode != 0:
-        raise GitOperationError(result.stderr.strip())
-    return result.stdout
+        raise GitOperationError(result.stderr.decode("utf-8", errors="replace").strip())
+    return result.stdout.decode("utf-8")
 
 
 def parse_diff(raw_diff: str) -> ParsedDiff:

--- a/pr_split/diff_ops/parser.py
+++ b/pr_split/diff_ops/parser.py
@@ -91,9 +91,43 @@ def unquote_git_path(path: str) -> str:
     return bytes(out).decode("utf-8", errors="surrogateescape")
 
 
+_QUOTED_PATH_RE = re.compile(r'"(?:[^"\\]|\\.)*"')
+_HEADER_PREFIXES = ("diff --git ", "--- ", "+++ ")
+
+
+def _escape_spaces_in_quoted_paths(line: str) -> str:
+    return _QUOTED_PATH_RE.sub(lambda m: m.group(0).replace(" ", "\\040"), line)
+
+
+def _normalize_quoted_headers(raw_diff: str) -> str:
+    """Make C-quoted paths containing spaces parseable by unidiff.
+
+    unidiff splits `diff --git <src> <dst>` on the last space, so a quoted
+    path with a space (`"a/my \\"notes\\".md"`) is cut in the wrong place and
+    no longer matches the `---`/`+++` lines: unidiff then keeps a phantom
+    0-hunk file for a modification and raises "Target without source" for an
+    addition or deletion. Spaces inside quoted paths are rewritten as the
+    octal escape `\\040` -- still valid C-quoting, which unquote_git_path
+    decodes -- on the header lines only (between `diff --git` and the first
+    `@@`), so hunk content is never touched.
+    """
+    if '"' not in raw_diff:
+        return raw_diff
+    lines = raw_diff.split("\n")
+    in_header = False
+    for i, line in enumerate(lines):
+        if line.startswith("diff --git "):
+            in_header = True
+        elif line.startswith("@@"):
+            in_header = False
+        if in_header and '"' in line and line.startswith(_HEADER_PREFIXES):
+            lines[i] = _escape_spaces_in_quoted_paths(line)
+    return "\n".join(lines)
+
+
 def parse_diff(raw_diff: str) -> ParsedDiff:
     try:
-        patch_set = PatchSet(raw_diff)
+        patch_set = PatchSet(_normalize_quoted_headers(raw_diff))
     except Exception as exc:
         raise DiffParseError(str(exc)) from exc
     for patch_file in patch_set:

--- a/pr_split/diff_ops/parser.py
+++ b/pr_split/diff_ops/parser.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import subprocess
 from dataclasses import dataclass
 from functools import cached_property
@@ -49,11 +50,55 @@ def extract_diff(dev_branch: str, base_branch: str) -> str:
     return result.stdout.decode("utf-8")
 
 
+_C_ESCAPES = {
+    "a": b"\a",
+    "b": b"\b",
+    "f": b"\f",
+    "n": b"\n",
+    "r": b"\r",
+    "t": b"\t",
+    "v": b"\v",
+    "\\": b"\\",
+    '"': b'"',
+}
+_C_ESCAPE_RE = re.compile(r"\\([0-7]{1,3}|.)", re.DOTALL)
+
+
+def unquote_git_path(path: str) -> str:
+    """Decode a path git printed in its C-quoted form, e.g. `"a/we\\"ird.py"`.
+
+    Even with core.quotePath=false git quotes any path containing `"`, `\\`
+    or a control character. unidiff keeps the quotes and escapes verbatim, so
+    without this the a/ b/ prefix is never stripped and the file would be
+    written under a literally quoted name.
+    """
+    if len(path) < 2 or path[0] != '"' or path[-1] != '"':
+        return path
+    out = bytearray()
+    pos = 0
+    body = path[1:-1]
+    for match in _C_ESCAPE_RE.finditer(body):
+        out += body[pos : match.start()].encode("utf-8")
+        escape = match.group(1)
+        if escape[0] in "01234567":
+            # Octal escapes are single bytes; consecutive ones form one
+            # multi-byte UTF-8 character, which the final decode reassembles.
+            out.append(int(escape, 8))
+        else:
+            out += _C_ESCAPES.get(escape, escape.encode("utf-8"))
+        pos = match.end()
+    out += body[pos:].encode("utf-8")
+    return bytes(out).decode("utf-8", errors="surrogateescape")
+
+
 def parse_diff(raw_diff: str) -> ParsedDiff:
     try:
         patch_set = PatchSet(raw_diff)
     except Exception as exc:
         raise DiffParseError(str(exc)) from exc
+    for patch_file in patch_set:
+        patch_file.source_file = unquote_git_path(patch_file.source_file)
+        patch_file.target_file = unquote_git_path(patch_file.target_file)
     return ParsedDiff(patch_set=patch_set, raw_diff=raw_diff)
 
 

--- a/pr_split/diff_ops/parser.py
+++ b/pr_split/diff_ops/parser.py
@@ -47,7 +47,10 @@ def extract_diff(dev_branch: str, base_branch: str) -> str:
     )
     if result.returncode != 0:
         raise GitOperationError(result.stderr.decode("utf-8", errors="replace").strip())
-    return result.stdout.decode("utf-8")
+    # Git diffs any NUL-free file as text, so legacy latin-1 sources reach us
+    # too; surrogateescape keeps their bytes intact so they round-trip when
+    # the worker writes them back with the same error handler.
+    return result.stdout.decode("utf-8", errors="surrogateescape")
 
 
 _C_ESCAPES = {

--- a/pr_split/diff_ops/parser.py
+++ b/pr_split/diff_ops/parser.py
@@ -38,7 +38,10 @@ def extract_diff(dev_branch: str, base_branch: str) -> str:
     # turns CRLF into LF and would make every sub-PR rewrite the file's
     # line endings.
     result = subprocess.run(
-        ["git", "diff", *DIFF_ARGS, f"{base_branch}...{dev_branch}"],
+        # core.quotePath=false: otherwise git octal-escapes and quotes any
+        # non-ASCII path ("b/caf\303\251.txt"), which unidiff cannot parse for
+        # new/deleted files and mis-reports as a literal quoted path otherwise.
+        ["git", "-c", "core.quotePath=false", "diff", *DIFF_ARGS, f"{base_branch}...{dev_branch}"],
         capture_output=True,
     )
     if result.returncode != 0:

--- a/pr_split/diff_ops/reconstructor.py
+++ b/pr_split/diff_ops/reconstructor.py
@@ -60,14 +60,15 @@ def merge_chain_assignments(
 
 
 def _get_base_file_content(file_path: str, ref: str) -> str:
+    # Bytes, not text mode: universal newlines would strip the CR from CRLF
+    # files and the reconstructed file would come out with LF endings.
     result = subprocess.run(
         ["git", "show", f"{ref}:{file_path}"],
         capture_output=True,
-        text=True,
     )
     if result.returncode != 0:
-        raise GitOperationError(result.stderr.strip())
-    return result.stdout
+        raise GitOperationError(result.stderr.decode("utf-8", errors="replace").strip())
+    return result.stdout.decode("utf-8")
 
 
 NO_NEWLINE_MARKER = "\\"

--- a/pr_split/diff_ops/reconstructor.py
+++ b/pr_split/diff_ops/reconstructor.py
@@ -68,7 +68,7 @@ def _get_base_file_content(file_path: str, ref: str) -> str:
     )
     if result.returncode != 0:
         raise GitOperationError(result.stderr.decode("utf-8", errors="replace").strip())
-    return result.stdout.decode("utf-8")
+    return result.stdout.decode("utf-8", errors="surrogateescape")
 
 
 NO_NEWLINE_MARKER = "\\"

--- a/pr_split/plan_store.py
+++ b/pr_split/plan_store.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 from loguru import logger
@@ -12,7 +13,11 @@ def save_plan(plan_file: PlanFile) -> None:
     path = Path(PLAN_DIR)
     path.mkdir(parents=True, exist_ok=True)
     plan_path = Path(PLAN_FILE)
-    plan_path.write_text(plan_file.model_dump_json(indent=2))
+    # The raw diff may carry surrogate-escaped bytes from non-UTF-8 files;
+    # json.dumps escapes those as \udcXX and loads them back losslessly,
+    # which pydantic's own JSON writer refuses to do.
+    payload = json.dumps(plan_file.model_dump(mode="json"), indent=2, ensure_ascii=True)
+    plan_path.write_text(payload, encoding="utf-8")
     logger.info(logs.SAVING_PLAN.format(path=plan_path))
 
 
@@ -20,7 +25,7 @@ def load_plan() -> PlanFile:
     plan_path = Path(PLAN_FILE)
     if not plan_path.exists():
         raise PRSplitError(ErrorMsg.NO_PLAN())
-    plan_file = PlanFile.model_validate_json(plan_path.read_text())
+    plan_file = PlanFile.model_validate(json.loads(plan_path.read_text(encoding="utf-8")))
     logger.info(logs.PLAN_LOADED.format(count=len(plan_file.plan.groups), path=plan_path))
     return plan_file
 

--- a/pr_split/planner/client.py
+++ b/pr_split/planner/client.py
@@ -107,7 +107,18 @@ def _count_tokens_openai(texts: list[str], *, model: str) -> int:
     return sum(len(enc.encode(t)) for t in texts)
 
 
+def _utf8_safe(text: str) -> str:
+    """Replace surrogate-escaped bytes so the text can be sent as JSON.
+
+    Diff text keeps undecodable bytes as surrogates so files round-trip on
+    disk; the HTTP clients encode request bodies as strict UTF-8, so the
+    prompt copy gets U+FFFD instead.
+    """
+    return text.encode("utf-8", errors="surrogateescape").decode("utf-8", errors="replace")
+
+
 def _count_tokens(system: str, user: str, *, settings: Settings) -> int:
+    system, user = _utf8_safe(system), _utf8_safe(user)
     match settings.provider:
         case Provider.ANTHROPIC:
             return _count_tokens_anthropic(system, user, settings=settings)
@@ -169,6 +180,7 @@ def _call_openai(system: str, user: str, *, settings: Settings) -> RawToolOutput
 
 
 def _call_llm(system: str, user: str, *, settings: Settings) -> RawToolOutput:
+    system, user = _utf8_safe(system), _utf8_safe(user)
     match settings.provider:
         case Provider.ANTHROPIC:
             return _call_anthropic(system, user, settings=settings)

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import threading
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -574,3 +575,27 @@ class TestTransitivePushFailureGating:
         with pytest.raises(PRSplitError):
             _push_and_create_prs(groups, records)
         assert mock_create.call_count == 0
+
+
+class TestWorktreeWritesPreserveCrlf:
+    @patch("pr_split.cli.commit_files_in_dir", return_value="sha1")
+    @patch("pr_split.cli.materialize_group_files", return_value={"c.txt": "a\r\nb\r\n"})
+    @patch("pr_split.cli.remove_worktree")
+    @patch("pr_split.cli.add_worktree")
+    def test_crlf_content_written_verbatim(
+        self,
+        mock_add: MagicMock,
+        mock_remove: MagicMock,
+        mock_mat: MagicMock,
+        mock_commit: MagicMock,
+    ) -> None:
+        written: dict[str, bytes] = {}
+
+        def capture(cwd: str, file_paths: list[str], message: str, **kwargs: object) -> str:
+            for file_path in file_paths:
+                written[file_path] = (Path(cwd) / file_path).read_bytes()
+            return "sha1"
+
+        mock_commit.side_effect = capture
+        _create_branches_and_commits([_group("pr-1", "t")], MagicMock(), "main", "sha", "ns")
+        assert written["c.txt"] == b"a\r\nb\r\n"

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -597,5 +597,10 @@ class TestWorktreeWritesPreserveCrlf:
             return "sha1"
 
         mock_commit.side_effect = capture
-        _create_branches_and_commits([_group("pr-1", "t")], MagicMock(), "main", "sha", "ns")
+        # On POSIX write_text only translates "\n" (a no-op), so also assert the
+        # newline="" argument that keeps CRLF intact on Windows.
+        with patch.object(Path, "write_text", autospec=True, side_effect=Path.write_text) as wt:
+            _create_branches_and_commits([_group("pr-1", "t")], MagicMock(), "main", "sha", "ns")
         assert written["c.txt"] == b"a\r\nb\r\n"
+        content_writes = [c for c in wt.call_args_list if c.args[1] == "a\r\nb\r\n"]
+        assert content_writes and all(c.kwargs.get("newline") == "" for c in content_writes)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -986,3 +986,24 @@ class TestPlanSplitWithLlm:
         result = _plan_split_with_llm(parsed, settings)
         assert len(result) == 1
         mock_chunked.assert_called_once()
+
+
+class TestSurrogateSafePrompts:
+    @patch("pr_split.planner.client._call_anthropic")
+    def test_call_llm_replaces_surrogates_before_the_request(self, mock_call: MagicMock) -> None:
+        from pr_split.planner.client import _call_llm
+
+        user = b"diff caf\xe9".decode("utf-8", errors="surrogateescape")
+        _call_llm("sys", user, settings=_make_settings())
+        sent_user = mock_call.call_args.args[1]
+        assert "\udce9" not in sent_user
+        assert sent_user == "diff caf\ufffd"
+        sent_user.encode("utf-8")  # must be JSON-serialisable
+
+    @patch("pr_split.planner.client._count_tokens_anthropic", return_value=3)
+    def test_count_tokens_replaces_surrogates(self, mock_count: MagicMock) -> None:
+        from pr_split.planner.client import _count_tokens
+
+        user = b"caf\xe9".decode("utf-8", errors="surrogateescape")
+        assert _count_tokens("sys", user, settings=_make_settings()) == 3
+        mock_count.call_args.args[1].encode("utf-8")

--- a/tests/test_diff_parser_extended.py
+++ b/tests/test_diff_parser_extended.py
@@ -7,7 +7,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from pr_split.diff_ops.parser import extract_diff, parse_diff, unquote_git_path
+from pr_split.diff_ops.parser import (
+    _normalize_quoted_headers,
+    extract_diff,
+    parse_diff,
+    unquote_git_path,
+)
 from pr_split.exceptions import GitOperationError
 
 SAMPLE_DIFF = (
@@ -251,3 +256,102 @@ class TestUnquoteGitPath:
 
         assert sorted(pf.path for pf in parsed.patch_set) == sorted(names)
         assert all(pf.is_added_file for pf in parsed.patch_set)
+
+
+class TestQuotedPathsWithSpaces:
+    def test_header_spaces_are_escaped_but_hunk_content_is_not(self) -> None:
+        raw = (
+            'diff --git "a/my \\"notes\\".md" "b/my \\"notes\\".md"\n'
+            "index 1..2 100644\n"
+            '--- "a/my \\"notes\\".md"\t\n'
+            '+++ "b/my \\"notes\\".md"\t\n'
+            "@@ -1 +1 @@\n"
+            '-a "quoted line" here\n'
+            '+--- "not a header" line\n'
+        )
+        normalized = _normalize_quoted_headers(raw)
+        assert normalized.splitlines()[0] == (
+            'diff --git "a/my\\040\\"notes\\".md" "b/my\\040\\"notes\\".md"'
+        )
+        assert normalized.splitlines()[2] == '--- "a/my\\040\\"notes\\".md"\t'
+        assert normalized.splitlines()[5:] == raw.splitlines()[5:]
+
+    def test_diff_without_quotes_is_returned_unchanged(self) -> None:
+        raw = (
+            "diff --git a/plain name.md b/plain name.md\n"
+            "--- a/plain name.md\n"
+            "+++ b/plain name.md\n"
+        )
+        assert _normalize_quoted_headers(raw) is raw
+
+    def test_modified_quoted_path_with_space_parses_to_one_file(self) -> None:
+        raw = (
+            'diff --git "a/my \\"notes\\".md" "b/my \\"notes\\".md"\n'
+            "index 1..2 100644\n"
+            '--- "a/my \\"notes\\".md"\n'
+            '+++ "b/my \\"notes\\".md"\n'
+            "@@ -1 +1 @@\n"
+            "-a\n"
+            "+b\n"
+        )
+        parsed = parse_diff(raw)
+        assert [(pf.path, len(pf)) for pf in parsed.patch_set] == [('my "notes".md', 1)]
+        assert parsed.stats["total_files"] == 1
+
+    def test_added_and_deleted_quoted_paths_with_spaces_parse(self) -> None:
+        raw = (
+            'diff --git "a/new \\"file\\".txt" "b/new \\"file\\".txt"\n'
+            "new file mode 100644\n"
+            "--- /dev/null\n"
+            '+++ "b/new \\"file\\".txt"\n'
+            "@@ -0,0 +1 @@\n"
+            "+x\n"
+            'diff --git "a/old \\"file\\".txt" "b/old \\"file\\".txt"\n'
+            "deleted file mode 100644\n"
+            '--- "a/old \\"file\\".txt"\n'
+            "+++ /dev/null\n"
+            "@@ -1 +0,0 @@\n"
+            "-y\n"
+        )
+        parsed = parse_diff(raw)
+        assert [pf.path for pf in parsed.patch_set] == ['new "file".txt', 'old "file".txt']
+        assert parsed.patch_set[0].is_added_file
+        assert parsed.patch_set[1].is_removed_file
+
+    def test_real_git_diff_with_quoted_spaced_paths(self, tmp_path: Path) -> None:
+        def git(*args: str) -> str:
+            return subprocess.run(
+                ["git", "-c", "user.name=t", "-c", "user.email=t@x", *args],
+                cwd=tmp_path,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout
+
+        git("init", "-q", "-b", "main")
+        modified = 'my "notes".md'
+        deleted = 'old "file".txt'
+        (tmp_path / modified).write_text("a\n", encoding="utf-8")
+        (tmp_path / deleted).write_text("y\n", encoding="utf-8")
+        (tmp_path / "plain name.md").write_text("p\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-qm", "base")
+        git("checkout", "-qb", "dev")
+        (tmp_path / modified).write_text("b\n", encoding="utf-8")
+        (tmp_path / deleted).unlink()
+        (tmp_path / "plain name.md").write_text("q\n", encoding="utf-8")
+        (tmp_path / 'new "file".txt').write_text("x\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-qm", "dev")
+
+        cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            parsed = parse_diff(extract_diff("dev", "main"))
+        finally:
+            os.chdir(cwd)
+
+        assert sorted((pf.path, len(pf)) for pf in parsed.patch_set) == sorted(
+            [(modified, 1), (deleted, 1), ("plain name.md", 1), ('new "file".txt', 1)]
+        )
+        assert parsed.stats["total_files"] == 4

--- a/tests/test_diff_parser_extended.py
+++ b/tests/test_diff_parser_extended.py
@@ -97,7 +97,7 @@ class TestExtractDiffSubprocess:
     @patch("pr_split.diff_ops.parser.subprocess.run")
     def test_extract_diff_success(self, mock_run: MagicMock) -> None:
         mock_run.return_value = subprocess.CompletedProcess(
-            args=["git", "diff"], returncode=0, stdout=EXTRACT_DIFF_SAMPLE, stderr=""
+            args=["git", "diff"], returncode=0, stdout=EXTRACT_DIFF_SAMPLE.encode(), stderr=b""
         )
         result = extract_diff("feature", "main")
         assert result == EXTRACT_DIFF_SAMPLE
@@ -115,7 +115,6 @@ class TestExtractDiffSubprocess:
                 "main...feature",
             ],
             capture_output=True,
-            text=True,
         )
 
     @patch("pr_split.diff_ops.parser.subprocess.run")
@@ -123,8 +122,8 @@ class TestExtractDiffSubprocess:
         mock_run.return_value = subprocess.CompletedProcess(
             args=["git", "diff"],
             returncode=1,
-            stdout="",
-            stderr="fatal: bad revision",
+            stdout=b"",
+            stderr=b"fatal: bad revision",
         )
         with pytest.raises(GitOperationError, match="bad revision"):
             extract_diff("bad-branch", "main")
@@ -134,3 +133,16 @@ class TestRawDiffPreserved:
     def test_raw_diff_preserved(self) -> None:
         parsed = parse_diff(EXTRACT_DIFF_SAMPLE)
         assert parsed.raw_diff == EXTRACT_DIFF_SAMPLE
+
+
+class TestExtractDiffPreservesCarriageReturns:
+    @patch("pr_split.diff_ops.parser.subprocess.run")
+    def test_crlf_diff_is_returned_verbatim(self, mock_run: MagicMock) -> None:
+        raw = b"--- a/c.txt\n+++ b/c.txt\n@@ -1 +1 @@\n-old\r\n+new\r\n"
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["git", "diff"], returncode=0, stdout=raw, stderr=b""
+        )
+        result = extract_diff("feature", "main")
+        assert "\r\n" in result
+        assert result == raw.decode()
+        assert mock_run.call_args.kwargs.get("text") is not True

--- a/tests/test_diff_parser_extended.py
+++ b/tests/test_diff_parser_extended.py
@@ -355,3 +355,58 @@ class TestQuotedPathsWithSpaces:
             [(modified, 1), (deleted, 1), ("plain name.md", 1), ('new "file".txt', 1)]
         )
         assert parsed.stats["total_files"] == 4
+
+
+class TestNonUtf8FileContent:
+    def test_latin1_file_round_trips_byte_for_byte(self, tmp_path: Path) -> None:
+        from pr_split.constants import AssignmentType
+        from pr_split.diff_ops.reconstructor import materialize_group_files
+        from pr_split.git_ops.branches import merge_base
+        from pr_split.schemas import Group, GroupAssignment
+
+        def git(*args: str) -> str:
+            return subprocess.run(
+                ["git", "-c", "user.name=t", "-c", "user.email=t@x", *args],
+                cwd=tmp_path,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout
+
+        git("init", "-q", "-b", "main")
+        base_bytes = "caf\xe9 one\nkeep\n".encode("latin-1")
+        dev_bytes = "caf\xe9 two\nkeep\n".encode("latin-1")
+        (tmp_path / "legacy.txt").write_bytes(base_bytes)
+        git("add", "-A")
+        git("commit", "-qm", "base")
+        git("checkout", "-qb", "dev")
+        (tmp_path / "legacy.txt").write_bytes(dev_bytes)
+        git("add", "-A")
+        git("commit", "-qm", "dev")
+
+        cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            parsed = parse_diff(extract_diff("dev", "main"))
+            group = Group(
+                id="pr-1",
+                title="t",
+                description="d",
+                assignments=[
+                    GroupAssignment(
+                        file_path="legacy.txt",
+                        assignment_type=AssignmentType.WHOLE_FILE,
+                        hunk_indices=[0],
+                    )
+                ],
+            )
+            materialized = materialize_group_files(parsed, group, merge_base("main", "dev"))
+            out = tmp_path / "out.txt"
+            content = materialized["legacy.txt"]
+            assert content is not None
+            out.write_text(content, encoding="utf-8", errors="surrogateescape", newline="")
+        finally:
+            os.chdir(cwd)
+
+        assert [pf.path for pf in parsed.patch_set] == ["legacy.txt"]
+        assert out.read_bytes() == dev_bytes

--- a/tests/test_diff_parser_extended.py
+++ b/tests/test_diff_parser_extended.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from pr_split.diff_ops.parser import extract_diff, parse_diff
+from pr_split.diff_ops.parser import extract_diff, parse_diff, unquote_git_path
 from pr_split.exceptions import GitOperationError
 
 SAMPLE_DIFF = (
@@ -181,3 +181,73 @@ class TestNonAsciiPaths:
             os.chdir(cwd)
 
         assert sorted(pf.path for pf in parsed.patch_set) == ["new file ü.txt", "ünï.txt"]
+
+
+class TestUnquoteGitPath:
+    @pytest.mark.parametrize(
+        ("quoted", "expected"),
+        [
+            ("plain/path.py", "plain/path.py"),
+            ('"a/we\\"ird.py"', 'a/we"ird.py'),
+            ('"b/tab\\tname.py"', "b/tab\tname.py"),
+            ('"b/back\\\\slash.py"', "b/back\\slash.py"),
+            ('"b/caf\\303\\251.txt"', "b/café.txt"),
+            ('"b/bell\\a\\1.txt"', "b/bell\a\x01.txt"),
+            ('""', ""),
+            ('"', '"'),
+        ],
+    )
+    def test_decodes_c_style_quoting(self, quoted: str, expected: str) -> None:
+        assert unquote_git_path(quoted) == expected
+
+    def test_quoted_headers_are_unquoted_after_parse(self) -> None:
+        raw = (
+            'diff --git "a/we\\"ird.py" "b/we\\"ird.py"\n'
+            "new file mode 100644\n"
+            "--- /dev/null\n"
+            '+++ "b/we\\"ird.py"\n'
+            "@@ -0,0 +1 @@\n"
+            "+x\n"
+            'diff --git "a/tab\\tname.py" "b/tab\\tname.py"\n'
+            "deleted file mode 100644\n"
+            '--- "a/tab\\tname.py"\n'
+            "+++ /dev/null\n"
+            "@@ -1 +0,0 @@\n"
+            "-y\n"
+        )
+        parsed = parse_diff(raw)
+        assert [pf.path for pf in parsed.patch_set] == ['we"ird.py', "tab\tname.py"]
+        assert parsed.patch_set[0].source_file == "/dev/null"
+        assert parsed.patch_set[1].target_file == "/dev/null"
+        assert parsed.patch_set[1].is_removed_file
+
+    def test_special_paths_survive_real_git_diff(self, tmp_path: Path) -> None:
+        def git(*args: str) -> str:
+            return subprocess.run(
+                ["git", "-c", "user.name=t", "-c", "user.email=t@x", *args],
+                cwd=tmp_path,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout
+
+        git("init", "-q", "-b", "main")
+        (tmp_path / "keep.txt").write_text("one\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-qm", "base")
+        git("checkout", "-qb", "dev")
+        names = ['we"ird.py', "tab\tname.py", "back\\slash.py"]
+        for name in names:
+            (tmp_path / name).write_text("x\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-qm", "dev")
+
+        cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            parsed = parse_diff(extract_diff("dev", "main"))
+        finally:
+            os.chdir(cwd)
+
+        assert sorted(pf.path for pf in parsed.patch_set) == sorted(names)
+        assert all(pf.is_added_file for pf in parsed.patch_set)

--- a/tests/test_diff_parser_extended.py
+++ b/tests/test_diff_parser_extended.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 import subprocess
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -104,6 +106,8 @@ class TestExtractDiffSubprocess:
         mock_run.assert_called_once_with(
             [
                 "git",
+                "-c",
+                "core.quotePath=false",
                 "diff",
                 "--no-color",
                 "--no-ext-diff",
@@ -146,3 +150,34 @@ class TestExtractDiffPreservesCarriageReturns:
         assert "\r\n" in result
         assert result == raw.decode()
         assert mock_run.call_args.kwargs.get("text") is not True
+
+
+class TestNonAsciiPaths:
+    def test_unicode_paths_survive_extraction_and_parsing(self, tmp_path: Path) -> None:
+        def git(*args: str) -> str:
+            return subprocess.run(
+                ["git", "-c", "user.name=t", "-c", "user.email=t@x", *args],
+                cwd=tmp_path,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout
+
+        git("init", "-q", "-b", "main")
+        (tmp_path / "ünï.txt").write_text("one\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-qm", "base")
+        git("checkout", "-qb", "dev")
+        (tmp_path / "ünï.txt").write_text("two\n", encoding="utf-8")
+        (tmp_path / "new file ü.txt").write_text("x\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-qm", "dev")
+
+        cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            parsed = parse_diff(extract_diff("dev", "main"))
+        finally:
+            os.chdir(cwd)
+
+        assert sorted(pf.path for pf in parsed.patch_set) == ["new file ü.txt", "ünï.txt"]

--- a/tests/test_plan_store.py
+++ b/tests/test_plan_store.py
@@ -106,3 +106,32 @@ class TestPlanStoreJson:
         assert raw["plan"]["priority"] == "logical"
         assert raw["plan"]["min_loc"] == 25
         assert raw["plan"]["strict_loc_bounds"] is True
+
+
+class TestPlanStoreSurrogates:
+    def test_raw_diff_with_undecodable_bytes_round_trips(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pr_split.constants import Priority
+        from pr_split.plan_store import load_plan, save_plan
+        from pr_split.schemas import PlanFile, SplitPlan
+
+        monkeypatch.chdir(tmp_path)
+        raw = b"--- a/x\n+++ b/x\n@@ -1 +1 @@\n-caf\xe9\n+caf\xe9!\n".decode(
+            "utf-8", errors="surrogateescape"
+        )
+        plan = SplitPlan(
+            dev_branch="dev",
+            base_branch="main",
+            max_loc=400,
+            priority=Priority.ORTHOGONAL,
+            raw_diff=raw,
+        )
+        save_plan(PlanFile(plan=plan))
+
+        loaded = load_plan()
+
+        assert loaded.plan.raw_diff == raw
+        assert loaded.plan.raw_diff.encode("utf-8", errors="surrogateescape").endswith(
+            b"+caf\xe9!\n"
+        )

--- a/tests/test_reconstructor.py
+++ b/tests/test_reconstructor.py
@@ -115,13 +115,13 @@ class TestApplyHunks:
 class TestGetBaseFileContent:
     @patch("pr_split.diff_ops.reconstructor.subprocess.run")
     def test_success(self, mock_run: MagicMock) -> None:
-        mock_run.return_value = MagicMock(returncode=0, stdout="file content\n", stderr="")
+        mock_run.return_value = MagicMock(returncode=0, stdout=b"file content\n", stderr=b"")
         result = _get_base_file_content("foo.py", "abc123")
         assert result == "file content\n"
 
     @patch("pr_split.diff_ops.reconstructor.subprocess.run")
     def test_failure_raises(self, mock_run: MagicMock) -> None:
-        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="not found")
+        mock_run.return_value = MagicMock(returncode=1, stdout=b"", stderr=b"not found")
         with pytest.raises(GitOperationError):
             _get_base_file_content("missing.py", "abc123")
 
@@ -183,7 +183,7 @@ class TestMaterializeGroupFilesNewFile:
 class TestGetBaseFileContentExtended:
     @patch("pr_split.diff_ops.reconstructor.subprocess.run")
     def test_empty_file_returns_empty(self, mock_run: MagicMock) -> None:
-        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        mock_run.return_value = MagicMock(returncode=0, stdout=b"", stderr=b"")
         result = _get_base_file_content("empty.py", "abc123")
         assert result == ""
 
@@ -479,3 +479,59 @@ class TestApplyHunksWithSplitlinesSeparators:
         diff = "--- a/f.txt\n+++ b/f.txt\n@@ -7,5 +7,5 @@\n h\n i\n j\n-k\n+K\n l\n"
         pf = PatchSet(diff)[0]
         assert apply_hunks(base, pf, [0]) == dev
+
+
+class TestCrlfPreserved:
+    @patch("pr_split.diff_ops.reconstructor.subprocess.run")
+    def test_base_content_keeps_crlf(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(returncode=0, stdout=b"a\r\nb\r\n", stderr=b"")
+        assert _get_base_file_content("c.txt", "main") == "a\r\nb\r\n"
+
+    @patch("pr_split.diff_ops.reconstructor.subprocess.run")
+    def test_partial_change_to_crlf_file_keeps_endings(self, mock_run: MagicMock) -> None:
+        base = "".join(f"line{i}\r\n" for i in range(1, 8))
+        mock_run.return_value = MagicMock(returncode=0, stdout=base.encode(), stderr=b"")
+        diff = (
+            "diff --git a/c.txt b/c.txt\n--- a/c.txt\n+++ b/c.txt\n"
+            "@@ -1,6 +1,6 @@\n line1\r\n line2\r\n-line3\r\n+LINE3\r\n"
+            " line4\r\n line5\r\n line6\r\n"
+        )
+        parsed = parse_diff(diff)
+        group = Group(
+            id="pr-1",
+            title="t",
+            description="d",
+            assignments=[
+                GroupAssignment(
+                    file_path="c.txt",
+                    assignment_type=AssignmentType.WHOLE_FILE,
+                    hunk_indices=[0],
+                )
+            ],
+        )
+        result = materialize_group_files(parsed, group, "main")
+        assert result["c.txt"] == base.replace("line3\r\n", "LINE3\r\n")
+
+    @patch("pr_split.diff_ops.reconstructor.subprocess.run")
+    def test_bare_carriage_return_does_not_shift_hunks(self, mock_run: MagicMock) -> None:
+        # A lone CR is not a line break for git; with base content no longer
+        # newline-translated, splitting on it would misplace every later hunk.
+        mock_run.return_value = MagicMock(returncode=0, stdout=b"x\ry\nz\n", stderr=b"")
+        diff = (
+            "diff --git a/c.txt b/c.txt\n--- a/c.txt\n+++ b/c.txt\n"
+            "@@ -1,2 +1,2 @@\n x\ry\n-z\n+Z\n"
+        )
+        parsed = parse_diff(diff)
+        group = Group(
+            id="pr-1",
+            title="t",
+            description="d",
+            assignments=[
+                GroupAssignment(
+                    file_path="c.txt",
+                    assignment_type=AssignmentType.WHOLE_FILE,
+                    hunk_indices=[0],
+                )
+            ],
+        )
+        assert materialize_group_files(parsed, group, "main")["c.txt"] == "x\ry\nZ\n"


### PR DESCRIPTION
## Summary

Git diffs any NUL-free file as text, so a latin-1 `.txt` / `.properties` / legacy source reached `extract_diff` and `_get_base_file_content`, whose strict `.decode("utf-8")` raised an uncaught `UnicodeDecodeError` — a raw traceback from `pr-split split`.

The fix keeps such files' bytes intact end to end:

- `extract_diff` / `_get_base_file_content` decode with `errors="surrogateescape"`, and the worker writes files back with the same handler, so the materialised sub-PR file is byte-identical to the dev blob
- the prompt text handed to the Anthropic/OpenAI SDKs goes through `_utf8_safe` at the single choke point (`_count_tokens` / `_call_llm`), replacing undecodable bytes with U+FFFD so the JSON request bodies stay valid
- `save_plan` writes `json.dumps(..., ensure_ascii=True)` (which escapes lone surrogates as `\udcXX`) and `load_plan` reads via `json.loads`, so `--dry-run` → `execute` round-trips `raw_diff` losslessly

Stacked on #113 (top of stack #81, where the bytes-based capture from #70 lives).

## Test plan

- latin-1 file: extract → parse → materialize → write is byte-equal to the dev blob; `_call_llm`/`_count_tokens` receive replaced text; plan save/load round-trips a surrogate-bearing `raw_diff` — all four fail on the base
- Review verified request bodies for both providers decode as strict UTF-8 and that non-ASCII UTF-8 plans still read back unchanged
- 483 tests pass, ruff clean
- Local review: 5/5 (after one fix→re-review round)
