### PR TITLE
fix: write the plan file atomically so a crash mid-save cannot destroy it

### DIFF
--- a/pr_split/plan_store.py
+++ b/pr_split/plan_store.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from loguru import logger
@@ -32,9 +33,22 @@ def plan_path() -> Path:
 
 
 def save_plan(plan_file: PlanFile) -> None:
+    """Atomically replace the plan file.
+
+    The most important save happens right after PRs are created; a crash or
+    full disk mid-write must not leave truncated JSON that destroys the only
+    record of those PRs and branches. The plan is therefore written to a
+    temporary file in the same directory and renamed over the target, which
+    is atomic on POSIX and Windows alike.
+    """
     plan_dir().mkdir(parents=True, exist_ok=True)
     target = plan_path()
-    target.write_text(plan_file.model_dump_json(indent=2))
+    tmp = target.with_name(target.name + ".tmp")
+    try:
+        tmp.write_text(plan_file.model_dump_json(indent=2))
+        os.replace(tmp, target)
+    finally:
+        tmp.unlink(missing_ok=True)
     logger.info(logs.SAVING_PLAN.format(path=target))
 
 

--- a/tests/test_plan_store.py
+++ b/tests/test_plan_store.py
@@ -7,7 +7,7 @@ import pytest
 
 from pr_split.constants import Priority
 from pr_split.exceptions import PRSplitError
-from pr_split.plan_store import load_plan, plan_exists, save_plan
+from pr_split.plan_store import load_plan, plan_dir, plan_exists, plan_path, save_plan
 from pr_split.schemas import (
     BranchRecord,
     GitState,
@@ -191,3 +191,38 @@ class TestPlanPathsResolveAgainstTheRepoRoot:
         (repo / ".pr-split" / "template.md").write_text("# {title}")
         monkeypatch.chdir(repo / "src")
         assert _pr_template_path().read_text() == "# {title}"
+
+
+class TestSavePlanIsAtomic:
+    def test_no_temp_file_left_behind(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        save_plan(_make_plan_file())
+        leftovers = [p.name for p in plan_dir().iterdir() if p.name != "plan.json"]
+        assert leftovers == []
+
+    def test_failed_write_preserves_the_previous_plan(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A crash mid-write must not destroy the only record of created PRs."""
+        monkeypatch.chdir(tmp_path)
+        save_plan(_make_plan_file())
+        before = plan_path().read_text()
+
+        def exploding_write(self: Path, *args: object, **kwargs: object) -> int:
+            # Emulate a crash/disk-full: leave a truncated temp file behind.
+            Path(str(self)).parent.mkdir(parents=True, exist_ok=True)
+            with open(self, "w") as fh:
+                fh.write('{"plan": {"dev_branch"')
+            raise OSError(28, "No space left on device")
+
+        # A nested patch context: monkeypatch.undo() would also undo chdir.
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(Path, "write_text", exploding_write)
+            with pytest.raises(OSError):
+                save_plan(_make_plan_file())
+
+        assert plan_path().read_text() == before
+        loaded = load_plan()
+        assert loaded.plan.dev_branch == _make_plan_file().plan.dev_branch


### PR DESCRIPTION
## Summary

`save_plan` truncated and rewrote `.pr-split/plan.json` in place. The file embeds the full raw diff, and the most important save happens right after PRs are created — so a crash, SIGKILL, or full disk mid-write left truncated JSON *and* destroyed the previous good plan, orphaning the just-created PRs and branches with no record for `clean`/`status`/`merge` to act on (#64 only cleans up the resulting error message; the data was still gone).

The plan is now written to `plan.json.tmp` in the same directory and `os.replace()`d onto the target — atomic on the same filesystem — with the temp file unlinked in a `finally` on failure. Review confirmed the temp file is invisible to #169's clean check and that a stray `.tmp` after SIGKILL is harmless and overwritten by the next save.

Stacked on #169 (stack #159 = #64→#158→#169→this).

## Test plan

- `test_failed_write_preserves_the_previous_plan`: an ENOSPC mid-write leaves the previous plan byte-for-byte intact and loadable — fails on the base
- `test_no_temp_file_left_behind` guards the new mechanism
- Review reproduced the base failure mode (truncated JSON) and verified replace/unlink semantics in a scratch repo
- 464 tests pass, ruff clean
- Local review: 5/5
