### PR TITLE
fix: treat a bare PR number as a PR even when git resolves it as an abbreviated commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ pr-split split feature-branch --base main
 pr-split split '#42' --base main
 ```
 
+A bare number (with or without `#`) is always treated as a PR number, even if a
+local branch or abbreviated commit hash with the same digits exists. To split a
+local branch literally named like a number, pass its full ref:
+
+```bash
+pr-split split refs/heads/1006 --base main
+```
+
 ### Split a fork PR by user:branch
 
 ```bash

--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -662,7 +662,14 @@ def _resolve_fork_ref(dev_branch: str) -> ForkPRInfo | None:
 
 @app.command(help="Split a large PR into smaller dependency-ordered PRs.")
 def split(
-    dev_branch: Annotated[str, typer.Argument(help="Branch name, PR number, or user:branch")],
+    dev_branch: Annotated[
+        str,
+        typer.Argument(
+            help="Branch name, PR number, or user:branch. A bare number is always "
+            "treated as a PR number; for a local branch literally named like a "
+            "number, use its full ref, e.g. refs/heads/1006."
+        ),
+    ],
     base: Annotated[str, typer.Option(help="Base branch")] = "main",
     min_loc: Annotated[
         int | None,
@@ -730,7 +737,11 @@ def split(
     author: str | None = None
     fork_info: ForkPRInfo | None = None
 
-    if not branch_exists(dev_branch):
+    # Decide the argument form before consulting git: `git rev-parse` accepts
+    # abbreviated SHAs, so a bare PR number such as 1006 would otherwise be
+    # taken for a commit whose hash starts with those digits and the wrong
+    # diff would be split without any warning.
+    if _is_fork_ref(dev_branch) or not branch_exists(dev_branch):
         # Only a PR number or user:branch can be fetched from GitHub; a plain
         # branch name that does not exist is just a typo, so say so before
         # touching gh (which --dry-run must not require).

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -496,6 +496,52 @@ class TestSplitCommandValidation:
         mock_auth.assert_not_called()
         mock_resolve.assert_not_called()
 
+    @patch("pr_split.cli._resolve_fork_ref", return_value=None)
+    @patch("pr_split.cli.is_worktree_clean", return_value=True)
+    @patch("pr_split.cli.check_gh_auth", return_value=True)
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_pr_number_is_never_taken_for_an_abbreviated_sha(
+        self,
+        mock_be: MagicMock,
+        mock_auth: MagicMock,
+        mock_clean: MagicMock,
+        mock_resolve: MagicMock,
+    ) -> None:
+        # branch_exists says True because `git rev-parse 1006` resolves a
+        # commit whose hash starts with 1006; the argument is still PR #1006.
+        result = runner.invoke(app, ["split", "1006", "--dry-run"])
+        assert result.exit_code == 1
+        mock_resolve.assert_called_once_with("1006")
+        assert "Branch '1006' does not exist" in result.output
+
+    def test_full_ref_is_not_a_fork_ref(self) -> None:
+        from pr_split.cli import _is_fork_ref
+
+        # Documented escape hatch: a local branch literally named like a
+        # number is reachable through its full ref.
+        assert _is_fork_ref("refs/heads/1006") is False
+        assert _is_fork_ref("1006") is True
+        assert _is_fork_ref("#1006") is True
+
+    @patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"})
+    @patch("pr_split.cli.extract_diff", side_effect=RuntimeError("stop here"))
+    @patch("pr_split.cli._resolve_fork_ref", return_value=None)
+    @patch("pr_split.cli.is_worktree_clean", return_value=True)
+    @patch("pr_split.cli.check_gh_auth", return_value=True)
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    def test_full_ref_escape_hatch_takes_the_branch_path(
+        self,
+        mock_be: MagicMock,
+        mock_auth: MagicMock,
+        mock_clean: MagicMock,
+        mock_resolve: MagicMock,
+        mock_extract: MagicMock,
+    ) -> None:
+        result = runner.invoke(app, ["split", "refs/heads/1006", "--dry-run"])
+        mock_resolve.assert_not_called()
+        mock_extract.assert_called_once()
+        assert result.exit_code != 0  # stopped by the stubbed extract_diff
+
     @patch("pr_split.cli.check_gh_auth", return_value=False)
     @patch("pr_split.cli.branch_exists", return_value=False)
     def test_split_fork_shaped_ref_still_checks_gh_auth(


### PR DESCRIPTION
## Summary

`split 1006` could silently split the wrong thing: the argument-form decision consulted `branch_exists()` (`git rev-parse --verify`) before `_is_fork_ref()`, and rev-parse happily resolves `1006` as an *abbreviated commit SHA* if any commit hash starts with those digits. The run then proceeded with "Extracting diff between main and 1006" against an arbitrary commit instead of fetching PR #1006 — reproduced against a real repo during review.

`_is_fork_ref` now wins unconditionally: a bare number (with or without `#`) is always a PR number. The precedence is documented in the argument help and README, including the escape hatch for a local branch literally named like a number — pass its full ref (`refs/heads/1006`), which flows through `branch_exists`/rev-parse and the whole pipeline (verified end to end, including the derived sub-branch namespace).

Stacked on #136 (stack = #111→#136→this).

## Test plan

- `test_pr_number_is_never_taken_for_an_abbreviated_sha` — fails on the base (`_resolve_fork_ref` never called there)
- `test_full_ref_is_not_a_fork_ref` and `test_full_ref_escape_hatch_takes_the_branch_path` pin the documented escape hatch
- Review reproduced the original bug on a real repo (brute-forced a commit whose hash starts with `1006`) and verified the escape hatch on real git
- 452 tests pass, ruff clean
- Local review: 5/5
