### PR TITLE
fix: retry execute after a failed push instead of forcing a full re-plan

### DIFF
--- a/pr_split/cli.py
+++ b/pr_split/cli.py
@@ -45,7 +45,13 @@ from .diff_ops import (
     merge_chain_assignments,
     parse_diff,
 )
-from .exceptions import ErrorMsg, PlanValidationError, PRCreationError, PRSplitError
+from .exceptions import (
+    ErrorMsg,
+    GitOperationError,
+    PlanValidationError,
+    PRCreationError,
+    PRSplitError,
+)
 from .git_ops import (
     add_worktree,
     branch_exists,
@@ -967,6 +973,44 @@ def clean() -> None:
     logger.success(logs.CLEAN_COMPLETE.format(branches=deleted_branches, prs=closed_prs))
 
 
+def _delete_stale_recorded_branches(
+    records: list[BranchRecord], groups: list[Group], namespace: str
+) -> None:
+    """Remove branches from a previous failed run that the plan no longer contains.
+
+    A retried execute recreates only the current groups and then overwrites
+    git_state; without this, a branch created before the plan was edited would
+    survive locally (and on origin, if its push succeeded) with no record left
+    for `pr-split clean` to delete.
+    """
+    expected = {f"{BRANCH_PREFIX}{namespace}/{group.id}" for group in groups}
+    for record in records:
+        if record.branch_name in expected:
+            continue
+        if branch_exists(record.branch_name):
+            try:
+                delete_branch(record.branch_name)
+            except GitOperationError as exc:
+                console.print(
+                    f"[yellow]Could not delete stale branch"
+                    f" {escape(record.branch_name)}: {escape(str(exc))}[/yellow]"
+                )
+        # The remote copy is handled independently: the local branch may be
+        # gone (manual prune, an earlier retry) while the pushed one survives,
+        # and delete_branch would raise before reaching the remote delete.
+        try:
+            run_git("ls-remote", "--exit-code", "origin", f"refs/heads/{record.branch_name}")
+        except GitOperationError:
+            continue  # never pushed (or remote unreachable): nothing to delete
+        try:
+            run_git("push", "origin", "--delete", record.branch_name)
+        except GitOperationError as exc:
+            console.print(
+                f"[yellow]Could not delete stale remote branch"
+                f" {escape(record.branch_name)}: {escape(str(exc))}[/yellow]"
+            )
+
+
 @app.command(
     help="Execute a previously saved dry-run plan, creating branches and PRs.",
 )
@@ -999,9 +1043,18 @@ def execute(
     if draft and not plan.draft:
         plan = plan.model_copy(update={"draft": True})
 
-    if plan_file.git_state.branches or plan_file.git_state.prs:
-        console.print("[red]This plan already has branches/PRs. Use 'pr-split clean' first.[/red]")
+    if plan_file.git_state.prs:
+        console.print("[red]This plan already has PRs. Use 'pr-split clean' first.[/red]")
         raise typer.Exit(1)
+    if plan_file.git_state.branches:
+        # A previous execute created branches but no PRs - a failed push or PR
+        # creation. Branch creation is idempotent (add_worktree recreates an
+        # existing branch), so retry instead of forcing 'clean' + a full
+        # re-plan, which for the LLM backend means paying for planning again.
+        console.print(
+            "[yellow]A previous run created branches but no PRs"
+            " (the push or PR creation failed). Recreating them and retrying.[/yellow]"
+        )
 
     if not plan.raw_diff:
         console.print(
@@ -1046,6 +1099,7 @@ def execute(
     typer.confirm("Proceed with creating branches and PRs?", abort=True)
 
     namespace = derive_split_namespace(plan.dev_branch_arg or plan.dev_branch)
+    _delete_stale_recorded_branches(plan_file.git_state.branches, plan.groups, namespace)
     try:
         branch_records = _create_branches_and_commits(
             plan.groups,

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -490,13 +490,14 @@ class TestExecuteCommand:
 
     @patch("pr_split.cli.load_plan")
     @patch("pr_split.cli.plan_exists", return_value=True)
-    def test_execute_already_has_git_state(self, mock_pe: MagicMock, mock_load: MagicMock) -> None:
+    def test_execute_already_has_prs(self, mock_pe: MagicMock, mock_load: MagicMock) -> None:
         mock_plan_file = MagicMock()
         mock_plan_file.git_state.branches = [MagicMock()]
-        mock_plan_file.git_state.prs = []
+        mock_plan_file.git_state.prs = [MagicMock()]
         mock_load.return_value = mock_plan_file
         result = runner.invoke(app, ["execute"])
         assert result.exit_code != 0
+        assert "already has PRs" in result.output
 
     @patch("pr_split.cli.load_plan")
     @patch("pr_split.cli.plan_exists", return_value=True)
@@ -597,6 +598,187 @@ class TestStatusCommand:
     def test_clean_no_plan(self, mock_pe: MagicMock) -> None:
         result = runner.invoke(app, ["clean"])
         assert result.exit_code == 0
+
+
+class TestExecuteRetriesAfterFailedPush:
+    """Branches without PRs mean a failed push; execute must retry, not refuse.
+
+    Forcing 'clean' + re-plan would delete the plan and require paying for
+    LLM planning again after a transient network failure.
+    """
+
+    @patch("pr_split.cli.typer.confirm", return_value=True)
+    @patch("pr_split.cli.save_plan")
+    @patch("pr_split.cli._push_and_create_prs", return_value=[])
+    @patch("pr_split.cli._create_branches_and_commits", return_value=[])
+    @patch("pr_split.cli.commit_exists", return_value=True)
+    @patch("pr_split.cli.parse_diff")
+    @patch("pr_split.cli.is_worktree_clean", return_value=True)
+    @patch("pr_split.cli.check_gh_auth", return_value=True)
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_branches_without_prs_is_retried(
+        self,
+        mock_pe: MagicMock,
+        mock_load: MagicMock,
+        mock_be: MagicMock,
+        mock_auth: MagicMock,
+        mock_clean: MagicMock,
+        mock_parse: MagicMock,
+        mock_commit: MagicMock,
+        mock_create: MagicMock,
+        mock_push: MagicMock,
+        mock_save: MagicMock,
+        mock_confirm: MagicMock,
+    ) -> None:
+        from pr_split.constants import Priority
+        from pr_split.schemas import BranchRecord, GitState, PlanFile, SplitPlan
+
+        plan_file = PlanFile(
+            plan=SplitPlan(
+                dev_branch="feature-branch",
+                base_branch="main",
+                max_loc=400,
+                priority=Priority.ORTHOGONAL,
+                merge_base_sha="0123456789abcdef",
+                raw_diff="some diff",
+                groups=[_group("pr-1", "feat: auth", files=["a.py"])],
+            ),
+            git_state=GitState(
+                branches=[
+                    BranchRecord(
+                        group_id="pr-1",
+                        branch_name="pr-split/feature-branch/pr-1",
+                        base_branch="main",
+                        commit_sha="abc123",
+                    )
+                ]
+            ),
+        )
+        mock_load.return_value = plan_file
+
+        result = runner.invoke(app, ["execute"])
+
+        assert result.exit_code == 0
+        assert "Recreating them and retrying" in result.output.replace("\n", " ")
+        mock_create.assert_called_once()
+        mock_push.assert_called_once()
+        mock_save.assert_called_once()
+
+    @staticmethod
+    def _plan_with_stale_pr2() -> object:
+        from pr_split.constants import Priority
+        from pr_split.schemas import BranchRecord, GitState, PlanFile, SplitPlan
+
+        return PlanFile(
+            plan=SplitPlan(
+                dev_branch="feature-branch",
+                base_branch="main",
+                max_loc=400,
+                priority=Priority.ORTHOGONAL,
+                merge_base_sha="0123456789abcdef",
+                raw_diff="some diff",
+                groups=[_group("pr-1", "feat: auth", files=["a.py"])],
+            ),
+            git_state=GitState(
+                branches=[
+                    BranchRecord(
+                        group_id="pr-1",
+                        branch_name="pr-split/feature-branch/pr-1",
+                        base_branch="main",
+                        commit_sha="abc123",
+                    ),
+                    # pr-2 was merged into pr-1 by an edit between the runs.
+                    BranchRecord(
+                        group_id="pr-2",
+                        branch_name="pr-split/feature-branch/pr-2",
+                        base_branch="main",
+                        commit_sha="def456",
+                    ),
+                ]
+            ),
+        )
+
+    @patch("pr_split.cli.run_git")
+    @patch("pr_split.cli.delete_branch")
+    @patch("pr_split.cli.typer.confirm", return_value=True)
+    @patch("pr_split.cli.save_plan")
+    @patch("pr_split.cli._push_and_create_prs", return_value=[])
+    @patch("pr_split.cli._create_branches_and_commits", return_value=[])
+    @patch("pr_split.cli.commit_exists", return_value=True)
+    @patch("pr_split.cli.parse_diff")
+    @patch("pr_split.cli.is_worktree_clean", return_value=True)
+    @patch("pr_split.cli.check_gh_auth", return_value=True)
+    @patch("pr_split.cli.branch_exists", return_value=True)
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_branches_dropped_from_an_edited_plan_are_deleted(
+        self,
+        mock_pe: MagicMock,
+        mock_load: MagicMock,
+        mock_be: MagicMock,
+        mock_auth: MagicMock,
+        mock_clean: MagicMock,
+        mock_parse: MagicMock,
+        mock_commit: MagicMock,
+        mock_create: MagicMock,
+        mock_push: MagicMock,
+        mock_save: MagicMock,
+        mock_confirm: MagicMock,
+        mock_delete: MagicMock,
+        mock_rg: MagicMock,
+    ) -> None:
+        """A retry must not orphan branches the edited plan no longer contains."""
+        mock_load.return_value = self._plan_with_stale_pr2()
+
+        result = runner.invoke(app, ["execute"])
+
+        assert result.exit_code == 0
+        mock_delete.assert_called_once_with("pr-split/feature-branch/pr-2")
+        mock_rg.assert_any_call(
+            "ls-remote", "--exit-code", "origin", "refs/heads/pr-split/feature-branch/pr-2"
+        )
+        mock_rg.assert_any_call("push", "origin", "--delete", "pr-split/feature-branch/pr-2")
+
+    @patch("pr_split.cli.run_git")
+    @patch("pr_split.cli.delete_branch")
+    @patch("pr_split.cli.typer.confirm", return_value=True)
+    @patch("pr_split.cli.save_plan")
+    @patch("pr_split.cli._push_and_create_prs", return_value=[])
+    @patch("pr_split.cli._create_branches_and_commits", return_value=[])
+    @patch("pr_split.cli.commit_exists", return_value=True)
+    @patch("pr_split.cli.parse_diff")
+    @patch("pr_split.cli.is_worktree_clean", return_value=True)
+    @patch("pr_split.cli.check_gh_auth", return_value=True)
+    @patch("pr_split.cli.branch_exists")
+    @patch("pr_split.cli.load_plan")
+    @patch("pr_split.cli.plan_exists", return_value=True)
+    def test_remote_only_stale_branch_is_still_deleted_on_origin(
+        self,
+        mock_pe: MagicMock,
+        mock_load: MagicMock,
+        mock_be: MagicMock,
+        mock_auth: MagicMock,
+        mock_clean: MagicMock,
+        mock_parse: MagicMock,
+        mock_commit: MagicMock,
+        mock_create: MagicMock,
+        mock_push: MagicMock,
+        mock_save: MagicMock,
+        mock_confirm: MagicMock,
+        mock_delete: MagicMock,
+        mock_rg: MagicMock,
+    ) -> None:
+        """A stale branch pruned locally must still be removed from origin."""
+        mock_be.side_effect = lambda name: name != "pr-split/feature-branch/pr-2"
+        mock_load.return_value = self._plan_with_stale_pr2()
+
+        result = runner.invoke(app, ["execute"])
+
+        assert result.exit_code == 0
+        mock_delete.assert_not_called()
+        mock_rg.assert_any_call("push", "origin", "--delete", "pr-split/feature-branch/pr-2")
 
 
 class TestPRCreationErrorIsACleanMessage:


### PR DESCRIPTION
## Summary

After a failed push/PR creation the plan is saved with `git_state.branches` populated and `prs=[]`. `execute` then refused to run ("use 'pr-split clean' first") and `clean` deletes the plan file entirely — so recovering from a transient network failure meant regenerating the whole plan: for the LLM backend, paying for planning again and possibly getting a different split.

`execute` now refuses only when PRs actually exist (partial PR success still refuses, so no duplicates); a branches-only state prints a notice and retries — safe because `add_worktree` deletes and recreates existing branches, and `push_branch` uses `--force-with-lease` so re-pushing rewritten branches succeeds. If the plan was edited between the failed run and the retry, `_delete_stale_recorded_branches` removes recorded branches the plan no longer contains — local and remote deletion handled independently (`ls-remote --exit-code` probe, so a never-pushed branch is skipped silently and a locally-pruned branch still gets its origin ref deleted), all after the confirm gate.

Stacked on #174 (stack #175 = #125→#174→this).

## Test plan

- 4 tests: refusal now requires PRs; branches-only state retries (exit 0, create/push/save called); an edited plan's dropped branch is deleted locally and on origin; a remote-only stale branch is still deleted on origin — all fail on the base
- Three review passes ran the flow end to end in a scratch repo with a real origin: failed push → retry → success; partial PR success → correct refusal; edited-plan and remote-only stale branch cleanup verified via `ls-remote`
- 454 tests pass, ruff clean
- Local review: 5/5
