### PR TITLE
fix: stage files the dev branch tracks despite .gitignore when committing a sub-PR

### DIFF
--- a/pr_split/git_ops/branches.py
+++ b/pr_split/git_ops/branches.py
@@ -119,7 +119,11 @@ def commit_files_in_dir(
 ) -> str:
     if not file_paths:
         raise GitOperationError("commit_files_in_dir called with no file paths")
-    run_git_in_dir(cwd, "add", "-A", "--", *file_paths)
+    # -f: the dev branch may track a file that matches .gitignore (added
+    # with `git add -f`); the diff materialises it, and without -f `git add`
+    # refuses the path and the whole group fails. The path list is explicit,
+    # so -f cannot pull in anything unintended; -A still stages deletions.
+    run_git_in_dir(cwd, "add", "-A", "-f", "--", *file_paths)
     author_args = ("--author", author) if author else ()
     # The content is a subset of commits already accepted on the dev
     # branch; a pre-commit/commit-msg hook (husky, pre-commit, lint-staged)

--- a/tests/test_git_branches.py
+++ b/tests/test_git_branches.py
@@ -302,7 +302,7 @@ class TestCommitFilesInDir:
         mock_git.side_effect = ["", "", "abc123"]
         sha = commit_files_in_dir("/tmp/wt", ["file.py"], "test commit")
         assert sha == "abc123"
-        assert mock_git.call_args_list[0].args == ("/tmp/wt", "add", "-A", "--", "file.py")
+        assert mock_git.call_args_list[0].args == ("/tmp/wt", "add", "-A", "-f", "--", "file.py")
 
     @patch("pr_split.git_ops.branches.run_git_in_dir")
     def test_commit_with_author(self, mock_git: MagicMock) -> None:
@@ -369,3 +369,40 @@ class TestCommitsSkipHooks:
             check=True,
         ).stdout
         assert log.strip() == "feat: a"
+
+
+class TestIgnoredPathsAreStillCommitted:
+    def test_file_tracked_on_dev_despite_gitignore_is_committed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _git_identity(monkeypatch)
+        repo = tmp_path / "repo"
+        (repo / "build").mkdir(parents=True)
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+        (repo / ".gitignore").write_text("build/\n")
+        (repo / "build" / "out.txt").write_text("artifact\n")
+
+        commit_files_in_dir(str(repo), [".gitignore", "build/out.txt"], "feat: artifact")
+
+        tracked = subprocess.run(
+            ["git", "ls-files"], cwd=repo, capture_output=True, text=True, check=True
+        ).stdout.split()
+        assert "build/out.txt" in tracked
+
+    def test_deleted_files_are_still_staged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _git_identity(monkeypatch)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+        (repo / "a.py").write_text("x\n")
+        commit_files_in_dir(str(repo), ["a.py"], "add")
+        (repo / "a.py").unlink()
+
+        commit_files_in_dir(str(repo), ["a.py"], "remove")
+
+        tracked = subprocess.run(
+            ["git", "ls-files"], cwd=repo, capture_output=True, text=True, check=True
+        ).stdout.split()
+        assert tracked == []


### PR DESCRIPTION
## Summary

If the dev branch tracks a file that matches `.gitignore` (added with `git add -f` — a checked-in build artefact, a lockfile under an ignored directory), the diff shows it as a normal change and materialisation writes it into the sub-PR worktree, but `git add -A -- build/out.txt` refuses ignored paths ("The following paths are ignored by one of your .gitignore files") and the whole group fails.

`commit_files_in_dir` now runs `git add -A -f -- <paths>`. The path list is always the exact set of files from the diff (`materialize_group_files` keys), so `-f` cannot pull in unintended files; `-A` still stages deletions, including of an ignored-but-tracked file.

Stacked on #161 (`fix/commit-without-hooks`), which touches the same lines.

## Test plan

- real-git: an ignored-but-tracked file is committed (fails on the base with the git refusal); deleted files are still staged; argv assertion updated
- Review probed directory/glob inputs (unreachable from the CLI), deletions, and `info/exclude`
- 449 tests pass, ruff clean
- Local review: 5/5
