### PR TITLE
fix: keep PR bodies under GitHub's 65,536-character limit

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -343,6 +343,18 @@ _gh_semaphore = Semaphore(_GH_API_CONCURRENCY)
 
 
 _PR_TEMPLATE_PATH = Path(PLAN_DIR) / "template.md"
+# GitHub rejects PR bodies over 65 536 characters; a group holding thousands
+# of files (mass rename, formatter run) blows past that with its file list
+# alone, and the failure only surfaced after every branch had been pushed.
+_PR_BODY_FILE_LIST_LIMIT = 200
+
+
+def _format_file_list(files: list[str]) -> str:
+    shown = files[:_PR_BODY_FILE_LIST_LIMIT]
+    lines = [f"- `{f}`" for f in shown]
+    if len(files) > len(shown):
+        lines.append(f"- … and {len(files) - len(shown)} more files")
+    return "\n".join(lines)
 
 
 def _build_pr_body(group: Group, all_groups: list[Group]) -> str:
@@ -350,7 +362,7 @@ def _build_pr_body(group: Group, all_groups: list[Group]) -> str:
         files = [a.file_path for a in group.assignments]
         template_vars = {
             "description": group.description,
-            "files": "\n".join(f"- `{f}`" for f in files),
+            "files": _format_file_list(files),
             "added": group.estimated_added,
             "removed": group.estimated_removed,
             "loc": group.estimated_loc,
@@ -377,8 +389,7 @@ def _build_pr_body(group: Group, all_groups: list[Group]) -> str:
     files = [a.file_path for a in group.assignments]
     sections = [group.description]
     if files:
-        file_list = "\n".join(f"- `{f}`" for f in files)
-        sections.append(f"## Files changed\n\n{file_list}")
+        sections.append(f"## Files changed\n\n{_format_file_list(files)}")
     sections.append(
         f"## Diff stats\n\n"
         f"**+{group.estimated_added}** additions, "

--- a/pr_split/git_ops/prs.py
+++ b/pr_split/git_ops/prs.py
@@ -22,6 +22,30 @@ def _run_gh(*args: str) -> str:
     return result.stdout.strip()
 
 
+PR_BODY_MAX_CHARS = 65_536
+_PR_BODY_TRUNCATION_NOTE = "\n\n_(body truncated: GitHub's limit is 65,536 characters)_"
+
+
+def _truncate_pr_body(body: str) -> str:
+    """Keep the body under GitHub's hard limit so PR creation cannot fail on it.
+
+    The cut lands on a line boundary and closes an open code fence (the
+    dependency graph is the last section of every generated body), so the
+    truncation note renders as a note rather than as code text.
+    """
+    if len(body) <= PR_BODY_MAX_CHARS:
+        return body
+    fence_close = "\n```"
+    keep = PR_BODY_MAX_CHARS - len(_PR_BODY_TRUNCATION_NOTE) - len(fence_close)
+    cut = body[:keep]
+    newline = cut.rfind("\n")
+    if newline > 0:
+        cut = cut[:newline]
+    if cut.count("```") % 2 == 1:
+        cut += fence_close
+    return cut + _PR_BODY_TRUNCATION_NOTE
+
+
 def check_gh_auth() -> bool:
     try:
         _run_gh("auth", "status")
@@ -33,6 +57,7 @@ def check_gh_auth() -> bool:
 def create_pr(
     head: str, base: str, title: str, body: str, *, draft: bool = False
 ) -> tuple[int, str]:
+    body = _truncate_pr_body(body)
     args = [
         "pr",
         "create",

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -537,3 +537,23 @@ class TestStatusCommand:
     def test_clean_no_plan(self, mock_pe: MagicMock) -> None:
         result = runner.invoke(app, ["clean"])
         assert result.exit_code == 0
+
+
+class TestPrBodyFileListCap:
+    def test_long_file_lists_are_summarised(self) -> None:
+        from pr_split.cli import _PR_BODY_FILE_LIST_LIMIT, _build_pr_body
+
+        n = 2000
+        g = _group("pr-1", "mass rename", files=[f"pkg/mod_{i}/handler.py" for i in range(n)])
+        body = _build_pr_body(g, [g])
+        assert body.count("- `pkg/") == _PR_BODY_FILE_LIST_LIMIT
+        assert f"… and {n - _PR_BODY_FILE_LIST_LIMIT} more files" in body
+        assert len(body) < 65_536
+
+    def test_short_file_lists_are_complete(self) -> None:
+        from pr_split.cli import _build_pr_body
+
+        g = _group("pr-1", "t", files=["a.py", "b.py"])
+        body = _build_pr_body(g, [g])
+        assert "- `a.py`\n- `b.py`" in body
+        assert "more files" not in body

--- a/tests/test_git_prs.py
+++ b/tests/test_git_prs.py
@@ -149,3 +149,44 @@ class TestCreatePrDraft:
         mock_gh.return_value = "https://github.com/org/repo/pull/7"
         create_pr("head", "main", "Title", "Body")
         assert "--draft" not in mock_gh.call_args.args
+
+
+class TestCreatePrBodyLimit:
+    @patch("pr_split.git_ops.prs._run_gh", return_value="https://github.com/o/r/pull/9")
+    def test_oversized_body_is_truncated_below_the_limit(self, mock_gh: MagicMock) -> None:
+        from pr_split.git_ops.prs import PR_BODY_MAX_CHARS
+
+        create_pr(head="h", base="b", title="t", body="x" * 100_000)
+        args = mock_gh.call_args[0]
+        sent = args[args.index("--body") + 1]
+        assert len(sent) <= PR_BODY_MAX_CHARS
+        assert sent.endswith("_(body truncated: GitHub's limit is 65,536 characters)_")
+
+    @patch("pr_split.git_ops.prs._run_gh", return_value="https://github.com/o/r/pull/9")
+    def test_truncation_closes_an_open_code_fence_on_a_line_boundary(
+        self, mock_gh: MagicMock
+    ) -> None:
+        from pr_split.git_ops.prs import PR_BODY_MAX_CHARS
+
+        lines = "\n".join(f"pr-{i}: group {i}" for i in range(6000))
+        body = f"intro\n\n```\n{lines}\n```"
+        create_pr(head="h", base="b", title="t", body=body)
+        args = mock_gh.call_args[0]
+        sent = args[args.index("--body") + 1]
+        assert len(sent) <= PR_BODY_MAX_CHARS
+        assert sent.count("```") % 2 == 0
+        assert sent.endswith("```\n\n_(body truncated: GitHub's limit is 65,536 characters)_")
+        # cut on a line boundary: the line before the closing fence is intact
+        before_close = sent.rsplit("\n```", 1)[0]
+        last_line = before_close.rsplit("\n", 1)[-1]
+        assert last_line.startswith("pr-")
+        assert (
+            last_line
+            == f"{last_line.split(':')[0]}: group {last_line.split('-')[1].split(':')[0]}"
+        )
+
+    @patch("pr_split.git_ops.prs._run_gh", return_value="https://github.com/o/r/pull/9")
+    def test_normal_body_is_sent_verbatim(self, mock_gh: MagicMock) -> None:
+        create_pr(head="h", base="b", title="t", body="hello")
+        args = mock_gh.call_args[0]
+        assert args[args.index("--body") + 1] == "hello"


### PR DESCRIPTION
## Summary

`_build_pr_body` listed every file in a group, and `create_pr` sent the body verbatim. A group holding thousands of files (mass rename, formatter run with `--max-loc` raised) produced a >100k-character body; GitHub rejects anything over 65 536 characters, and that failure only surfaced after every branch had already been pushed.

- `_format_file_list` (used by the default body and the `{files}` template placeholder) lists at most 200 files plus `… and N more files`
- `create_pr` truncates any body still over 65 536 characters: cut on a line boundary, close an open code fence (the dependency graph is always the last section), then append `_(body truncated: GitHub's limit is 65,536 characters)_`

## Test plan

- `TestPrBodyFileListCap` (2000 files → 200 listed, under the limit; short lists complete) and `TestCreatePrBodyLimit` (100k body truncated; open fence closed on a line boundary; normal body verbatim) — all fail on main
- Review probed a 3000-root DAG, a 900-deep chain, no-newline bodies, inline-only fences, CRLF, and the exact 65 536 boundary
- 449 tests pass, ruff clean
- Local review: 5/5 (after one fix→re-review round)
