### PR TITLE
fix: reject submodule pointer changes up front instead of failing at branch creation

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -44,7 +44,13 @@ from .diff_ops import (
     merge_chain_assignments,
     parse_diff,
 )
-from .exceptions import ErrorMsg, PlanValidationError, PRCreationError, PRSplitError
+from .exceptions import (
+    DiffParseError,
+    ErrorMsg,
+    PlanValidationError,
+    PRCreationError,
+    PRSplitError,
+)
 from .git_ops import (
     add_worktree,
     branch_exists,
@@ -762,7 +768,11 @@ def split(
             logger.info("Overwriting existing dry-run plan")
 
     raw_diff = extract_diff(dev_branch, base)
-    parsed_diff = parse_diff(raw_diff)
+    try:
+        parsed_diff = parse_diff(raw_diff)
+    except DiffParseError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
     stats = parsed_diff.stats
     logger.info(
         logs.DIFF_STATS.format(
@@ -1020,7 +1030,11 @@ def execute(
         console.print(f"[red]{ErrorMsg.GH_AUTH_FAILED()}[/red]")
         raise typer.Exit(1)
 
-    parsed_diff = parse_diff(plan.raw_diff)
+    try:
+        parsed_diff = parse_diff(plan.raw_diff)
+    except DiffParseError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
 
     try:
         validate_coverage(plan.groups, parsed_diff)

--- a/pr_split/diff_ops/parser.py
+++ b/pr_split/diff_ops/parser.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import subprocess
 from dataclasses import dataclass
 from functools import cached_property
@@ -8,14 +9,18 @@ from loguru import logger
 from unidiff import PatchSet
 
 from .. import logs
-from ..exceptions import DiffParseError, GitOperationError
+from ..exceptions import DiffParseError, ErrorMsg, GitOperationError
 from ..types_defs import DiffStats, FileSummary, HunkInfo
 
 
 def extract_diff(dev_branch: str, base_branch: str) -> str:
     logger.info(logs.EXTRACTING_DIFF.format(base=base_branch, dev=dev_branch))
     result = subprocess.run(
-        ["git", "diff", f"{base_branch}...{dev_branch}"],
+        # --submodule=short: with diff.submodule=log|diff in the user's
+        # config a gitlink change has no "index … 160000" header and would
+        # slip past the submodule check below (or show up as a bogus
+        # vendor/<file> diff).
+        ["git", "diff", "--submodule=short", f"{base_branch}...{dev_branch}"],
         capture_output=True,
         text=True,
     )
@@ -24,11 +29,32 @@ def extract_diff(dev_branch: str, base_branch: str) -> str:
     return result.stdout
 
 
+_GITLINK_MODE = "160000"
+
+
+def _submodule_paths(patch_set: PatchSet) -> list[str]:
+    """Files whose diff header carries the gitlink mode (a submodule pointer)."""
+    paths: list[str] = []
+    for patch_file in patch_set:
+        header = "\n".join(patch_file.patch_info or [])
+        if re.search(
+            rf"^index [0-9a-f]+\.\.[0-9a-f]+ {_GITLINK_MODE}$", header, re.M
+        ) or re.search(rf"^(?:new|deleted) file mode {_GITLINK_MODE}$", header, re.M):
+            paths.append(patch_file.path)
+    return paths
+
+
 def parse_diff(raw_diff: str) -> ParsedDiff:
     try:
         patch_set = PatchSet(raw_diff)
     except Exception as exc:
         raise DiffParseError(str(exc)) from exc
+    # A submodule bump looks like a one-hunk text change ("-Subproject
+    # commit …"), so it would plan and validate fine and only fail with
+    # "bad object" while materializing, after the user confirmed.
+    submodules = _submodule_paths(patch_set)
+    if submodules:
+        raise DiffParseError(ErrorMsg.SUBMODULE_UNSUPPORTED(paths=", ".join(submodules)))
     return ParsedDiff(patch_set=patch_set, raw_diff=raw_diff)
 
 

--- a/pr_split/exceptions.py
+++ b/pr_split/exceptions.py
@@ -27,6 +27,10 @@ class ErrorMsg(StrEnum):
     HUNK_TOO_LARGE = "Hunk {file}[{index}] has ~{tokens} estimated tokens, exceeds budget {budget}"
     MIN_LOC_GE_MAX_LOC = "min_loc {min_loc} must be less than max_loc {max_loc}"
     LOC_BOUNDS_STRICT_FAILED = "Plan violates configured LOC bounds"
+    SUBMODULE_UNSUPPORTED = (
+        "Submodule changes are not supported (pointer bump at {paths}); "
+        "split them out of the branch first"
+    )
 
     def __call__(self, **kwargs: object) -> str:
         return self.value.format(**kwargs) if kwargs else self.value

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -509,6 +509,43 @@ class TestExecuteCommand:
         result = runner.invoke(app, ["execute"])
         assert result.exit_code != 0
 
+    @patch("pr_split.cli.validate_coverage")
+    @patch("pr_split.cli.check_gh_auth", return_value=True)
+    @patch("pr_split.cli.is_worktree_clean", return_value=True)
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_execute_rejects_a_saved_submodule_plan(
+        self,
+        mock_pe: MagicMock,
+        mock_load: MagicMock,
+        mock_be: MagicMock,
+        mock_clean: MagicMock,
+        mock_auth: MagicMock,
+        mock_validate: MagicMock,
+    ) -> None:
+        mock_plan_file = MagicMock()
+        mock_plan_file.git_state.branches = []
+        mock_plan_file.git_state.prs = []
+        mock_plan_file.plan.merge_base_sha = "abc123"
+        mock_plan_file.plan.raw_diff = (
+            "diff --git a/vendor b/vendor\n"
+            "index 0ebfaa8..2f687ea 160000\n"
+            "--- a/vendor\n"
+            "+++ b/vendor\n"
+            "@@ -1 +1 @@\n"
+            "-Subproject commit 0ebfaa8000000000000000000000000000000000\n"
+            "+Subproject commit 2f687ea000000000000000000000000000000000\n"
+        )
+        mock_load.return_value = mock_plan_file
+        result = runner.invoke(app, ["execute"])
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "Submodule changes are not supported (pointer bump at vendor)" in " ".join(
+            result.output.split()
+        )
+        mock_validate.assert_not_called()
+
     @patch("pr_split.cli.load_plan")
     @patch("pr_split.cli.plan_exists", return_value=True)
     def test_execute_missing_merge_base_sha(

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -332,3 +332,35 @@ class TestSplitCliEnvVars:
         assert mock_validate_plan.call_args_list[0].kwargs["min_loc"] == 50
         assert mock_validate_plan.call_args_list[1].kwargs["min_loc"] == 50
         mock_save_plan.assert_not_called()
+
+
+class TestSplitRejectsSubmoduleDiffs:
+    @patch("pr_split.cli.plan_split")
+    @patch("pr_split.cli.extract_diff")
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_submodule_diff_is_a_clean_error(
+        self,
+        mock_branch_exists: MagicMock,
+        mock_validate_inputs: MagicMock,
+        mock_extract_diff: MagicMock,
+        mock_plan_split: MagicMock,
+    ) -> None:
+        mock_extract_diff.return_value = (
+            "diff --git a/vendor b/vendor\n"
+            "index 0ebfaa8..2f687ea 160000\n"
+            "--- a/vendor\n"
+            "+++ b/vendor\n"
+            "@@ -1 +1 @@\n"
+            "-Subproject commit 0ebfaa8000000000000000000000000000000000\n"
+            "+Subproject commit 2f687ea000000000000000000000000000000000\n"
+        )
+        result = runner.invoke(
+            app, ["split", "feature-branch", "--dry-run"], env={"ANTHROPIC_API_KEY": "sk-test"}
+        )
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "Submodule changes are not supported (pointer bump at vendor)" in " ".join(
+            result.output.split()
+        )
+        mock_plan_split.assert_not_called()

--- a/tests/test_diff_parser_extended.py
+++ b/tests/test_diff_parser_extended.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 import subprocess
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -102,7 +104,7 @@ class TestExtractDiffSubprocess:
         result = extract_diff("feature", "main")
         assert result == EXTRACT_DIFF_SAMPLE
         mock_run.assert_called_once_with(
-            ["git", "diff", "main...feature"],
+            ["git", "diff", "--submodule=short", "main...feature"],
             capture_output=True,
             text=True,
         )
@@ -123,3 +125,126 @@ class TestRawDiffPreserved:
     def test_raw_diff_preserved(self) -> None:
         parsed = parse_diff(EXTRACT_DIFF_SAMPLE)
         assert parsed.raw_diff == EXTRACT_DIFF_SAMPLE
+
+
+SUBMODULE_DIFF = """\
+diff --git a/app.py b/app.py
+--- a/app.py
++++ b/app.py
+@@ -1 +1 @@
+-x
++y
+diff --git a/vendor b/vendor
+index 0ebfaa8..2f687ea 160000
+--- a/vendor
++++ b/vendor
+@@ -1 +1 @@
+-Subproject commit 0ebfaa8000000000000000000000000000000000
++Subproject commit 2f687ea000000000000000000000000000000000
+"""
+
+NEW_SUBMODULE_DIFF = """\
+diff --git a/lib b/lib
+new file mode 160000
+index 0000000..2f687ea
+--- /dev/null
++++ b/lib
+@@ -0,0 +1 @@
++Subproject commit 2f687ea000000000000000000000000000000000
+"""
+
+
+DELETED_SUBMODULE_DIFF = """\
+diff --git a/vendor b/vendor
+deleted file mode 160000
+index d075b20..0000000
+--- a/vendor
++++ /dev/null
+@@ -1 +0,0 @@
+-Subproject commit d075b20000000000000000000000000000000000
+"""
+
+
+class TestSubmoduleChangesAreRejected:
+    def test_deleted_submodule_is_rejected(self) -> None:
+        from pr_split.exceptions import DiffParseError
+
+        with pytest.raises(DiffParseError, match="pointer bump at vendor"):
+            parse_diff(DELETED_SUBMODULE_DIFF)
+
+    def test_pointer_bump_is_rejected_by_name(self) -> None:
+        from pr_split.exceptions import DiffParseError
+
+        with pytest.raises(DiffParseError, match="pointer bump at vendor"):
+            parse_diff(SUBMODULE_DIFF)
+
+    def test_added_submodule_is_rejected(self) -> None:
+        from pr_split.exceptions import DiffParseError
+
+        with pytest.raises(DiffParseError, match="Submodule changes are not supported"):
+            parse_diff(NEW_SUBMODULE_DIFF)
+
+    def test_regular_files_with_similar_content_are_fine(self) -> None:
+        raw = (
+            "diff --git a/notes.txt b/notes.txt\n"
+            "index 0ebfaa8..2f687ea 100644\n"
+            "--- a/notes.txt\n"
+            "+++ b/notes.txt\n"
+            "@@ -1 +1 @@\n"
+            "-Subproject commit 0ebfaa8000000000000000000000000000000000\n"
+            "+Subproject commit 2f687ea000000000000000000000000000000000\n"
+        )
+        assert [pf.path for pf in parse_diff(raw).patch_set] == ["notes.txt"]
+
+    def test_real_submodule_bump_is_rejected_before_planning(self, tmp_path: Path) -> None:
+        from pr_split.exceptions import DiffParseError
+
+        def git(cwd: Path, *args: str) -> str:
+            return subprocess.run(
+                [
+                    "git",
+                    "-c",
+                    "user.name=t",
+                    "-c",
+                    "user.email=t@x",
+                    "-c",
+                    "protocol.file.allow=always",
+                    *args,
+                ],
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout
+
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        git(sub, "init", "-q", "-b", "main")
+        (sub / "f").write_text("1\n")
+        git(sub, "add", "-A")
+        git(sub, "commit", "-qm", "one")
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        git(repo, "init", "-q", "-b", "main")
+        (repo / "app.py").write_text("x\n")
+        git(repo, "add", "-A")
+        git(repo, "submodule", "add", "-q", str(sub), "vendor")
+        git(repo, "commit", "-qm", "base")
+        git(repo, "checkout", "-qb", "dev")
+        (sub / "f").write_text("2\n")
+        git(sub, "commit", "-qam", "two")
+        git(repo / "vendor", "pull", "-q", "origin", "main")
+        (repo / "app.py").write_text("y\n")
+        git(repo, "add", "-A")
+        git(repo, "commit", "-qm", "bump")
+
+        cwd = os.getcwd()
+        os.chdir(repo)
+        try:
+            for mode in ("short", "log", "diff"):
+                # A user-level diff.submodule setting must not hide the bump.
+                git(repo, "config", "diff.submodule", mode)
+                with pytest.raises(DiffParseError, match="vendor"):
+                    parse_diff(extract_diff("dev", "main"))
+        finally:
+            os.chdir(cwd)


### PR DESCRIPTION
## Summary

`git diff` emits a submodule pointer bump as a normal-looking one-hunk text change (`index 0ebfaa8..2f687ea 160000`, `-Subproject commit …` / `+Subproject commit …`). unidiff parses it as a file, the plan validates, the user confirms — and only then `git show <merge-base>:vendor` fails with `fatal: bad object …` inside `_create_branches_and_commits`.

- `parse_diff` now detects gitlink entries (mode `160000` on the `index`, `new file mode` or `deleted file mode` line) and raises `Submodule changes are not supported (pointer bump at vendor); split them out of the branch first`
- `extract_diff` pins `--submodule=short`: with `diff.submodule=log|diff` in the user's git config the gitlink change has no `160000` header and would otherwise slip past the check (or appear as a bogus `vendor/<file>` diff) — the review caught that
- `split` and `execute` catch `DiffParseError` and exit 1 with the message instead of a traceback

## Test plan

- parser: pointer bump, added, deleted submodule rejected by name; a regular file whose *content* looks like a gitlink is fine; a real-git superproject bump rejected under `diff.submodule` = `short`, `log`, `diff`
- CLI: `split --dry-run` and `execute` on such a diff exit 1 cleanly before planning / coverage validation
- 451 tests pass, ruff clean
- Local review: 5/5 (after two fix→re-review rounds)

Overlap note: #49 pins other `git diff` flags on the same line; whichever lands second merges the flag list.
