### PR TITLE
fix: skip git hooks when committing sub-PR worktrees

### DIFF
--- a/pr_split/git_ops/branches.py
+++ b/pr_split/git_ops/branches.py
@@ -58,10 +58,10 @@ def commit_files(file_paths: list[str], message: str, *, author: str | None = No
     run_git("add", "--", *file_paths)
     author_args = ("--author", author) if author else ()
     try:
-        run_git("commit", "-m", message, *author_args)
+        run_git("commit", "--no-verify", "-m", message, *author_args)
     except GitOperationError:
         run_git("add", "-u")
-        run_git("commit", "-m", message, *author_args)
+        run_git("commit", "--no-verify", "-m", message, *author_args)
     return run_git("rev-parse", "HEAD")
 
 
@@ -121,5 +121,9 @@ def commit_files_in_dir(
         raise GitOperationError("commit_files_in_dir called with no file paths")
     run_git_in_dir(cwd, "add", "-A", "--", *file_paths)
     author_args = ("--author", author) if author else ()
-    run_git_in_dir(cwd, "commit", "-m", message, *author_args)
+    # The content is a subset of commits already accepted on the dev
+    # branch; a pre-commit/commit-msg hook (husky, pre-commit, lint-staged)
+    # run inside the throwaway worktree has no node_modules/venv and can
+    # only fail, so skip it.
+    run_git_in_dir(cwd, "commit", "--no-verify", "-m", message, *author_args)
     return run_git_in_dir(cwd, "rev-parse", "HEAD")

--- a/tests/test_git_branches.py
+++ b/tests/test_git_branches.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -314,3 +315,57 @@ class TestCommitFilesInDir:
     def test_empty_file_paths_raises(self) -> None:
         with pytest.raises(GitOperationError, match="no file paths"):
             commit_files_in_dir("/tmp/wt", [], "msg")
+
+
+def _git_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CI runners have no git identity configured; commits need one."""
+    for var in ("GIT_AUTHOR_NAME", "GIT_COMMITTER_NAME"):
+        monkeypatch.setenv(var, "t")
+    for var in ("GIT_AUTHOR_EMAIL", "GIT_COMMITTER_EMAIL"):
+        monkeypatch.setenv(var, "t@x")
+
+
+class TestCommitsSkipHooks:
+    @patch("pr_split.git_ops.branches.run_git_in_dir", return_value="sha")
+    def test_commit_files_in_dir_passes_no_verify(self, mock_git: MagicMock) -> None:
+        commit_files_in_dir("/wt", ["a.py"], "msg", author="A <a@x>")
+        commit_call = next(c for c in mock_git.call_args_list if c.args[1] == "commit")
+        assert commit_call.args == (
+            "/wt",
+            "commit",
+            "--no-verify",
+            "-m",
+            "msg",
+            "--author",
+            "A <a@x>",
+        )
+
+    @patch("pr_split.git_ops.branches.run_git", return_value="sha")
+    def test_commit_files_passes_no_verify(self, mock_git: MagicMock) -> None:
+        commit_files(["a.py"], "msg")
+        commit_call = next(c for c in mock_git.call_args_list if c.args[0] == "commit")
+        assert commit_call.args == ("commit", "--no-verify", "-m", "msg")
+
+    def test_failing_pre_commit_hook_does_not_block_the_sub_pr_commit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _git_identity(monkeypatch)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+        hook = repo / ".git" / "hooks" / "pre-commit"
+        hook.write_text("#!/bin/sh\necho 'husky: node_modules missing' >&2\nexit 1\n")
+        hook.chmod(0o755)
+        (repo / "a.py").write_text("x\n")
+
+        sha = commit_files_in_dir(str(repo), ["a.py"], "feat: a", author="Test <t@x>")
+
+        assert len(sha) == 40
+        log = subprocess.run(
+            ["git", "log", "--format=%s", "-1"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        assert log.strip() == "feat: a"


### PR DESCRIPTION
## Summary

`commit_files_in_dir` (and the older `commit_files`) ran `git commit` without `--no-verify`, so a repository's `pre-commit` / `commit-msg` hook — husky, the pre-commit framework, lint-staged — executed inside the throwaway sub-PR worktree, which has no `node_modules`, venv or other toolchain. The content being committed is a subset of commits already accepted on the dev branch, so the hook adds nothing and can only fail, taking the whole group with it (`husky: running lint (node_modules missing)` → `1 branch(es) failed`).

Both helpers now pass `--no-verify`. Hooks configured through `core.hooksPath` are bypassed too; `prepare-commit-msg`/`post-commit` still run but cannot break the flow (the PR title comes from the plan, not the commit subject).

## Test plan

- argv assertions for both helpers and a real-git test with a failing `pre-commit` hook — all three fail on main
- 447 tests pass, ruff clean
- Local review: 5/5

Noted by the review, not in this PR: a failing `post-checkout` hook still aborts `git worktree add` and leaves the directory behind.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Commits created in temporary worktrees now complete successfully even when pre-commit or commit-message hooks are configured to fail.
  - Improved reliability when committing both individual files and directory changes.

- **Tests**
  - Added coverage confirming hooks are skipped and valid commits are produced with the expected messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->