### PR TITLE
fix: do not run repository hooks when creating sub-PR worktrees

### DIFF
--- a/pr_split/git_ops/branches.py
+++ b/pr_split/git_ops/branches.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import re
 import subprocess
+import tempfile
+from pathlib import Path
 
 from loguru import logger
 
@@ -103,11 +105,31 @@ def add_worktree(path: str, branch_name: str, start_point: str) -> None:
         prev_sha = run_git("rev-parse", branch_name)
         run_git("branch", "-D", branch_name)
     try:
-        run_git("worktree", "add", "-b", branch_name, path, start_point)
+        # A repository post-checkout hook (husky, lint-staged installers)
+        # runs inside the throwaway worktree, where it has no toolchain and
+        # can only fail; pointing hooksPath at an empty directory for this
+        # one command disables it.
+        run_git(
+            "-c",
+            f"core.hooksPath={_no_hooks_dir()}",
+            "worktree",
+            "add",
+            "-b",
+            branch_name,
+            path,
+            start_point,
+        )
     except GitOperationError:
         if prev_sha is not None:
             run_git("branch", branch_name, prev_sha)
         raise
+
+
+def _no_hooks_dir() -> str:
+    """An empty directory to use as core.hooksPath (no hooks run)."""
+    path = Path(tempfile.gettempdir()) / "pr-split-no-hooks"
+    path.mkdir(exist_ok=True)
+    return str(path)
 
 
 def remove_worktree(path: str) -> None:

--- a/tests/test_git_branches.py
+++ b/tests/test_git_branches.py
@@ -260,9 +260,9 @@ class TestAddWorktree:
     def test_adds_worktree(self, mock_exists: MagicMock, mock_git: MagicMock) -> None:
         mock_git.return_value = ""
         add_worktree("/tmp/wt", "pr-split/ns/pr-1", "abc123")
-        mock_git.assert_called_once_with(
-            "worktree", "add", "-b", "pr-split/ns/pr-1", "/tmp/wt", "abc123"
-        )
+        args = mock_git.call_args.args
+        assert args[0] == "-c" and args[1].startswith("core.hooksPath=")
+        assert args[2:] == ("worktree", "add", "-b", "pr-split/ns/pr-1", "/tmp/wt", "abc123")
 
     @patch("pr_split.git_ops.branches.run_git")
     @patch("pr_split.git_ops.branches.branch_exists", return_value=True)
@@ -406,3 +406,45 @@ class TestIgnoredPathsAreStillCommitted:
             ["git", "ls-files"], cwd=repo, capture_output=True, text=True, check=True
         ).stdout.split()
         assert tracked == []
+
+
+class TestWorktreeAddSkipsHooks:
+    def test_failing_post_checkout_hook_does_not_block_worktree_creation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _git_identity(monkeypatch)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "--allow-empty", "-m", "base"], cwd=repo, check=True
+        )
+        hook = repo / ".git" / "hooks" / "post-checkout"
+        hook.write_text("#!/bin/sh\necho 'post-checkout failing' >&2\nexit 1\n")
+        hook.chmod(0o755)
+        monkeypatch.chdir(repo)
+
+        add_worktree(str(tmp_path / "wt"), "pr-split/ns/g1", "main")
+
+        assert (tmp_path / "wt" / ".git").exists()
+
+    def test_hooks_path_from_config_is_also_bypassed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _git_identity(monkeypatch)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "--allow-empty", "-m", "base"], cwd=repo, check=True
+        )
+        hooks = tmp_path / "myhooks"
+        hooks.mkdir()
+        (hooks / "post-checkout").write_text("#!/bin/sh\nexit 1\n")
+        (hooks / "post-checkout").chmod(0o755)
+        subprocess.run(["git", "config", "core.hooksPath", str(hooks)], cwd=repo, check=True)
+        monkeypatch.chdir(repo)
+
+        add_worktree(str(tmp_path / "wt"), "pr-split/ns/g2", "main")
+
+        assert (tmp_path / "wt" / ".git").exists()


### PR DESCRIPTION
## Summary

Follow-up to #161: `git worktree add` fires the repository's `post-checkout` hook inside the throwaway sub-PR worktree. A hook that needs the project toolchain (husky / lint-staged installers) fails there, aborting `add_worktree` with the hook's error and leaving the directory and branch behind.

`add_worktree` now runs `git -c core.hooksPath=<empty temp dir> worktree add …`, so no hook runs for that one command — the setting applies to the checkout git performs inside the new worktree too (verified with a marker-file hook). Hooks configured via `core.hooksPath` are bypassed the same way.

Stacked on #162 (stack #163 = #161→#162→this).

## Test plan

- real-git: a failing `.git/hooks/post-checkout` and a failing hook under `core.hooksPath` no longer block worktree creation; argv assertion updated — all three fail on the base
- 451 tests pass, ruff clean
- Local review: 5/5
