### PR TITLE
fix: let execute run when only pr-split's own plan file is modified

### DIFF
--- a/pr_split/git_ops/branches.py
+++ b/pr_split/git_ops/branches.py
@@ -6,7 +6,7 @@ import subprocess
 from loguru import logger
 
 from .. import logs
-from ..constants import BRANCH_PREFIX
+from ..constants import BRANCH_PREFIX, PLAN_DIR
 from ..exceptions import GitOperationError
 
 
@@ -42,7 +42,14 @@ def branch_exists(branch: str) -> bool:
 
 
 def is_worktree_clean() -> bool:
-    output = run_git("status", "--porcelain")
+    """True when nothing tracked is modified, ignoring pr-split's own plan directory.
+
+    `split`/`edit` write `.pr-split/plan.json`; a user who commits the plan
+    (to share or review it) then has a modified tracked file, and `execute`
+    would refuse to run on the very plan it was asked to execute. Everything
+    under the plan directory is therefore excluded from the check.
+    """
+    output = run_git("status", "--porcelain", "--", f":(top,exclude){PLAN_DIR}")
     return all(line.startswith("??") for line in output.splitlines())
 
 

--- a/tests/test_git_branches.py
+++ b/tests/test_git_branches.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import subprocess
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from pr_split.constants import PLAN_DIR
 from pr_split.exceptions import GitOperationError
 from pr_split.git_ops.branches import (
     add_worktree,
@@ -314,3 +316,50 @@ class TestCommitFilesInDir:
     def test_empty_file_paths_raises(self) -> None:
         with pytest.raises(GitOperationError, match="no file paths"):
             commit_files_in_dir("/tmp/wt", [], "msg")
+
+
+class TestIsWorktreeCleanIgnoresPlanDir:
+    """The check must not trip on pr-split's own `.pr-split/plan.json`."""
+
+    @pytest.fixture
+    def repo(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        env = {
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@example.com",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@example.com",
+        }
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+        subprocess.run(["git", "init", "-q", "-b", "main", str(tmp_path)], check=True)
+        (tmp_path / "src.py").write_text("x = 1\n")
+        plan = tmp_path / PLAN_DIR / "plan.json"
+        plan.parent.mkdir()
+        plan.write_text("{}\n")
+        subprocess.run(["git", "-C", str(tmp_path), "add", "-A"], check=True)
+        subprocess.run(["git", "-C", str(tmp_path), "commit", "-qm", "init"], check=True)
+        monkeypatch.chdir(tmp_path)
+        return tmp_path
+
+    def test_modified_tracked_plan_is_ignored(self, repo: Path) -> None:
+        (repo / PLAN_DIR / "plan.json").write_text('{"groups": []}\n')
+        assert is_worktree_clean() is True
+
+    def test_staged_plan_is_ignored(self, repo: Path) -> None:
+        (repo / PLAN_DIR / "plan.json").write_text('{"groups": []}\n')
+        subprocess.run(["git", "add", "-A"], check=True)
+        assert is_worktree_clean() is True
+
+    def test_plan_dir_is_ignored_from_a_subdirectory(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (repo / PLAN_DIR / "plan.json").write_text('{"groups": []}\n')
+        sub = repo / "pkg"
+        sub.mkdir()
+        monkeypatch.chdir(sub)
+        assert is_worktree_clean() is True
+
+    def test_other_modifications_still_count(self, repo: Path) -> None:
+        (repo / PLAN_DIR / "plan.json").write_text('{"groups": []}\n')
+        (repo / "src.py").write_text("x = 2\n")
+        assert is_worktree_clean() is False


### PR DESCRIPTION
## Summary

`is_worktree_clean` rejected any modified tracked file — including `.pr-split/plan.json`, which `split`/`edit` themselves write. A user who commits the plan (to share or review it) and then refines it was told the worktree is dirty by the very `execute` command meant to run that plan.

The status check now uses an exclude-only, top-anchored pathspec (`:(top,exclude).pr-split`), so everything under pr-split's own plan directory is ignored while any other modification still blocks. `:(top)` keeps it correct when invoked from a subdirectory. All three callers (split validate, fork split, execute) are pure pre-flight dirty-tree guards, and execution builds branches in throwaway worktrees, so nothing downstream relies on the plan dir being clean.

Stacked on #158.

## Test plan

- New real-git tests: modified tracked plan ignored, staged plan ignored, works from a subdirectory, other modifications still count — 3 of 4 fail on the base implementation
- Review confirmed exclude-only pathspec semantics on real git and audited all three callers
- 462 tests pass, ruff clean
- Local review: 5/5
