### PR TITLE
fix: clean skips already merged or closed PRs and reports why a close failed

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -960,11 +960,21 @@ def status() -> None:
 def _cleanup_git_state(git_state: GitState) -> tuple[int, int]:
     closed_prs = 0
     for pr_record in git_state.prs:
+        # gh refuses to close a merged PR and silently succeeds on a closed
+        # one; neither needs a warning nor should count as newly closed, but
+        # both are "done" for the purpose of removing the plan.
+        state = str(get_pr_state(pr_record.pr_number).get("state") or "").upper()
+        if state in ("MERGED", "CLOSED"):
+            logger.info(
+                logs.PR_ALREADY_DONE.format(number=pr_record.pr_number, state=state.lower())
+            )
+            closed_prs += 1
+            continue
         try:
             close_pr(pr_record.pr_number)
             closed_prs += 1
-        except PRSplitError:
-            logger.warning(f"Could not close PR #{pr_record.pr_number}")
+        except PRSplitError as exc:
+            logger.warning(f"Could not close PR #{pr_record.pr_number}: {exc}")
 
     logger.info(logs.CLEANING_BRANCHES)
     deleted_branches = 0

--- a/pr_split/logs.py
+++ b/pr_split/logs.py
@@ -19,6 +19,7 @@ PLAN_LOADED = "Loaded plan with {count} groups from {path}"
 CLEANING_BRANCHES = "Cleaning up pr-split branches"
 BRANCH_DELETED = "Deleted branch {branch}"
 PR_CLOSED = "Closed PR #{number}"
+PR_ALREADY_DONE = "PR #{number} is already {state}, nothing to close"
 CLEAN_COMPLETE = "Cleanup complete: {branches} branches, {prs} PRs"
 CLEAN_INCOMPLETE = (
     "Some PRs or branches could not be cleaned up; the plan file was kept"

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -122,6 +122,7 @@ class TestBuildPrBody:
 
 
 class TestCleanupGitState:
+    @patch("pr_split.cli.get_pr_state", return_value={"state": "OPEN"})
     @patch("pr_split.cli.shutil.rmtree")
     @patch("pr_split.cli.Path")
     @patch("pr_split.cli.delete_branch")
@@ -132,6 +133,7 @@ class TestCleanupGitState:
         mock_delete: MagicMock,
         mock_path: MagicMock,
         mock_rmtree: MagicMock,
+        mock_state: MagicMock,
     ) -> None:
         mock_path.return_value.exists.return_value = True
         git_state = GitState(
@@ -152,6 +154,7 @@ class TestCleanupGitState:
         mock_delete.assert_any_call("pr-split/ns/pr-1", remote=True)
         mock_delete.assert_any_call("pr-split/ns/pr-2", remote=True)
 
+    @patch("pr_split.cli.get_pr_state", return_value={"state": "OPEN"})
     @patch("pr_split.cli.shutil.rmtree")
     @patch("pr_split.cli.Path")
     @patch("pr_split.cli.delete_branch")
@@ -162,6 +165,7 @@ class TestCleanupGitState:
         mock_delete: MagicMock,
         mock_path: MagicMock,
         mock_rmtree: MagicMock,
+        mock_state: MagicMock,
     ) -> None:
         mock_path.return_value.exists.return_value = True
         mock_close.side_effect = [None, PRSplitError("fail")]
@@ -334,3 +338,63 @@ class TestSplitCliEnvVars:
         assert mock_validate_plan.call_args_list[0].kwargs["min_loc"] == 50
         assert mock_validate_plan.call_args_list[1].kwargs["min_loc"] == 50
         mock_save_plan.assert_not_called()
+
+
+class TestCleanupSkipsFinishedPrs:
+    @patch("pr_split.cli.get_pr_state")
+    @patch("pr_split.cli.shutil.rmtree")
+    @patch("pr_split.cli.Path")
+    @patch("pr_split.cli.delete_branch")
+    @patch("pr_split.cli.close_pr")
+    def test_merged_and_closed_prs_are_not_closed_again_but_count_as_done(
+        self,
+        mock_close: MagicMock,
+        mock_delete: MagicMock,
+        mock_path: MagicMock,
+        mock_rmtree: MagicMock,
+        mock_state: MagicMock,
+    ) -> None:
+        mock_path.return_value.exists.return_value = True
+        mock_state.side_effect = lambda n: {
+            7: {"state": "MERGED"},
+            8: {"state": "CLOSED"},
+            9: {"state": "OPEN"},
+        }[n]
+        git_state = GitState(
+            prs=[
+                PRRecord(group_id="pr-1", pr_number=7, pr_url="u"),
+                PRRecord(group_id="pr-2", pr_number=8, pr_url="u"),
+                PRRecord(group_id="pr-3", pr_number=9, pr_url="u"),
+            ]
+        )
+        with patch("pr_split.cli.logger") as mock_logger:
+            closed, deleted = _cleanup_git_state(git_state)
+
+        assert (closed, deleted) == (3, 0)
+        mock_close.assert_called_once_with(9)
+        mock_logger.warning.assert_not_called()
+        infos = " ".join(str(c.args[0]) for c in mock_logger.info.call_args_list)
+        assert "PR #7 is already merged" in infos
+        assert "PR #8 is already closed" in infos
+        mock_path.return_value.unlink.assert_called_once()
+
+    @patch("pr_split.cli.get_pr_state", return_value={"state": "OPEN"})
+    @patch("pr_split.cli.shutil.rmtree")
+    @patch("pr_split.cli.Path")
+    @patch("pr_split.cli.delete_branch")
+    @patch("pr_split.cli.close_pr", side_effect=GitOperationError("gh: rate limited"))
+    def test_close_failure_warning_includes_the_reason(
+        self,
+        mock_close: MagicMock,
+        mock_delete: MagicMock,
+        mock_path: MagicMock,
+        mock_rmtree: MagicMock,
+        mock_state: MagicMock,
+    ) -> None:
+        mock_path.return_value.exists.return_value = True
+        git_state = GitState(prs=[PRRecord(group_id="pr-1", pr_number=7, pr_url="u")])
+        with patch("pr_split.cli.logger") as mock_logger:
+            closed, _ = _cleanup_git_state(git_state)
+        assert closed == 0
+        assert "Could not close PR #7: gh: rate limited" in str(mock_logger.warning.call_args)
+        mock_path.return_value.unlink.assert_not_called()


### PR DESCRIPTION
## Summary

After `pr-split merge`, running `pr-split clean` warned `Could not close PR #N` for every merged PR — `gh pr close` refuses a merged PR — and dropped the reason; an already-closed PR (gh exits 0) was counted as newly closed. With #55's completeness check that also meant a fully merged split could never remove its plan file.

`_cleanup_git_state` now asks `get_pr_state` first: `MERGED`/`CLOSED` PRs log `PR #N is already merged, nothing to close`, are not closed again, and count as done; a real close failure logs `Could not close PR #N: <reason>`. An unknown state (fetch error) still attempts the close so the real error reaches the user.

Stacked on #55 (`fix/reliable-branch-cleanup`).

## Test plan

- `TestCleanupSkipsFinishedPrs`: merged + closed + open trio → only the open one is closed, no warnings, plan removed; a close failure keeps the plan and includes the reason — both fail on the base
- existing cleanup tests now stub `get_pr_state` as OPEN
- 450 tests pass, ruff clean
- Local review: 5/5

Noted by the review, not in this PR: after `merge --delete-branch` the *branch* half of #55's completeness check has the same "already gone" problem.
