### PR TITLE
fix: resolve the plan and PR template against the repository root, not the cwd

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -30,8 +30,6 @@ from .constants import (
     DEFAULT_MIN_LOC,
     DEFAULT_PARTITION_STRATEGY,
     DEFAULT_STRICT_LOC_BOUNDS,
-    PLAN_DIR,
-    PLAN_FILE,
     AssignmentType,
     ChunkStrategy,
     PartitionStrategy,
@@ -62,7 +60,7 @@ from .git_ops import (
 from .git_ops.branches import run_git
 from .git_ops.prs import close_pr, create_pr, get_pr_state, link_stack, merge_pr
 from .graph import PlanDAG
-from .plan_store import load_plan, plan_exists, save_plan
+from .plan_store import load_plan, plan_dir, plan_exists, plan_path, save_plan
 from .planner import plan_split, validate_coverage, validate_plan
 from .schemas import (
     BranchRecord,
@@ -350,11 +348,13 @@ _GH_API_CONCURRENCY = 3
 _gh_semaphore = Semaphore(_GH_API_CONCURRENCY)
 
 
-_PR_TEMPLATE_PATH = Path(PLAN_DIR) / "template.md"
+def _pr_template_path() -> Path:
+    return plan_dir() / "template.md"
 
 
 def _build_pr_body(group: Group, all_groups: list[Group]) -> str:
-    if _PR_TEMPLATE_PATH.exists():
+    template_path = _pr_template_path()
+    if template_path.exists():
         files = [a.file_path for a in group.assignments]
         template_vars = {
             "description": group.description,
@@ -368,19 +368,17 @@ def _build_pr_body(group: Group, all_groups: list[Group]) -> str:
             "title": group.title,
         }
         try:
-            template = _PR_TEMPLATE_PATH.read_text(encoding="utf-8")
+            template = template_path.read_text(encoding="utf-8")
             return template.format(**template_vars)
         except (KeyError, ValueError, IndexError) as exc:
             available = ", ".join(f"{{{k}}}" for k in sorted(template_vars))
             raise PRSplitError(
-                f"Invalid PR template at {_PR_TEMPLATE_PATH}: {exc}. "
+                f"Invalid PR template at {template_path}: {exc}. "
                 f"Available placeholders: {available}. "
                 "Escape literal braces with {{ and }}."
             ) from exc
         except OSError as exc:
-            raise PRSplitError(
-                f"Could not read PR template at {_PR_TEMPLATE_PATH}: {exc}"
-            ) from exc
+            raise PRSplitError(f"Could not read PR template at {template_path}: {exc}") from exc
 
     files = [a.file_path for a in group.assignments]
     sections = [group.description]
@@ -849,7 +847,7 @@ def split(
 
     if dry_run:
         save_plan(PlanFile(plan=split_plan, git_state=GitState(branches=[], prs=[])))
-        logger.success(f"Dry run complete: plan with {len(groups)} groups saved to {PLAN_FILE}")
+        logger.success(f"Dry run complete: plan with {len(groups)} groups saved to {plan_path()}")
         return
 
     typer.confirm("Proceed with creating branches and PRs?", abort=True)
@@ -946,9 +944,9 @@ def _cleanup_git_state(git_state: GitState) -> tuple[int, int]:
         except PRSplitError:
             logger.warning(f"Could not delete branch {branch_record.branch_name}")
 
-    plan_path = Path(PLAN_FILE)
-    if plan_path.exists():
-        plan_path.unlink()
+    saved_plan = plan_path()
+    if saved_plan.exists():
+        saved_plan.unlink()
 
     return closed_prs, deleted_branches
 

--- a/pr_split/plan_store.py
+++ b/pr_split/plan_store.py
@@ -5,29 +5,50 @@ from pydantic import ValidationError
 
 from . import logs
 from .constants import PLAN_DIR, PLAN_FILE
-from .exceptions import ErrorMsg, PRSplitError
+from .exceptions import ErrorMsg, GitOperationError, PRSplitError
+from .git_ops.branches import run_git
 from .schemas import PlanFile
 
 
+def repo_root() -> Path:
+    """The working tree's top level, or the cwd outside a git repository.
+
+    Every git call in the tool is cwd-independent, so the plan and template
+    must be too: a `split --dry-run` from `src/` and an `execute` from the
+    repository root have to see the same `.pr-split/plan.json`.
+    """
+    try:
+        return Path(run_git("rev-parse", "--show-toplevel"))
+    except GitOperationError:
+        return Path.cwd()
+
+
+def plan_dir() -> Path:
+    return repo_root() / PLAN_DIR
+
+
+def plan_path() -> Path:
+    return repo_root() / PLAN_FILE
+
+
 def save_plan(plan_file: PlanFile) -> None:
-    path = Path(PLAN_DIR)
-    path.mkdir(parents=True, exist_ok=True)
-    plan_path = Path(PLAN_FILE)
-    plan_path.write_text(plan_file.model_dump_json(indent=2))
-    logger.info(logs.SAVING_PLAN.format(path=plan_path))
+    plan_dir().mkdir(parents=True, exist_ok=True)
+    target = plan_path()
+    target.write_text(plan_file.model_dump_json(indent=2))
+    logger.info(logs.SAVING_PLAN.format(path=target))
 
 
 def load_plan() -> PlanFile:
-    plan_path = Path(PLAN_FILE)
-    if not plan_path.exists():
+    target = plan_path()
+    if not target.exists():
         raise PRSplitError(ErrorMsg.NO_PLAN())
     try:
-        plan_file = PlanFile.model_validate_json(plan_path.read_text())
+        plan_file = PlanFile.model_validate_json(target.read_text())
     except (OSError, UnicodeDecodeError, ValidationError) as exc:
-        raise PRSplitError(ErrorMsg.PLAN_LOAD_FAILED(path=plan_path, detail=exc)) from exc
-    logger.info(logs.PLAN_LOADED.format(count=len(plan_file.plan.groups), path=plan_path))
+        raise PRSplitError(ErrorMsg.PLAN_LOAD_FAILED(path=target, detail=exc)) from exc
+    logger.info(logs.PLAN_LOADED.format(count=len(plan_file.plan.groups), path=target))
     return plan_file
 
 
 def plan_exists() -> bool:
-    return Path(PLAN_FILE).exists()
+    return plan_path().exists()

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -203,7 +203,7 @@ class TestBuildPrBodyOsError:
         mock_path = MagicMock()
         mock_path.exists.return_value = True
         mock_path.read_text.side_effect = OSError("Permission denied")
-        monkeypatch.setattr("pr_split.cli._PR_TEMPLATE_PATH", mock_path)
+        monkeypatch.setattr("pr_split.cli._pr_template_path", lambda: mock_path)
 
         group = _group("pr-1", "t", files=["a.py"])
         with pytest.raises(PRSplitError, match="Could not read PR template"):

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -99,7 +99,7 @@ class TestBuildPrBody:
         template_dir.mkdir()
         template_file = template_dir / "template.md"
         template_file.write_text("{description}\n\nFiles: {files}\nLOC: {loc}")
-        monkeypatch.setattr("pr_split.cli._PR_TEMPLATE_PATH", template_file)
+        monkeypatch.setattr("pr_split.cli._pr_template_path", lambda: template_file)
 
         group = _group("pr-1", "feat: auth", files=["auth.py"], added=10, removed=5)
         body = _build_pr_body(group, [group])
@@ -114,7 +114,7 @@ class TestBuildPrBody:
         template_dir.mkdir()
         template_file = template_dir / "template.md"
         template_file.write_text("{nonexistent}")
-        monkeypatch.setattr("pr_split.cli._PR_TEMPLATE_PATH", template_file)
+        monkeypatch.setattr("pr_split.cli._pr_template_path", lambda: template_file)
 
         group = _group("pr-1", "feat: auth", files=["auth.py"])
         with pytest.raises(PRSplitError, match="Invalid PR template"):

--- a/tests/test_plan_store.py
+++ b/tests/test_plan_store.py
@@ -146,3 +146,48 @@ class TestPlanStoreCorruptFiles:
         (tmp_path / ".pr-split" / "plan.json").mkdir()
         with pytest.raises(PRSplitError, match="Cannot load split plan"):
             load_plan()
+
+
+class TestPlanPathsResolveAgainstTheRepoRoot:
+    def _repo(self, tmp_path: Path) -> Path:
+        import subprocess
+
+        repo = tmp_path / "repo"
+        (repo / "src").mkdir(parents=True)
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+        return repo
+
+    def test_plan_saved_from_a_subdirectory_is_found_from_the_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pr_split.plan_store import plan_path
+
+        repo = self._repo(tmp_path)
+        monkeypatch.chdir(repo / "src")
+        save_plan(_make_plan_file())
+        assert (repo / ".pr-split" / "plan.json").exists()
+        assert not (repo / "src" / ".pr-split").exists()
+        assert plan_path() == (repo / ".pr-split" / "plan.json").resolve()
+
+        monkeypatch.chdir(repo)
+        assert plan_exists()
+        assert load_plan().plan.dev_branch == "feat/big"
+
+    def test_outside_a_repository_the_cwd_is_used(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pr_split.plan_store import plan_path
+
+        monkeypatch.chdir(tmp_path)
+        assert plan_path() == tmp_path / ".pr-split" / "plan.json"
+
+    def test_template_is_read_from_the_repo_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pr_split.cli import _pr_template_path
+
+        repo = self._repo(tmp_path)
+        (repo / ".pr-split").mkdir()
+        (repo / ".pr-split" / "template.md").write_text("# {title}")
+        monkeypatch.chdir(repo / "src")
+        assert _pr_template_path().read_text() == "# {title}"


### PR DESCRIPTION
## Summary

`.pr-split/plan.json` and `.pr-split/template.md` were resolved relative to the current directory while every git call is cwd-independent. `cd src && pr-split split dev --dry-run` wrote `src/.pr-split/plan.json`; `pr-split status` / `execute` from the repository root then said "No split plan found", and a root-level PR template was ignored from any subdirectory.

`plan_store` now has `repo_root()` (`git rev-parse --show-toplevel`, falling back to the cwd outside a repository) with `plan_dir()` / `plan_path()`; `save_plan`, `load_plan`, `plan_exists`, the cleanup unlink, the dry-run success message and the PR template lookup (`_pr_template_path()`) all use them. `constants.PLAN_DIR` / `PLAN_FILE` are unchanged.

Stacked on #64 (`fix/plan-store-corrupt-file`), which owns `load_plan`.

## Test plan

- `TestPlanPathsResolveAgainstTheRepoRoot`: plan saved from `src/` lands at the root and loads from the root; cwd fallback outside a repo; template found from a subdirectory — all fail on the base
- Review verified linked worktrees, bare repos, `GIT_DIR`, symlinked paths, nested repos, and that `scripts/score_pr.py` (run from the workspace root) is unaffected
- 458 tests pass, ruff clean
- Local review: 5/5
