### PR TITLE
fix: scale the DP chunker's same-file boundary penalty with the token budget

### DIFF
--- a/pr_split/planner/chunker.py
+++ b/pr_split/planner/chunker.py
@@ -62,13 +62,23 @@ def _chunk_slack_penalty(used_tokens: int, token_budget: int) -> float:
     return (slack * slack) / max(1, token_budget)
 
 
-def _chunk_boundary_penalty(hunk_sequence: list[HunkRef], boundary_index: int) -> float:
+def _same_file_boundary_penalty(token_budget: int) -> float:
+    # The slack penalty can reach token_budget per chunk, so a fixed penalty
+    # is dwarfed at real budgets (hundreds of thousands of tokens) and the
+    # DP happily cuts a file in half to balance chunk sizes. Make cutting a
+    # file always cost more than any slack it could save.
+    return max(_DP_SAME_FILE_BOUNDARY_PENALTY, 2.0 * token_budget)
+
+
+def _chunk_boundary_penalty(
+    hunk_sequence: list[HunkRef], boundary_index: int, token_budget: int
+) -> float:
     if boundary_index >= len(hunk_sequence) - 1:
         return 0.0
     left = hunk_sequence[boundary_index]
     right = hunk_sequence[boundary_index + 1]
     if left.file_path == right.file_path:
-        return _DP_SAME_FILE_BOUNDARY_PENALTY
+        return _same_file_boundary_penalty(token_budget)
     return 0.0
 
 
@@ -109,7 +119,7 @@ def chunk_hunks_dynamic_programming(
                 _DP_CHUNK_BASE_COST
                 + _chunk_slack_penalty(used_tokens, token_budget)
                 + file_mix_penalty
-                + _chunk_boundary_penalty(hunk_sequence, end - 1)
+                + _chunk_boundary_penalty(hunk_sequence, end - 1, token_budget)
             )
             candidate_cost = best_cost[start - 1] + chunk_cost
             if candidate_cost < best_cost[end]:

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -161,6 +161,29 @@ class TestChunkHunksDynamicProgramming:
         assert [ref.file_path for ref in chunks[0]] == ["a.py"]
         assert [ref.file_path for ref in chunks[1]] == ["b.py", "b.py"]
 
+    def test_large_budget_still_keeps_files_whole_when_possible(self) -> None:
+        # At a realistic budget the slack term is hundreds of thousands of
+        # tokens; a fixed same-file penalty used to lose to it and b.py was
+        # cut in half although a two-chunk plan without any cut exists.
+        budget = 538_000
+        refs = [HunkRef("a.py", 0, 10_000)]
+        refs += [HunkRef("b.py", i, 50_000) for i in range(10)]
+        refs += [HunkRef("c.py", i, 50_000) for i in range(2)]
+        chunks = chunk_hunks_dynamic_programming(refs, budget)
+        assert len(chunks) == 2
+        for chunk in chunks:
+            assert sum(r.token_estimate for r in chunk) <= budget
+        # no file appears in more than one chunk
+        seen: dict[str, int] = {}
+        for idx, chunk in enumerate(chunks):
+            for ref in chunk:
+                assert seen.setdefault(ref.file_path, idx) == idx
+
+    def test_file_is_still_cut_when_it_cannot_fit_one_chunk(self) -> None:
+        refs = [HunkRef("big.py", i, 60) for i in range(3)]
+        chunks = chunk_hunks_dynamic_programming(refs, 100)
+        assert [len(c) for c in chunks] == [1, 1, 1]
+
     def test_greedy_helper_retains_previous_behavior(self) -> None:
         refs = [
             HunkRef("a.py", 0, 30),

--- a/tests/test_chunker_exhaustive.py
+++ b/tests/test_chunker_exhaustive.py
@@ -25,7 +25,7 @@ def _chunk_plan_cost(
             100.0
             + _chunk_slack_penalty(used_tokens, token_budget)
             + file_mix_penalty
-            + _chunk_boundary_penalty(hunk_sequence, end_index - 1)
+            + _chunk_boundary_penalty(hunk_sequence, end_index - 1, token_budget)
         )
     return cost
 


### PR DESCRIPTION
## Summary

The DP chunker charged a fixed 10 000 for cutting between two hunks of the same file, while its slack term is bounded by `token_budget`. At the real budget (≈538 000 tokens) the slack term dwarfs the boundary penalty, so the DP cut a file in half to balance chunk sizes even when a chunking with the same number of chunks and no mid-file cut existed (greedy found it): with `a.py` 10k, `b.py` 10×50k, `c.py` 2×50k the DP produced `[a, b×6] [b×4, c, c]`.

The same-file penalty now scales as `max(10 000, 2 × token_budget)`, so cutting a file always costs more than any slack it could save; a file that cannot fit one chunk is still cut. The brute-force oracle test was updated to the new signature (same cost model as the DP).

## Test plan

- `test_large_budget_still_keeps_files_whole_when_possible` (fails on main: `b.py` split) and `test_file_is_still_cut_when_it_cannot_fit_one_chunk`
- Review searched 6 000 adversarial and 20 000 random instances: max slack saving per same-file cut ≈ 1.5 × budget (< 2 ×), and the DP never cut a file when a no-cut plan with the same or fewer chunks existed
- 446 tests pass (including the exhaustive oracle), ruff clean
- Local review: 5/5
