### PR TITLE
fix: report an Anthropic token-count failure as an LLM error instead of an SDK traceback

### DIFF
--- a/pr_split/exceptions.py
+++ b/pr_split/exceptions.py
@@ -22,6 +22,7 @@ class ErrorMsg(StrEnum):
     MERGE_CONFLICT = "Groups '{a}' and '{b}' modify overlapping regions in '{file}'"
     NO_PLAN = "No split plan found; run 'pr-split split' first"
     LLM_PARSE_ERROR = "Failed to parse LLM response: {detail}"
+    LLM_TOKEN_COUNT_FAILED = "Could not count prompt tokens with the LLM API: {detail}"
     BRANCH_CREATE_FAILED = "Failed to create branch '{branch}': {detail}"
     PR_CREATE_FAILED = "Failed to create PR for group '{group}': {detail}"
     MERGE_FAILED = "Merge of '{source}' into '{target}' failed: {detail}"

--- a/pr_split/planner/client.py
+++ b/pr_split/planner/client.py
@@ -90,12 +90,18 @@ def _extract_raw_output(block_input: dict[str, object]) -> list[_RawGroup]:
 
 def _count_tokens_anthropic(system: str, user: str, *, settings: Settings) -> int:
     client = anthropic.Anthropic(api_key=settings.api_key)
-    response = client.messages.count_tokens(
-        model=settings.model,
-        system=system,
-        messages=[{"role": "user", "content": user}],
-        tools=[_ANTHROPIC_TOOL_DEF],
-    )
+    # This is the first API call of a run, so a bad key, a network blip or a
+    # rate limit surfaces here; it must be an LLMError like every other
+    # provider failure rather than an SDK traceback.
+    try:
+        response = client.messages.count_tokens(
+            model=settings.model,
+            system=system,
+            messages=[{"role": "user", "content": user}],
+            tools=[_ANTHROPIC_TOOL_DEF],
+        )
+    except anthropic.APIError as exc:
+        raise LLMError(ErrorMsg.LLM_TOKEN_COUNT_FAILED(detail=str(exc))) from exc
     return response.input_tokens
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import anthropic
 import pytest
 
 from pr_split.config import Settings
@@ -546,6 +547,16 @@ class TestCountTokensAnthropic:
         result = _count_tokens_anthropic("sys", "usr", settings=settings)
         assert result == 42
         mock_client.messages.count_tokens.assert_called_once()
+
+    @patch("pr_split.planner.client.anthropic.Anthropic")
+    def test_api_failure_is_an_llm_error(self, mock_cls: MagicMock) -> None:
+        mock_client = mock_cls.return_value
+        mock_client.messages.count_tokens.side_effect = anthropic.APIConnectionError(
+            request=MagicMock()
+        )
+        settings = _make_settings(Provider.ANTHROPIC)
+        with pytest.raises(LLMError, match="Could not count prompt tokens"):
+            _count_tokens_anthropic("sys", "usr", settings=settings)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`_count_tokens_anthropic` called `client.messages.count_tokens` with no error handling. It is the first API call of a `split` run, so a bad key, an unreachable proxy or a rate limit surfaced as a raw `anthropic.AuthenticationError` / `APIConnectionError` traceback rather than the `LLMError` path `_call_anthropic` already uses.

`anthropic.APIError` is now wrapped into `LLMError(ErrorMsg.LLM_TOKEN_COUNT_FAILED)` at both count call sites (single-shot sizing and chunked overhead). No local fallback estimate: the count uses the same key/host as the planning call, so anything that breaks it breaks the next request too, and the SDK's own retries already absorb transient blips. With #63's `PRSplitError` guard this becomes a clean red message.

Stacked on #146 (stack #81 = #49→#50→#69→#70→#93→#105→#113→#146→this).

## Test plan

- `test_api_failure_is_an_llm_error`: `APIConnectionError` from `count_tokens` → `LLMError` naming the detail; fails on the base
- Review verified both call sites end to end and that `_count_tokens_openai` (tiktoken, local) needs nothing
- 484 tests pass, ruff clean
- Local review: 5/5
