### PR TITLE
fix: let split --dry-run run unattended instead of aborting on closed stdin

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json as json_mod
 import shutil
+import sys
 import tempfile
 import time
 import urllib.request
@@ -612,6 +613,12 @@ def _show_group_detail(groups: list[Group], group_id: str) -> None:
 
 
 def _interactive_edit(groups: list[Group], parsed_diff: ParsedDiff) -> list[Group]:
+    if not sys.stdin.isatty():
+        # Scripts and CI (`split --dry-run < /dev/null`) have no one to answer
+        # the editor prompt; typer.prompt would turn the EOF into an Abort
+        # before the plan is ever saved. Accept the plan as-is instead.
+        console.print("[yellow]Non-interactive stdin; accepting the plan as-is.[/yellow]")
+        return groups
     console.print(
         "\n[cyan]Interactive editor. Commands:[/cyan]\n"
         "  [bold]move[/bold] <file>:<hunk> <from_group> <to_group>\n"

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -597,3 +597,58 @@ class TestStatusCommand:
     def test_clean_no_plan(self, mock_pe: MagicMock) -> None:
         result = runner.invoke(app, ["clean"])
         assert result.exit_code == 0
+
+
+class TestDryRunWithClosedStdin:
+    """`split --dry-run < /dev/null` must save the plan, not abort.
+
+    The interactive editor is entered unconditionally; with a closed stdin
+    (scripts, CI) `typer.prompt` raises EOFError, which used to become
+    typer.Abort before the plan was ever saved.
+    """
+
+    @patch("pr_split.cli.save_plan")
+    @patch("pr_split.cli.merge_base", return_value="abc123")
+    @patch("pr_split.cli._present_plan")
+    @patch("pr_split.cli.validate_plan", return_value=[])
+    @patch("pr_split.cli.plan_split")
+    @patch("pr_split.cli.parse_diff")
+    @patch("pr_split.cli.extract_diff", return_value="diff --git a/a.py b/a.py\n")
+    @patch("pr_split.cli._validate_inputs")
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    @patch("pr_split.cli.plan_exists", return_value=False)
+    def test_closed_stdin_accepts_the_plan_and_saves_it(
+        self,
+        mock_plan_exists: MagicMock,
+        mock_branch_exists: MagicMock,
+        mock_validate_inputs: MagicMock,
+        mock_extract_diff: MagicMock,
+        mock_parse_diff: MagicMock,
+        mock_plan_split: MagicMock,
+        mock_validate_plan: MagicMock,
+        mock_present_plan: MagicMock,
+        mock_merge_base: MagicMock,
+        mock_save_plan: MagicMock,
+    ) -> None:
+        parsed_diff = MagicMock()
+        parsed_diff.stats = {
+            "total_files": 1,
+            "total_added": 10,
+            "total_removed": 5,
+            "total_loc": 15,
+        }
+        mock_parse_diff.return_value = parsed_diff
+        group = _group("pr-1", "feat: auth", files=["a.py"])
+        mock_plan_split.return_value = [group]
+
+        # No `input=` and no patched _interactive_edit: the editor really runs
+        # and hits EOF on the runner's empty stdin.
+        result = runner.invoke(
+            app,
+            ["split", "feature-branch", "--dry-run"],
+            env={"ANTHROPIC_API_KEY": "sk-test"},
+        )
+
+        assert result.exit_code == 0
+        assert "accepting the plan as-is" in result.output.replace("\n", " ")
+        mock_save_plan.assert_called_once()


### PR DESCRIPTION
## Summary

`split --dry-run < /dev/null` — the documented automation mode (preview + save plan) — exited 1 without saving anything. The interactive editor runs unconditionally before the plan is saved, and typer/click converts the EOF from a closed stdin into an `Abort` *inside* the prompt, so no `except EOFError` around it can help. The repo's own `scripts/score_pr.py` had to work around this with `input="done\n"`.

`_interactive_edit` now returns the plan as-is with a yellow notice when `sys.stdin.isatty()` is false, before any prompt. Interactive behaviour (including Ctrl+C → abort) is unchanged. Review verified with real subprocess runs: dry-run with closed stdin exits 0 and writes the plan; the `score_pr.py` workaround still works; a *non*-dry-run split with closed stdin is still stopped by the `Proceed with creating branches and PRs?` confirm gate before anything is created.

## Test plan

- `TestDryRunWithClosedStdin` drives the real editor under CliRunner's non-TTY stdin (no `_interactive_edit` patch) — fails on main, passes here
- Review ran the CLI end to end in a scratch repo for dry-run, piped-"done", and non-dry-run closed-stdin cases
- 457 tests pass, ruff clean
- Local review: 5/5
