### PR TITLE
fix: report a missing gh or git binary as a clean error instead of a FileNotFoundError traceback

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -59,7 +59,7 @@ from .git_ops import (
     push_branch,
     remove_worktree,
 )
-from .git_ops.branches import run_git
+from .git_ops.branches import require_tools, run_git
 from .git_ops.prs import close_pr, create_pr, get_pr_state, link_stack, merge_pr
 from .graph import PlanDAG
 from .plan_store import load_plan, plan_exists, save_plan
@@ -123,6 +123,13 @@ def _render_dag_markdown(groups: list[Group], current_id: str) -> str:
 
     tree_block = "\n".join(lines)
     return f"## Dependency graph\n\nMerge in this order:\n\n```\n{tree_block}\n```"
+
+
+def _require_cli_tools(*tools: str) -> None:
+    missing = require_tools(*tools)
+    if missing is not None:
+        console.print(f"[red]{ErrorMsg.TOOL_NOT_FOUND(tool=missing)}[/red]")
+        raise typer.Exit(1)
 
 
 def _validate_inputs(dev_branch: str, base: str, *, dry_run: bool = False) -> None:
@@ -725,7 +732,14 @@ def split(
     author: str | None = None
     fork_info: ForkPRInfo | None = None
 
+    # Say "git/gh is not installed" before any helper turns that into a
+    # misleading "branch not found" or "authentication failed".
+    _require_cli_tools("git", *(() if dry_run else ("gh",)))
+
     if not branch_exists(dev_branch):
+        # A PR number or user:branch has to be fetched with gh even for a
+        # dry run.
+        _require_cli_tools("gh")
         if not check_gh_auth():
             console.print(f"[red]{ErrorMsg.GH_AUTH_FAILED()}[/red]")
             raise typer.Exit(1)
@@ -750,6 +764,7 @@ def split(
             console.print(
                 "[red]Warning: this will permanently close PRs and delete remote branches.[/red]"
             )
+            _require_cleanup_tools(existing.git_state)
             if typer.confirm("Clean up and proceed with re-splitting?"):
                 closed_prs, deleted_branches = _cleanup_git_state(existing.git_state)
                 logger.success(
@@ -920,6 +935,14 @@ def status() -> None:
     console.print(table)
 
 
+def _require_cleanup_tools(git_state: GitState) -> None:
+    # Every close/delete failure inside _cleanup_git_state is swallowed as a
+    # warning, so a missing binary would otherwise look like a successful
+    # cleanup that then deletes the plan. Both callers (clean and the
+    # re-split prompt in split) go through here before asking to proceed.
+    _require_cli_tools("git", *(("gh",) if git_state.prs else ()))
+
+
 def _cleanup_git_state(git_state: GitState) -> tuple[int, int]:
     closed_prs = 0
     for pr_record in git_state.prs:
@@ -953,6 +976,8 @@ def clean() -> None:
 
     plan_file = load_plan()
     git_state = plan_file.git_state
+
+    _require_cleanup_tools(git_state)
 
     typer.confirm("Delete all pr-split branches and close PRs?", abort=True)
 
@@ -1010,6 +1035,7 @@ def execute(
         )
         raise typer.Exit(1)
 
+    _require_cli_tools("git", "gh")
     if not branch_exists(plan.base_branch):
         console.print(f"[red]{ErrorMsg.BRANCH_NOT_FOUND(branch=plan.base_branch)}[/red]")
         raise typer.Exit(1)
@@ -1133,6 +1159,10 @@ def merge_all(
     if not pr_map:
         console.print("[yellow]No PRs found in plan. Nothing to merge.[/yellow]")
         raise typer.Exit(0)
+
+    # Without gh every PR would be skipped as a "fetch error" and the run
+    # would still report success.
+    _require_cli_tools("gh")
 
     dag = PlanDAG(plan.groups)
     merged: list[str] = []

--- a/pr_split/diff_ops/parser.py
+++ b/pr_split/diff_ops/parser.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import subprocess
 from dataclasses import dataclass
 from functools import cached_property
 
@@ -8,20 +7,14 @@ from loguru import logger
 from unidiff import PatchSet
 
 from .. import logs
-from ..exceptions import DiffParseError, GitOperationError
+from ..exceptions import DiffParseError
+from ..git_ops.branches import run_git_raw
 from ..types_defs import DiffStats, FileSummary, HunkInfo
 
 
 def extract_diff(dev_branch: str, base_branch: str) -> str:
     logger.info(logs.EXTRACTING_DIFF.format(base=base_branch, dev=dev_branch))
-    result = subprocess.run(
-        ["git", "diff", f"{base_branch}...{dev_branch}"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise GitOperationError(result.stderr.strip())
-    return result.stdout
+    return run_git_raw("diff", f"{base_branch}...{dev_branch}")
 
 
 def parse_diff(raw_diff: str) -> ParsedDiff:

--- a/pr_split/diff_ops/reconstructor.py
+++ b/pr_split/diff_ops/reconstructor.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import subprocess
-
 from loguru import logger
 from unidiff import PatchedFile
 
 from .. import logs
 from ..constants import AssignmentType
-from ..exceptions import GitOperationError
+from ..git_ops.branches import run_git_raw
 from ..schemas import Group, GroupAssignment
 from .parser import ParsedDiff
 
@@ -60,14 +58,7 @@ def merge_chain_assignments(
 
 
 def _get_base_file_content(file_path: str, ref: str) -> str:
-    result = subprocess.run(
-        ["git", "show", f"{ref}:{file_path}"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise GitOperationError(result.stderr.strip())
-    return result.stdout
+    return run_git_raw("show", f"{ref}:{file_path}")
 
 
 def apply_hunks(base_content: str, patch_file: PatchedFile, assigned_indices: list[int]) -> str:

--- a/pr_split/exceptions.py
+++ b/pr_split/exceptions.py
@@ -11,6 +11,7 @@ class ErrorMsg(StrEnum):
     BRANCH_NOT_FOUND = "Branch '{branch}' does not exist"
     DIRTY_WORKTREE = "Working tree has uncommitted changes; commit or stash first"
     GH_AUTH_FAILED = "GitHub CLI authentication failed; run 'gh auth login'"
+    TOOL_NOT_FOUND = "'{tool}' is not installed or not on PATH"
     CYCLE_DETECTED = "Dependency cycle detected in split plan"
     COVERAGE_GAP = "Hunk {file}[{index}] not assigned to any group"
     COVERAGE_OVERLAP = "Hunk {file}[{index}] assigned to multiple groups: {groups}"

--- a/pr_split/git_ops/branches.py
+++ b/pr_split/git_ops/branches.py
@@ -1,36 +1,50 @@
 from __future__ import annotations
 
 import re
+import shutil
 import subprocess
 
 from loguru import logger
 
 from .. import logs
 from ..constants import BRANCH_PREFIX
-from ..exceptions import GitOperationError
+from ..exceptions import ErrorMsg, GitOperationError
+
+
+def _git(args: tuple[str, ...], cwd: str | None = None, *, strip: bool = True) -> str:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+        )
+    except FileNotFoundError as exc:
+        raise GitOperationError(ErrorMsg.TOOL_NOT_FOUND(tool="git")) from exc
+    if result.returncode != 0:
+        raise GitOperationError(result.stderr.strip())
+    return result.stdout.strip() if strip else result.stdout
 
 
 def run_git(*args: str) -> str:
-    result = subprocess.run(
-        ["git", *args],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise GitOperationError(result.stderr.strip())
-    return result.stdout.strip()
+    return _git(args)
+
+
+def run_git_raw(*args: str) -> str:
+    """Like run_git but returns stdout verbatim (diff and blob content)."""
+    return _git(args, strip=False)
 
 
 def run_git_in_dir(cwd: str, *args: str) -> str:
-    result = subprocess.run(
-        ["git", *args],
-        capture_output=True,
-        text=True,
-        cwd=cwd,
-    )
-    if result.returncode != 0:
-        raise GitOperationError(result.stderr.strip())
-    return result.stdout.strip()
+    return _git(args, cwd=cwd)
+
+
+def require_tools(*tools: str) -> str | None:
+    """Return the first of ``tools`` that is not on PATH, or None."""
+    for tool in tools:
+        if shutil.which(tool) is None:
+            return tool
+    return None
 
 
 def branch_exists(branch: str) -> bool:

--- a/pr_split/git_ops/prs.py
+++ b/pr_split/git_ops/prs.py
@@ -12,11 +12,16 @@ from ..types_defs import ForkPRInfo
 
 
 def _run_gh(*args: str) -> str:
-    result = subprocess.run(
-        ["gh", *args],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        # Callers only expect GitOperationError; a missing binary must not
+        # escape as a raw traceback (or make check_gh_auth raise).
+        raise GitOperationError(ErrorMsg.TOOL_NOT_FOUND(tool="gh")) from exc
     if result.returncode != 0:
         raise GitOperationError(result.stderr.strip())
     return result.stdout.strip()

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -537,3 +537,135 @@ class TestStatusCommand:
     def test_clean_no_plan(self, mock_pe: MagicMock) -> None:
         result = runner.invoke(app, ["clean"])
         assert result.exit_code == 0
+
+
+class TestMissingCliToolsAreReportedFirst:
+    @patch("pr_split.cli.branch_exists", return_value=False)
+    @patch("pr_split.cli.require_tools", return_value="git")
+    def test_split_reports_missing_git_before_anything_else(
+        self, mock_req: MagicMock, mock_be: MagicMock
+    ) -> None:
+        result = runner.invoke(app, ["split", "feature", "--dry-run"])
+        assert result.exit_code == 1
+        assert "'git' is not installed or not on PATH" in result.output
+        mock_be.assert_not_called()
+
+    @patch("pr_split.cli.require_tools")
+    def test_dry_run_does_not_require_gh(self, mock_req: MagicMock) -> None:
+        mock_req.return_value = None
+        with (
+            patch("pr_split.cli.branch_exists", return_value=True),
+            patch("pr_split.cli._validate_inputs", side_effect=typer.Exit(0)),
+        ):
+            runner.invoke(app, ["split", "feature", "--dry-run"])
+        assert [c.args for c in mock_req.call_args_list] == [("git",)]
+
+    @patch("pr_split.cli.get_pr_state")
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    @patch("pr_split.cli.require_tools", return_value="gh")
+    def test_merge_reports_missing_gh_instead_of_fetch_errors(
+        self,
+        mock_req: MagicMock,
+        mock_pe: MagicMock,
+        mock_load: MagicMock,
+        mock_state: MagicMock,
+    ) -> None:
+        from pr_split.schemas import PRRecord
+
+        plan_file = MagicMock()
+        plan_file.git_state.prs = [PRRecord(group_id="pr-1", pr_number=1, pr_url="u")]
+        mock_load.return_value = plan_file
+        result = runner.invoke(app, ["merge"])
+        assert result.exit_code == 1
+        assert "'gh' is not installed or not on PATH" in result.output
+        assert "fetch error" not in result.output
+        mock_state.assert_not_called()
+
+    @patch("pr_split.cli._cleanup_git_state")
+    @patch("pr_split.cli.typer.confirm", return_value=True)
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    @patch("pr_split.cli.require_tools", return_value="gh")
+    def test_clean_reports_missing_gh_and_keeps_the_plan(
+        self,
+        mock_req: MagicMock,
+        mock_pe: MagicMock,
+        mock_load: MagicMock,
+        mock_confirm: MagicMock,
+        mock_cleanup: MagicMock,
+    ) -> None:
+        from pr_split.schemas import PRRecord
+
+        plan_file = MagicMock()
+        plan_file.git_state.prs = [PRRecord(group_id="pr-1", pr_number=1, pr_url="u")]
+        mock_load.return_value = plan_file
+        result = runner.invoke(app, ["clean"])
+        assert result.exit_code == 1
+        assert "'gh' is not installed or not on PATH" in result.output
+        mock_confirm.assert_not_called()
+        mock_cleanup.assert_not_called()
+        assert mock_req.call_args.args == ("git", "gh")
+
+    @patch("pr_split.cli._cleanup_git_state")
+    @patch("pr_split.cli.typer.confirm", return_value=True)
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    @patch("pr_split.cli.require_tools")
+    def test_resplit_cleanup_in_dry_run_still_needs_gh(
+        self,
+        mock_req: MagicMock,
+        mock_be: MagicMock,
+        mock_validate: MagicMock,
+        mock_pe: MagicMock,
+        mock_load: MagicMock,
+        mock_confirm: MagicMock,
+        mock_cleanup: MagicMock,
+    ) -> None:
+        from pr_split.schemas import PRRecord
+
+        mock_req.side_effect = lambda *tools: "gh" if "gh" in tools else None
+        existing = MagicMock()
+        existing.git_state.branches = [MagicMock()]
+        existing.git_state.prs = [PRRecord(group_id="pr-1", pr_number=7, pr_url="u")]
+        mock_load.return_value = existing
+
+        result = runner.invoke(
+            app, ["split", "feature", "--dry-run"], env={"ANTHROPIC_API_KEY": "sk-test"}
+        )
+
+        assert result.exit_code == 1
+        assert "'gh' is not installed or not on PATH" in result.output
+        mock_confirm.assert_not_called()
+        mock_cleanup.assert_not_called()
+
+    @patch("pr_split.cli.check_gh_auth", return_value=False)
+    @patch("pr_split.cli.branch_exists", return_value=False)
+    @patch("pr_split.cli.require_tools")
+    def test_dry_run_of_a_pr_number_still_needs_gh(
+        self, mock_req: MagicMock, mock_be: MagicMock, mock_auth: MagicMock
+    ) -> None:
+        mock_req.side_effect = lambda *tools: "gh" if "gh" in tools else None
+        result = runner.invoke(app, ["split", "#123", "--dry-run"])
+        assert result.exit_code == 1
+        assert "'gh' is not installed or not on PATH" in result.output
+        assert "authentication failed" not in result.output
+        mock_auth.assert_not_called()
+
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    @patch("pr_split.cli.require_tools", return_value="gh")
+    def test_execute_reports_missing_gh(
+        self, mock_req: MagicMock, mock_pe: MagicMock, mock_load: MagicMock
+    ) -> None:
+        mock_plan_file = MagicMock()
+        mock_plan_file.git_state.branches = []
+        mock_plan_file.git_state.prs = []
+        mock_plan_file.plan.raw_diff = "some diff"
+        mock_plan_file.plan.merge_base_sha = "abc123"
+        mock_load.return_value = mock_plan_file
+        result = runner.invoke(app, ["execute"])
+        assert result.exit_code == 1
+        assert "'gh' is not installed or not on PATH" in result.output

--- a/tests/test_diff_parser_extended.py
+++ b/tests/test_diff_parser_extended.py
@@ -94,7 +94,7 @@ new file mode 100644
 
 
 class TestExtractDiffSubprocess:
-    @patch("pr_split.diff_ops.parser.subprocess.run")
+    @patch("pr_split.git_ops.branches.subprocess.run")
     def test_extract_diff_success(self, mock_run: MagicMock) -> None:
         mock_run.return_value = subprocess.CompletedProcess(
             args=["git", "diff"], returncode=0, stdout=EXTRACT_DIFF_SAMPLE, stderr=""
@@ -105,9 +105,10 @@ class TestExtractDiffSubprocess:
             ["git", "diff", "main...feature"],
             capture_output=True,
             text=True,
+            cwd=None,
         )
 
-    @patch("pr_split.diff_ops.parser.subprocess.run")
+    @patch("pr_split.git_ops.branches.subprocess.run")
     def test_extract_diff_failure(self, mock_run: MagicMock) -> None:
         mock_run.return_value = subprocess.CompletedProcess(
             args=["git", "diff"],

--- a/tests/test_git_branches.py
+++ b/tests/test_git_branches.py
@@ -314,3 +314,15 @@ class TestCommitFilesInDir:
     def test_empty_file_paths_raises(self) -> None:
         with pytest.raises(GitOperationError, match="no file paths"):
             commit_files_in_dir("/tmp/wt", [], "msg")
+
+
+class TestRequireTools:
+    def test_returns_first_missing_tool(self) -> None:
+        from pr_split.git_ops.branches import require_tools
+
+        with patch(
+            "pr_split.git_ops.branches.shutil.which",
+            side_effect=lambda t: None if t == "gh" else "/usr/bin/x",
+        ):
+            assert require_tools("git", "gh") == "gh"
+            assert require_tools("git") is None

--- a/tests/test_git_prs_coverage.py
+++ b/tests/test_git_prs_coverage.py
@@ -164,3 +164,29 @@ class TestFetchForkBranch:
 
         with pytest.raises(GitOperationError, match="Failed to fetch"):
             fetch_fork_branch("user", "branch")
+
+
+class TestMissingCliTools:
+    @patch(
+        "pr_split.git_ops.prs.subprocess.run",
+        side_effect=FileNotFoundError(2, "No such file", "gh"),
+    )
+    def test_missing_gh_is_a_git_operation_error(self, mock_run: MagicMock) -> None:
+        from pr_split.git_ops.prs import _run_gh, check_gh_auth
+
+        with pytest.raises(GitOperationError, match="'gh' is not installed or not on PATH"):
+            _run_gh("auth", "status")
+        assert check_gh_auth() is False
+        assert get_pr_state(1) == {}
+
+    @patch(
+        "pr_split.git_ops.branches.subprocess.run",
+        side_effect=FileNotFoundError(2, "No such file", "git"),
+    )
+    def test_missing_git_is_a_git_operation_error(self, mock_run: MagicMock) -> None:
+        from pr_split.git_ops.branches import run_git, run_git_in_dir
+
+        with pytest.raises(GitOperationError, match="'git' is not installed or not on PATH"):
+            run_git("status")
+        with pytest.raises(GitOperationError, match="'git' is not installed"):
+            run_git_in_dir("/tmp", "status")

--- a/tests/test_reconstructor.py
+++ b/tests/test_reconstructor.py
@@ -112,13 +112,13 @@ class TestApplyHunks:
 
 
 class TestGetBaseFileContent:
-    @patch("pr_split.diff_ops.reconstructor.subprocess.run")
+    @patch("pr_split.git_ops.branches.subprocess.run")
     def test_success(self, mock_run: MagicMock) -> None:
         mock_run.return_value = MagicMock(returncode=0, stdout="file content\n", stderr="")
         result = _get_base_file_content("foo.py", "abc123")
         assert result == "file content\n"
 
-    @patch("pr_split.diff_ops.reconstructor.subprocess.run")
+    @patch("pr_split.git_ops.branches.subprocess.run")
     def test_failure_raises(self, mock_run: MagicMock) -> None:
         mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="not found")
         with pytest.raises(GitOperationError):
@@ -180,7 +180,7 @@ class TestMaterializeGroupFilesNewFile:
 
 
 class TestGetBaseFileContentExtended:
-    @patch("pr_split.diff_ops.reconstructor.subprocess.run")
+    @patch("pr_split.git_ops.branches.subprocess.run")
     def test_empty_file_returns_empty(self, mock_run: MagicMock) -> None:
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
         result = _get_base_file_content("empty.py", "abc123")


### PR DESCRIPTION
## Summary

When `gh` (or `git`) is not on PATH, `subprocess.run` raises `FileNotFoundError`, which no caller expected: `check_gh_auth` (typed `-> bool`) raised instead of returning False, `get_pr_state` (catching only `GitOperationError`/`JSONDecodeError`) killed `merge` mid-loop, and `split` showed a raw traceback. Worse, once the wrappers convert that into a `GitOperationError`, `clean` and the re-split prompt swallow it per-PR as a warning, report "Cleanup complete" and delete the plan file while every PR and branch is left in place.

Now:

- `_run_gh` and a shared `_git` helper (also used by a new `run_git_raw` for `extract_diff` / `_get_base_file_content`, which had their own `subprocess.run`) raise `GitOperationError("'gh' is not installed or not on PATH")`
- `require_tools` pre-checks run up front in `split` (`git`, plus `gh` unless `--dry-run`; the PR-number/`user:branch` path always needs `gh`), `execute`, `merge` (which would otherwise skip every PR as a "fetch error" and exit 0), and — via a shared `_require_cleanup_tools` — before the confirm prompt in both `clean` and the re-split path, so a missing binary is reported instead of turning into a bogus "authentication failed" or a successful-looking cleanup

`status` intentionally still degrades to the cached state (read-only).

## Test plan

- `TestMissingCliTools` (wrappers), `TestRequireTools`, `TestMissingCliToolsAreReportedFirst` (split, dry-run of a local branch needs only git, dry-run of a PR number needs gh, execute, merge, clean keeps the plan, re-split cleanup in dry-run) — all fail on main
- Review re-ran four `PATH=/nonexistent` repros (clean, split #123 --dry-run, merge, split --dry-run re-split): clean error, exit 1, plan retained
- 454 tests pass, ruff clean
- Local review: 5/5 (after four fix→re-review rounds)
